### PR TITLE
Fix ordering when writing Persistent IConfigNode

### DIFF
--- a/KSPCommunityFixes/Modding/PersistentIConfigNode.cs
+++ b/KSPCommunityFixes/Modding/PersistentIConfigNode.cs
@@ -79,7 +79,11 @@ namespace KSPCommunityFixes.Modding
                             WriteValue(fieldName, typeof(int), writeLinks.AssignLink(value), node);
                         }
                     }
-                    // begin edit 1
+                    // begin edit
+                    else if (IsIConfigNode(fieldType))
+                    {
+                        WriteIConfigNode(fieldName, value, node);
+                    }
                     else if (fieldType == typeof(Guid))
                     {
                         node.AddValue(fieldName, ((Guid)value).ToString());
@@ -93,12 +97,6 @@ namespace KSPCommunityFixes.Modding
                     {
                         WriteArrayTypes(fieldName, fieldType, value, node, persistent);
                     }
-                    // begin edit 2
-                    else if (IsIConfigNode(fieldType))
-                    {
-                        WriteIConfigNode(fieldName, value, node);
-                    }
-                    // end edit
                     else
                     {
                         WriteStruct(fieldName, field, value, node, pass);


### PR DESCRIPTION
The writing of Persistent IConfigNode objects was broken in some cases because the check was after the IsArrayType check, etc. This fixes it by bringing the check up to the top, which is correct (if the object is IConfigNode, then that should be used in preference to anything else.)