### PR TITLE
Fix a bug in the UpgradesBugs patch where the upgrades field could be null

### DIFF
--- a/KSPCommunityFixes/BugFixes/UpgradeBugs.cs
+++ b/KSPCommunityFixes/BugFixes/UpgradeBugs.cs
@@ -16,6 +16,11 @@ namespace KSPCommunityFixes
         protected override void ApplyPatches(List<PatchInfo> patches)
         {
             patches.Add(new PatchInfo(
+                PatchMethodType.Postfix,
+                AccessTools.Constructor(typeof(PartModule)),
+                this, "PartModule_ctor_Postfix"));
+
+            patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
                 AccessTools.Method(typeof(PartListTooltip), nameof(PartListTooltip.SetupUpgradeInfo)),
                 this));
@@ -70,6 +75,11 @@ namespace KSPCommunityFixes
                 AccessTools.Method(typeof(PartUpgradeHandler.Upgrade), nameof(PartUpgradeHandler.Upgrade.GetUsedByStrings)),
                 this,
                 "GetUsedBy_Prefix"));
+        }
+
+        static void PartModule_ctor_Postfix(PartModule __instance)
+        {
+            __instance.upgrades = new List<ConfigNode>();
         }
 
         // This was doing weird stuff with PartStatsUpgradeModules where it only applied its upgrades' costs.


### PR DESCRIPTION
This is true only for PartModules that are added via code, and only on the prefab itself it appears.

The symptom only occurs on parts with upgrades but that have code-added modules, and only when the substitute part fix is disabled. (I tested against regular KSP, and against RP-1 with both patches enabled, but missed this particular set of cases. Thankfully a user on the RO discord encountered it and I was able to diagnose.)