### PR TITLE
New QoL Feature: allow hide extended info of PartUpgrade parttooltips

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -135,4 +135,7 @@ KSP_COMMUNITY_FIXES
   // the `CreateObjectFromConfig()`, `LoadObjectFromConfig()` and `CreateConfigFromObject()` methods.
   // Disabled by default, you can enable it with a MM patch.
   PersistentIConfigNode = false
+
+  // Hides the extended info on the part tooltip for PartUpgrades
+  HidePartUpgradeExtendedInfo = false
 }

--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -137,5 +137,5 @@ KSP_COMMUNITY_FIXES
   PersistentIConfigNode = false
 
   // Hides the extended info on the part tooltip for PartUpgrades
-  HidePartUpgradeExtendedInfo = false
+  HidePartUpgradeExtendedInfo = true
 }

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -103,6 +103,7 @@
     <Compile Include="QoL\PAWCollapsedInventories.cs" />
     <Compile Include="QoL\AltimeterHorizontalPosition.cs" />
     <Compile Include="QoL\PAWStockGroups.cs" />
+    <Compile Include="QoL\HidePartUpgradeExtendedInfo.cs" />
     <Compile Include="QoL\UIFloatEditNumericInput.cs" />
     <Compile Include="Utility.cs" />
   </ItemGroup>

--- a/KSPCommunityFixes/QoL/HidePartUpgradeExtendedInfo.cs
+++ b/KSPCommunityFixes/QoL/HidePartUpgradeExtendedInfo.cs
@@ -1,0 +1,33 @@
+﻿using HarmonyLib;
+using KSP.UI.Screens.Editor;
+using System;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+
+namespace KSPCommunityFixes
+{
+    public class HidePartUpgradeExtendedInfo : BasePatch
+    {
+        protected override Version VersionMin => new Version(1, 8, 0);
+
+        protected override void ApplyPatches(ref List<PatchInfo> patches)
+        {
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(PartListTooltip), "DisplayExtendedInfo"),
+                this));
+        }
+
+        static bool PartListTooltip_DisplayExtendedInfo_Prefix(PartListTooltip __instance)
+        {
+            if (__instance.upgrade != null && __instance.HasExtendedInfo)
+            {
+                __instance.panelExtended.SetActive(false);
+                return false;
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Part Upgrades hijack the existing part tooltip system, but (either because I was dumb at the time, or because it atrophied later, can't remember at this point) when you right-click to get them to stick (and so you can purchase them), the extended info tab of the base AvailablePart/PartPrefab used for the icon gets displayed. Ugh.

This simple fix will prevent it from displaying.