### PR TITLE
Fix #55: Add ProgressTrackingSpeedBoost

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -206,6 +206,13 @@ KSP_COMMUNITY_FIXES
     LogGameEventsSubscribers = false
   }
 
+  // KSP's stock ProgressTracking evaluates every progress node for every vessel in the universe.
+  // There are ~19 progress nodes per celestial body, and this can get extremely expensive for mods with a
+  // large number of bodies or saves with a large number of vessels.
+  // This tweak only evaluates the currently active vessel and removes the per-body checks which don't
+  // have any effect, at least in the stock game.
+  ProgressTrackingSpeedBoost = true
+
   // ##########################
   // Modding
   // ##########################

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Modding\OnSymmetryFieldChanged.cs" />
     <Compile Include="Modding\ReflectionTypeLoadExceptionHandler.cs" />
     <Compile Include="Performance\PQSUpdateNoMemoryAlloc.cs" />
+    <Compile Include="Performance\ProgressTrackingSpeedBoost.cs" />
     <Compile Include="QoL\AutostrutActions.cs" />
     <Compile Include="QoL\DisableNewGameIntro.cs" />
     <Compile Include="QoL\NoIVA.cs" />

--- a/KSPCommunityFixes/Performance/ProgressTrackingSpeedBoost.cs
+++ b/KSPCommunityFixes/Performance/ProgressTrackingSpeedBoost.cs
@@ -1,0 +1,38 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+
+namespace KSPCommunityFixes.Performance
+{
+	public class ProgressTrackingSpeedBoost : BasePatch
+	{
+		protected override void ApplyPatches(List<PatchInfo> patches)
+		{
+			patches.Add(new PatchInfo(
+				PatchMethodType.Prefix,
+				AccessTools.Method(typeof(ProgressTracking), nameof(ProgressTracking.Update)),
+				this));
+
+			patches.Add(new PatchInfo(
+				PatchMethodType.Postfix,
+				AccessTools.DeclaredConstructor(typeof(KSPAchievements.CelestialBodySubtree), new Type[] { typeof(CelestialBody) }),
+				this,
+				nameof(CelestialBodySubtree_Constructor_Postfix)));
+		}
+
+		static bool ProgressTracking_Update_Prefix(ProgressTracking __instance)
+		{
+			if (!HighLogic.LoadedSceneIsEditor && FlightGlobals.ActiveVessel != null)
+			{
+				__instance.achievementTree.IterateVessels(FlightGlobals.ActiveVessel);
+			}
+
+			return false;
+		}
+
+		static void CelestialBodySubtree_Constructor_Postfix(KSPAchievements.CelestialBodySubtree __instance)
+		{
+			__instance.OnIterateVessels = null;
+		}
+	}
+}


### PR DESCRIPTION
KSP's stock ProgressTracking evaluates every progress node for every vessel in the universe.
There are ~19 progress nodes per celestial body, and this can get extremely expensive for mods with a
large number of bodies or saves with a large number of vessels.
This tweak only evaluates the currently active vessel and removes the per-body checks which don't
have any effect, at least in the stock game.