### PR TITLE
Hide delta V UI when the stock delta V app/calculations are disabled.

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -74,6 +74,12 @@ KSP_COMMUNITY_FIXES
   // Fix deployable parts (antennas, solar panels, radiators...) always starting in the extended 
   // state when the model isn't exported in the retracted state. Affect parts from various mods.
   ExtendedDeployableParts = true
+  
+  // Fix the delta V data (and info panels) on stage UI elements showing
+  // when the delta V app and delta V calculations are disabled.
+  // Also hide extended burn time info on the navball in this case, because
+  // it depends on the stock delta V implementation.
+  DeltaVHideWhenDisabled = true
 
   // ##########################
   // Obsolete bugfixes

--- a/KSPCommunityFixes/BugFixes/DeltaVHideWhenDisabled.cs
+++ b/KSPCommunityFixes/BugFixes/DeltaVHideWhenDisabled.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using HarmonyLib;
+using KSP.UI.Screens;
+using KSP.UI.Screens.Flight;
+
+namespace KSPCommunityFixes
+{
+    public class DeltaVHideWhenDisabled : BasePatch
+    {
+        protected override Version VersionMin => new Version(1, 12, 0);
+
+        protected static bool extendedBurntimeCache;
+
+        protected override void ApplyPatches(ref List<PatchInfo> patches)
+        {
+            patches.Add(new PatchInfo(
+                PatchMethodType.Postfix,
+                AccessTools.Method(typeof(StageGroup), "Awake"),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Postfix,
+                AccessTools.Method(typeof(StageManager), "Awake"),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(StageGroup), "ToggleInfoPanel", new Type[] { typeof(bool) }),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(NavBallBurnVector), "onGameSettingsApplied"),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Postfix,
+                AccessTools.Method(typeof(NavBallBurnVector), "onGameSettingsApplied"),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(NavBallBurnVector), "LateUpdate"),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Postfix,
+                AccessTools.Method(typeof(NavBallBurnVector), "LateUpdate"),
+                this));
+        }
+
+        static void StageGroup_Awake_Postfix(StageGroup __instance)
+        {
+            if (GameSettings.DELTAV_APP_ENABLED == false && GameSettings.DELTAV_CALCULATIONS_ENABLED == false)
+            {
+                __instance.DisableDeltaVHeading();
+            }
+        }
+
+        static void StageManager_Awake_Postfix(StageManager __instance)
+        {
+            if (GameSettings.DELTAV_APP_ENABLED == false && GameSettings.DELTAV_CALCULATIONS_ENABLED == false)
+            {
+                // Note: not using __instance here because the singleton pattern
+                // destroys the new object in favor of the old, if Instance
+                // is non-null during Awake.
+                StageManager.Instance.DisableDeltaVTotal();
+                StageManager.Instance.deltaVTotalButton.gameObject.SetActive(false);
+            }
+        }
+
+        static bool StageGroup_ToggleInfoPanel_Prefix(ref bool showPanel, StageGroup __instance)
+        {
+            // If we don't have delta V enabled, just short-circuit any attempt to toggle the info panel.
+            if (showPanel && GameSettings.DELTAV_APP_ENABLED == false && GameSettings.DELTAV_CALCULATIONS_ENABLED == false)
+                return false;
+
+            // but Just In Case let it close.
+            return true;
+        }
+
+        static bool NavBallBurnVector_onGameSettingsApplied_Prefix(NavBallBurnVector __instance)
+        {
+            extendedBurntimeCache = GameSettings.EXTENDED_BURNTIME;
+
+            if (GameSettings.DELTAV_APP_ENABLED == false && GameSettings.DELTAV_CALCULATIONS_ENABLED == false)
+                GameSettings.EXTENDED_BURNTIME = false;
+
+            return true;
+        }
+
+        static void NavBallBurnVector_onGameSettingsApplied_Postfix(NavBallBurnVector __instance)
+        {
+            GameSettings.EXTENDED_BURNTIME = extendedBurntimeCache;
+        }
+
+        static bool NavBallBurnVector_LateUpdate_Prefix(NavBallBurnVector __instance)
+        {
+            extendedBurntimeCache = GameSettings.EXTENDED_BURNTIME;
+
+            if (GameSettings.DELTAV_APP_ENABLED == false && GameSettings.DELTAV_CALCULATIONS_ENABLED == false)
+                GameSettings.EXTENDED_BURNTIME = false;
+
+            return true;
+        }
+
+        static void NavBallBurnVector_LateUpdate_Postfix(NavBallBurnVector __instance)
+        {
+            GameSettings.EXTENDED_BURNTIME = extendedBurntimeCache;
+        }
+    }
+}

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -75,6 +75,7 @@
     <Compile Include="BugFixes\AutoStrutDrift.cs" />
     <Compile Include="BugFixes\DockingPortRotationDriftAndFixes.cs" />
     <Compile Include="BugFixes\ExtendedDeployableParts.cs" />
+    <Compile Include="BugFixes\DeltaVHideWhenDisabled.cs" />
     <Compile Include="BugFixes\KerbalTooltipMaxSustainedG.cs" />
     <Compile Include="BugFixes\PackedPartsRotation.cs" />
     <Compile Include="BugFixes\PartStartStability.cs" />


### PR DESCRIPTION
Otherwise it's just showing a bunch of "0m/s" and empty UI windows, which looks broken.

Annoyingly there's a little empty gray area where the total dV display was on the staging UI, but I'm not seeing an obvious way to remove it or shrink the background, so eh. Better than a constant display of "0m/s" there at least.