### PR TITLE
Fix Strategy Duration handling

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -125,6 +125,12 @@ KSP_COMMUNITY_FIXES
   // Fix mass of comets not actually reducing when mining them, despite the PAW saying so.
   CometMiningNotRemovingMass = true
 
+  // Fix Strategies not using Duration settings
+  // Note that many stock strategies do have these set, but the code was broken.
+  // For this reason this defaults to off, since otherwise it would change
+  // stock gameplay.
+  StrategyDuration = false
+
   // ##########################
   // Obsolete bugfixes
   // ##########################

--- a/KSPCommunityFixes/BugFixes/StrategyDuration.cs
+++ b/KSPCommunityFixes/BugFixes/StrategyDuration.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using HarmonyLib;
+using Strategies;
+using System.Reflection.Emit;
+
+namespace KSPCommunityFixes.BugFixes
+{
+    class StrategyDuration : BasePatch
+    {
+        protected override Version VersionMin => new Version(1, 8, 0);
+
+        protected override void ApplyPatches(List<PatchInfo> patches)
+        {
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.PropertyGetter(typeof(Strategy), nameof(Strategy.LongestDuration)),
+                this, nameof(Strategy_LongestDuration)));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.PropertyGetter(typeof(Strategy), nameof(Strategy.LeastDuration)),
+                this, nameof(Strategy_LeastDuration)));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Transpiler,
+                AccessTools.Method(typeof(Strategy), nameof(Strategy.CanBeDeactivated)),
+                this));
+        }
+
+        static bool Strategy_LongestDuration(Strategy __instance, ref double __result)
+        {
+            __result = __instance.FactorLerp(__instance.MinLongestDuration, __instance.MaxLongestDuration);
+            return false;
+        }
+
+        static bool Strategy_LeastDuration(Strategy __instance, ref double __result)
+        {
+            __result = __instance.FactorLerp(__instance.MinLeastDuration, __instance.MaxLeastDuration);
+            return false;
+        }
+
+        internal static IEnumerable<CodeInstruction> Strategy_CanBeActivated_Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            List<CodeInstruction> code = new List<CodeInstruction>(instructions);
+            for (int i = 9; i < code.Count; ++i)
+            {
+                // We need to fix the inequality check for if ( dateActivated + LeastDuration < Planetarium.fetch.time )
+                // because that should be a > check.
+                if (code[i].opcode == OpCodes.Bge_Un_S)
+                {
+                    code[i].opcode = OpCodes.Ble_Un_S;
+                    break;
+                }
+            }
+
+            return code;
+        }
+    }
+}

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -94,6 +94,7 @@
     <Compile Include="BugFixes\AsteroidInfiniteMining.cs" />
     <Compile Include="BugFixes\CometMiningNotRemovingMass.cs" />
     <Compile Include="BugFixes\EnginePlateAirstreamShieldedTopPart.cs" />
+    <Compile Include="BugFixes\StrategyDuration.cs" />
     <Compile Include="Performance\AsteroidAndCometDrillCache.cs" />
     <Compile Include="Performance\CommNetThrottling.cs" />
     <Compile Include="Performance\DisableMapUpdateInFlight.cs" />


### PR DESCRIPTION
Stock has broken support for min/max durations for strategies. This fixes:
* LongestDuration to actually use longestDuration fields
* Least and Longest Duration getters to use the duration properties, not the fields (which are never set)
* CanBeActivated to not have its inequality flipped when comparing LeastDuration + DateActivated vs UT.

Since the property patches are 75% new code it didn't seem worth trying to transpile them from near-scratch. If you want to you can, it involves replacing the ldflds with calls to the properties.