### PR TITLE
Allow app launcher to collapse/expand (even in SC UIs)

### DIFF
--- a/GameData/KSPCommunityFixes/KSPCommunityFixes.version
+++ b/GameData/KSPCommunityFixes/KSPCommunityFixes.version
@@ -2,7 +2,7 @@
   "NAME": "KSPCommunityFixes",
   "URL": "https://raw.githubusercontent.com/KSPModdingLibs/KSPCommunityFixes/master/GameData/KSPCommunityFixes/KSPCommunityFixes.version",
   "DOWNLOAD": "https://github.com/KSPModdingLibs/KSPCommunityFixes/releases",
-  "VERSION": {"MAJOR": 1, "MINOR": 18, "PATCH": 3, "BUILD": 0},
+  "VERSION": {"MAJOR": 1, "MINOR": 19, "PATCH": 0, "BUILD": 0},
   "KSP_VERSION": {"MAJOR": 1, "MINOR": 12, "PATCH": 3},
   "KSP_VERSION_MIN": {"MAJOR": 1, "MINOR": 8, "PATCH": 0},
   "KSP_VERSION_MAX": {"MAJOR": 1, "MINOR": 12, "PATCH": 3}

--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -114,6 +114,12 @@ KSP_COMMUNITY_FIXES
   // Fix rescaled servo parts propagating their scale to childrens after actuating the servo in the editor
   RescaledRoboticParts = true
 
+  // Fix engine plates causing the part attached above them to be incorrectly shielded from airstream
+  EnginePlateAirstreamShieldedTopPart = true
+
+  // Fix asteroid/comet mass being restored to 100% when reloading after having mined it down to 0%
+  AsteroidInfiniteMining = true
+
   // ##########################
   // Obsolete bugfixes
   // ##########################

--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -169,6 +169,11 @@ KSP_COMMUNITY_FIXES
   // upon creating a new career game. Disabled by default.
   DisableNewGameIntro = false
 
+  // Allows the AppLauncher (stock toolbar) to be collapsed and expanded via a button
+  // prior to the Messages app icon. This button is shown even in Space Center UIs
+  // like Mission Control, so it can be accessed there too.
+  AppLauncherCollapseShow = true
+
   // ##########################
   // Performance tweaks
   // ##########################

--- a/KSPCommunityFixes/BugFixes/AsteroidInfiniteMining.cs
+++ b/KSPCommunityFixes/BugFixes/AsteroidInfiniteMining.cs
@@ -1,0 +1,30 @@
+﻿// see https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/51
+
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+
+namespace KSPCommunityFixes.BugFixes
+{
+    class AsteroidInfiniteMining : BasePatch
+    {
+        protected override Version VersionMin => new Version(1, 10, 0);
+
+        protected override void ApplyPatches(List<PatchInfo> patches)
+        {
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.PropertySetter(typeof(ModuleSpaceObjectInfo), nameof(ModuleSpaceObjectInfo.currentMassVal)),
+                this, nameof(ModuleSpaceObjectInfo_currentMassVal_Setter_Prefix)));
+        }
+
+        static bool ModuleSpaceObjectInfo_currentMassVal_Setter_Prefix(ModuleSpaceObjectInfo __instance, double value)
+        {
+            if (value <= 1e-9)
+                value = 1e-8;
+
+            __instance.currentMass = value.ToString("G17");
+            return false;
+        }
+    }
+}

--- a/KSPCommunityFixes/BugFixes/EnginePlateAirstreamShieldedTopPart.cs
+++ b/KSPCommunityFixes/BugFixes/EnginePlateAirstreamShieldedTopPart.cs
@@ -1,0 +1,53 @@
+﻿// see https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/52
+
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace KSPCommunityFixes.BugFixes
+{
+    class EnginePlateAirstreamShieldedTopPart : BasePatch
+    {
+        protected override Version VersionMin => new Version(1, 11, 0);
+
+        protected override void ApplyPatches(List<PatchInfo> patches)
+        {
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(ModuleDecouplerBase), nameof(ModuleDecouplerBase.SetAirstream)),
+                this));
+        }
+
+        static bool ModuleDecouplerBase_SetAirstream_Prefix(ModuleDecouplerBase __instance, bool enclosed)
+        {
+            __instance.shroudOn = enclosed;
+
+            if (__instance.jettisonModule.IsNullOrDestroyed())
+                return false;
+
+            List<AttachNode> attachNodes = __instance.part.attachNodes;
+            AttachNode bottomNode = attachNodes.Find(node => node.id == __instance.jettisonModule.bottomNodeName);
+
+            foreach (AttachNode attachNode in attachNodes)
+            {
+                if (attachNode.attachedPart.IsNullOrDestroyed())
+                    continue;
+
+                if (attachNode == bottomNode)
+                    continue;
+
+                if (Vector3.Angle(bottomNode.orientation, attachNode.orientation) < 30f)
+                {
+                    attachNode.attachedPart.ShieldedFromAirstream = enclosed;
+                    if (enclosed)
+                        attachNode.attachedPart.AddShield(__instance);
+                    else
+                        attachNode.attachedPart.RemoveShield(__instance);
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -91,6 +91,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BasePatch.cs" />
+    <Compile Include="BugFixes\AsteroidInfiniteMining.cs" />
+    <Compile Include="BugFixes\EnginePlateAirstreamShieldedTopPart.cs" />
     <Compile Include="Performance\MemoryLeaks.cs" />
     <Compile Include="BugFixes\RescaledRoboticParts.cs" />
     <Compile Include="Modding\DepartmentHeadImage.cs" />

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Modding\ReflectionTypeLoadExceptionHandler.cs" />
     <Compile Include="Performance\PQSUpdateNoMemoryAlloc.cs" />
     <Compile Include="QoL\AutostrutActions.cs" />
+    <Compile Include="QoL\AppLauncherCollapseShow.cs" />
     <Compile Include="QoL\DisableNewGameIntro.cs" />
     <Compile Include="QoL\NoIVA.cs" />
     <Compile Include="Performance\OnDemandPartBuoyancy.cs" />

--- a/KSPCommunityFixes/Properties/AssemblyInfo.cs
+++ b/KSPCommunityFixes/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("1.18.3.0")]
-[assembly: AssemblyFileVersion("1.18.3.0")]
+[assembly: AssemblyVersion("1.19.0.0")]
+[assembly: AssemblyFileVersion("1.19.0.0")]

--- a/KSPCommunityFixes/QoL/AppLauncherCollapseShow.cs
+++ b/KSPCommunityFixes/QoL/AppLauncherCollapseShow.cs
@@ -1,0 +1,223 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using KSP.UI.Screens;
+using UnityEngine;
+using UniLinq;
+using UnityEngine.UI;
+
+namespace KSPCommunityFixes.QoL
+{
+    class AppLauncherCollapseShow : BasePatch
+    {
+        protected override Version VersionMin => new Version(1, 8, 0);
+
+        protected override void ApplyPatches(List<PatchInfo> patches)
+        {
+            patches.Add(new PatchInfo(
+                PatchMethodType.Postfix,
+                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.SpawnSimpleLayout)),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Postfix,
+                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.StartupSequence)),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.Show)),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.Hide)),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.ShouldItShow)),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.ShouldItHide)),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.ShouldItHide), new Type[] { typeof(GameEvents.VesselSpawnInfo) }),
+                this,
+                "ApplicationLauncher_ShouldItHideVesselSpawn_Prefix"));
+        }
+        static bool ApplicationLauncher_ShouldItShow_Prefix(ApplicationLauncher __instance)
+        {
+            if (__instance.ShouldBeVisible())
+            {
+                Canvas canvas = ApplicationLauncher.Instance.GetComponent<Canvas>();
+                canvas.sortingLayerName = "Default";
+                canvas.sortingOrder = 0;
+                canvas.overrideSorting = false;
+                __instance.Show();
+            }
+            return false;
+        }
+
+        static bool ApplicationLauncher_ShouldItHide_Prefix(ApplicationLauncher __instance)
+        {
+            if (__instance.ShouldBeVisible())
+            {
+                Canvas canvas = ApplicationLauncher.Instance.GetComponent<Canvas>();
+                canvas.overrideSorting = true;
+                canvas.sortingLayerName = "Actions";
+                canvas.sortingOrder = 20;
+                __instance.Hide();
+            }
+            return false;
+        }
+
+        static bool ApplicationLauncher_ShouldItHideVesselSpawn_Prefix(ApplicationLauncher __instance)
+        {
+            if (__instance.ShouldBeVisible())
+            {
+                Canvas canvas = ApplicationLauncher.Instance.GetComponent<Canvas>();
+                canvas.overrideSorting = true;
+                canvas.sortingLayerName = "Actions";
+                canvas.sortingOrder = 20;
+                __instance.Hide();
+            }
+            return false;
+        }
+
+        static bool ApplicationLauncher_Show_Prefix(ApplicationLauncher __instance)
+        {
+            if (!__instance.launcherSpace.gameObject.activeSelf)
+                __instance.launcherSpace.gameObject.SetActive(true);
+
+            ExpandAppLauncher();
+            return false;
+        }
+
+        static bool ApplicationLauncher_Hide_Prefix(ApplicationLauncher __instance)
+        {
+            if (__instance.ShouldBeVisible())
+            {
+                CollapseAppLauncher();
+                return false;
+            }
+
+            __instance.launcherSpace.gameObject.SetActive(false);
+            __instance.onHide();
+            ApplicationLauncher.Ready = false;
+            return false;
+        }
+
+        static void ApplicationLauncher_SpawnSimpleLayout_Postfix(ApplicationLauncher __instance)
+        {
+            List<Transform> allChilds = __instance.launcherSpace.GetComponentsInChildren<Transform>(true).ToList();
+            GameObject expand, collapse;
+            Transform appList = __instance.currentLayout.GetGameObject().transform.GetChild(0);
+            if (__instance.IsPositionedAtTop)
+            {
+                expand = GameObject.Instantiate(allChilds.First(t => t.name == "BtnArrowDown").gameObject);
+                collapse = GameObject.Instantiate(allChilds.First(t => t.name == "BtnArrowUp").gameObject);
+                var lG = __instance.currentLayout.GetGameObject().AddComponent<VerticalLayoutGroup>();
+                lG.childAlignment = appList.GetComponent<VerticalLayoutGroup>().childAlignment;
+                lG.childForceExpandHeight = false;
+            }
+            else
+            {
+                expand = GameObject.Instantiate(allChilds.First(t => t.name == "BtnArrowLeft").gameObject);
+                collapse = GameObject.Instantiate(allChilds.First(t => t.name == "BtnArrowRight").gameObject);
+                var lG = __instance.currentLayout.GetGameObject().AddComponent<HorizontalLayoutGroup>();
+                lG.childAlignment = appList.GetComponent<HorizontalLayoutGroup>().childAlignment;
+                lG.childForceExpandWidth = false;
+            }
+
+            expand.name = "BtnExpand";
+            expand.transform.SetParent(__instance.currentLayout.GetGameObject().transform, false);
+            expand.SetActive(true);
+            GameObject.DestroyImmediate(expand.GetComponent<KSP.UI.PointerClickAndHoldHandler>());
+            var exButton = expand.GetComponent<Button>();
+            exButton.onClick = new Button.ButtonClickedEvent();
+            exButton.onClick.AddListener(ExpandAppLauncher);
+            expand.SetActive(false);
+
+            collapse.name = "BtnCollapse";
+            collapse.transform.SetParent(appList.transform, false);
+            if (__instance.IsPositionedAtTop)
+                collapse.transform.SetSiblingIndex(0);
+            collapse.SetActive(true);
+            GameObject.DestroyImmediate(collapse.GetComponent<KSP.UI.PointerClickAndHoldHandler>());
+            var colButton = collapse.GetComponent<Button>();
+            colButton.onClick = new Button.ButtonClickedEvent();
+            colButton.onClick.AddListener(CollapseAppLauncher);
+        }
+        static void ApplicationLauncher_StartupSequence_Postfix(ApplicationLauncher __instance)
+        {
+            if (__instance.currentLayout == null)
+                return;
+
+            Transform[] childs = ApplicationLauncher.Instance.launcherSpace.GetComponentsInChildren<Transform>(true);
+            if (HighLogic.LoadedScene == GameScenes.EDITOR)
+            {
+                LayoutElement topRightSpacer = __instance.currentLayout.GetTopRightSpacer();
+                topRightSpacer.transform.SetAsLastSibling();
+
+                LayoutElement newSpacer;
+                var newSpacerTransform = childs.FirstOrDefault(t => t.name == "ExpandSpacer");
+                if (newSpacerTransform == null)
+                {
+                    newSpacer = GameObject.Instantiate(topRightSpacer);
+                    newSpacer.name = "ExpandSpacer";
+                    newSpacer.transform.SetParent(__instance.currentLayout.GetGameObject().transform, false);
+                }
+                else
+                {
+                    newSpacer = newSpacerTransform.gameObject.GetComponent<LayoutElement>();
+                }
+                newSpacer.preferredHeight = topRightSpacer.preferredHeight;
+                newSpacer.preferredWidth = topRightSpacer.preferredWidth;
+                newSpacer.gameObject.SetActive(childs.First(t => t.name == "BtnExpand").gameObject.activeSelf);
+            }
+            else
+            {
+                var newSpacerTransform = childs.FirstOrDefault(t => t.name == "ExpandSpacer");
+                if (newSpacerTransform != null)
+                    newSpacerTransform.gameObject.SetActive(false);
+            }
+        }
+
+        private static void ToggleAppLauncher(bool show)
+        {
+            Transform[] childs = ApplicationLauncher.Instance.launcherSpace.GetComponentsInChildren<Transform>(true);
+            var expand = childs.FirstOrDefault(t => t.name == "BtnExpand");
+            var list = ApplicationLauncher.Instance.currentLayout.GetGameObject().transform.GetChild(0);
+            if (expand == null || list == null)
+            {
+                Debug.LogError($"Couldn't find button (null? {expand == null}) or list (null? {list == null})");
+                ApplicationLauncher.Instance.launcherSpace.gameObject.SetActive(show);
+                return;
+            }
+            expand.gameObject.SetActive(!show);
+            list.gameObject.SetActive(show);
+            var spacer = childs.FirstOrDefault(t => t.name == "ExpandSpacer");
+            if (spacer != null)
+                spacer.gameObject.SetActive(!show);
+        }
+
+        public static void ExpandAppLauncher()
+        {
+            ToggleAppLauncher(true);
+            ApplicationLauncher.Ready = true;
+            ApplicationLauncher.Instance.onShow();
+        }
+
+        public static void CollapseAppLauncher()
+        {
+            ToggleAppLauncher(false);
+            ApplicationLauncher.Instance.onHide();
+            ApplicationLauncher.Ready = false;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ User options are available from the "ESC" in-game settings menu :<br/><img src="
 - **[EVAKerbalRecovery](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/43)** [KSP 1.11.0 - 1.12.3]<br/> Fix recovery of EVAing kerbals either causing their inventory to be recovered twice or the science data they carry not being recovered, depending on the EVA kerbal variant/suit.
 - **[StickySplashedFixer](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/44)** [KSP 1.8.0 - 1.12.3]<br/> Fix vessel never leaving the splashed state if it starts out splashed, and decouples from its only splashed parts. This also fixes an issue where Splashed overrides Prelaunch as a situation.
 - **[RescaledRoboticParts](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/48)** [KSP 1.8.0 - 1.12.3]<br/> Fix rescaled robotics parts propagating their scale to childrens after actuating the servo in the editor
+- **[EnginePlateAirstreamShieldedTopPart](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/52)** [KSP 1.11.0 - 1.12.3]<br/>Fix engine plates causing the part attached above them to be incorrectly shielded from airstream.
+- **[AsteroidInfiniteMining](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/51)** [KSP 1.10.0 - 1.12.3]<br/>Fix asteroid/comet mass being restored to 100% when reloading after having mined it down to 0%.
 
 #### Quality of Life tweaks 
 
@@ -130,6 +132,10 @@ The `Start` action of the IDE will trigger a build, update the `GameData` files 
 If doing so in the `Debug` configuration and if your KSP install is modified to be debuggable, you will be able to debug the code from within your IDE (if your IDE provides Unity debugging support).
 
 ### Changelog
+
+##### 1.19.0
+- New KSP bugfix : [EnginePlateAirstreamShieldedTopPart](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/52) (Thanks to @yalov (flart) for reporting and to @Aelfhe1m for coming up with a clever solution).
+- New KSP bugfix : [AsteroidInfiniteMining](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/51) (Thanks to @Rodg88 for reporting).
 
 ##### 1.18.3
 - MemoryLeaks : Only remove GameEvent delegates owned by destroyed UnityEngine.Object instances if they are declared by the stock assembly, or a PartModule, or a VesselModule. Some mods are relying on a singleton pattern by instantiating a KSPAddon once, registering GameEvents there and relying on those being called on the dead instance to manipulate static data (sigh...). Those cases will still be logged when the LogDestroyedUnityObjectGameEventsLeaks flag is set in settings.


### PR DESCRIPTION
Remaining wrinkle: the white bits of the Contracts and Messages buttons don't show when expanded in MC/AC/etc, because of how the rest of the applauncher has to have its canvas sorting order changed to render in those UIs. I'm not quite familiar enough with Unity UI to know if adding another Canvas to their buttons and leaving its override off except then would fix it, or if *every* child would need its canvas managed...