### PR TITLE
For archived contracts, show accepted/finished dates.

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -122,6 +122,9 @@ KSP_COMMUNITY_FIXES
 
   // Append "[Auto-Saved Craft]" when relevant to the craft name in the Launchpad / Runway UI
   AutoSavedCraftNameAtLaunch = true
+  
+  // Show date a contract finished when displaying info on a finished contract in Mission Control
+  ShowContractFinishDates = false
 
   // ##########################
   // Performance tweaks

--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -124,7 +124,7 @@ KSP_COMMUNITY_FIXES
   AutoSavedCraftNameAtLaunch = true
   
   // Show date a contract finished when displaying info on a finished contract in Mission Control
-  ShowContractFinishDates = false
+  ShowContractFinishDates = true
 
   // ##########################
   // Performance tweaks

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Internal\PatchSettings.cs" />
     <Compile Include="Performance\TextureLoaderOptimizations.cs" />
     <Compile Include="QoL\AutoSavedCraftNameAtLaunch.cs" />
+    <Compile Include="QoL\ShowContractFinishDates.cs" />
     <Compile Include="QoL\DisableManeuverTool.cs" />
     <Compile Include="QoL\FairingMouseOverPersistence.cs" />
     <Compile Include="QoL\TweakableWheelsAutostrut.cs" />

--- a/KSPCommunityFixes/QoL/ShowContractFinishDates.cs
+++ b/KSPCommunityFixes/QoL/ShowContractFinishDates.cs
@@ -49,7 +49,7 @@ namespace KSPCommunityFixes.QoL
                     {
                         // Success! Splice around the date.
                         __instance.contractText.text = __instance.contractText.text.Substring(0, insertionIdx + 2)
-                            + KSPRichTextUtil.TextDate(Localizer.Format("#autoLOC_266539"), contract.DateFinished)
+                            + KSPRichTextUtil.TextDate(Localizer.Format("#autoLOC_266539"), contract.DateAccepted)
                             + KSPRichTextUtil.TextDate(Localizer.Format(stateStr), contract.DateFinished)
                             + __instance.contractText.text.Substring(insertionIdx + 2);
                     }

--- a/KSPCommunityFixes/QoL/ShowContractFinishDates.cs
+++ b/KSPCommunityFixes/QoL/ShowContractFinishDates.cs
@@ -1,0 +1,60 @@
+﻿using HarmonyLib;
+using KSP.UI.Screens;
+using KSP.Localization;
+using Contracts;
+using System;
+using System.Collections.Generic;
+
+namespace KSPCommunityFixes.QoL
+{
+    class ShowContractFinishDates : BasePatch
+    {
+
+        protected override Version VersionMin => new Version(1, 12, 0);
+
+        protected override void ApplyPatches(ref List<PatchInfo> patches)
+        {
+            patches.Add(new PatchInfo(
+                PatchMethodType.Postfix, 
+                AccessTools.Method(typeof(MissionControl), "UpdateInfoPanelContract"), 
+                this));
+        }
+
+        private static void MissionControl_UpdateInfoPanelContract_Postfix(MissionControl __instance, Contract contract)
+        {
+            if (__instance.displayMode == MissionControl.DisplayMode.Archive)
+            {
+                // Find an autoloc for the status
+                string stateStr = string.Empty;
+                switch (contract.ContractState)
+                {
+                    case Contract.State.Failed: stateStr = "#autoLOC_900708"; break;
+                    case Contract.State.Cancelled: stateStr = "#autoLOC_900711"; break;
+                    case Contract.State.OfferExpired: stateStr = "#autoLOC_900714"; break;
+                    case Contract.State.DeadlineExpired: stateStr = "#autoLOC_900715"; break;
+                    case Contract.State.Declined: stateStr = "#autoLOC_900716"; break;
+                    default:
+                    case Contract.State.Completed: stateStr = "#autoLOC_900710"; break;
+                }
+
+                // Find the Prestige string. It's the first Param, so we find the first
+                // place where text is formatted with the Params color
+                string searchStr = "<b><color=#" + RUIutils.ColorToHex(RichTextUtil.colorParams) + ">";
+                int idx = __instance.contractText.text.IndexOf(searchStr);
+                if (idx >= 0)
+                {
+                    // Now skip after the double-newline
+                    int insertionIdx = __instance.contractText.text.IndexOf("\n\n", idx);
+                    if (insertionIdx > idx)
+                    {
+                        // Success! Splice around the date.
+                        __instance.contractText.text = __instance.contractText.text.Substring(0, insertionIdx + 2)
+                            + KSPRichTextUtil.TextDate(Localizer.Format("#autoLOC_266539"), contract.DateFinished)
+                            + KSPRichTextUtil.TextDate(Localizer.Format(stateStr), contract.DateFinished)
+                            + __instance.contractText.text.Substring(insertionIdx + 2);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Small QoL feature: right now KSP shows accepted/offered/deadline/etc dates for offered and active contracts, but shows *no date at all* for archived contracts. This patch makes it so that archived contracts show the date they were accepted and the date they completed/failed/etc.

Defaults to false, which I think is correct? I mean, *I* would always play with it turned on, but I'm not 100% comfortable making that call be the default.