### PR TITLE
Fix #56: Fix CommnetNetwork.Update performance

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -224,6 +224,18 @@ KSP_COMMUNITY_FIXES
   // have any effect, at least in the stock game.
   ProgressTrackingSpeedBoost = true
 
+  // Enables the commnet performance optimizations
+  // The stock game is supposed to throttle commnet updates to once every 5 seconds when the active vessel
+  // is unpacked, but there is a bug that prevents this from working properly.  Enabling this setting
+  // fixes the bug, and you can optionally customize the timing intervals with the settings below.
+  CommNetSpeedBoost = true
+
+  COMM_NET_PERFORMANCE_SETTINGS
+  {
+    packedInterval = 0.5
+    unpackedInterval = 5
+  }
+
   // ##########################
   // Modding
   // ##########################

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -93,6 +93,7 @@
     <Compile Include="BasePatch.cs" />
     <Compile Include="BugFixes\AsteroidInfiniteMining.cs" />
     <Compile Include="BugFixes\EnginePlateAirstreamShieldedTopPart.cs" />
+    <Compile Include="Performance\CommNetSpeedBoost.cs" />
     <Compile Include="Performance\MemoryLeaks.cs" />
     <Compile Include="BugFixes\RescaledRoboticParts.cs" />
     <Compile Include="Modding\DepartmentHeadImage.cs" />

--- a/KSPCommunityFixes/Performance/CommNetSpeedBoost.cs
+++ b/KSPCommunityFixes/Performance/CommNetSpeedBoost.cs
@@ -1,0 +1,49 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace KSPCommunityFixes.Performance
+{
+	class CommNetSpeedBoost : BasePatch
+	{
+		private static double packedInterval = 0.5;
+		private static double unpackedInterval = 5.0;
+
+		protected override void ApplyPatches(List<PatchInfo> patches)
+		{
+			ConfigNode settingsNode = KSPCommunityFixes.SettingsNode.GetNode("COMM_NET_PERFORMANCE_SETTINGS");
+
+			if (settingsNode != null)
+			{
+				settingsNode.TryGetValue("packedInterval", ref packedInterval);
+				settingsNode.TryGetValue("unpackedInterval", ref unpackedInterval);
+			}
+
+			patches.Add(new PatchInfo(
+				PatchMethodType.Prefix,
+				AccessTools.Method(typeof(CommNet.CommNetNetwork), nameof(CommNet.CommNetNetwork.Update)),
+				this));
+		}
+
+		static bool CommNetNetwork_Update_Prefix(CommNet.CommNetNetwork __instance)
+		{
+			double timeSinceLastUpdate = Time.timeSinceLevelLoad - __instance.prevUpdate;
+
+			if (FlightGlobals.ActiveVessel != null)
+			{
+				double interval = FlightGlobals.ActiveVessel.packed ? packedInterval : unpackedInterval;
+				if (timeSinceLastUpdate < interval)
+				{
+					__instance.graphDirty = true;
+					return false;
+				}
+			}
+
+			return true;
+		}
+	}
+}


### PR DESCRIPTION
The throttling logic that was supposed to update it once every 5 seconds was broken