### PR TITLE
Added fix for MapSO co-ordinate wrapping

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -149,6 +149,10 @@ KSP_COMMUNITY_FIXES
   // For this reason this defaults to off, since otherwise it would change
   // stock gameplay.
   StrategyDuration = false
+  
+  // Fix biome and heightmap texture wrapping from pole to pole
+  // Avoids big spikes on the poles and incorrect biomes where the oles have disparate biomes.
+  MapSOCorrectWrapping = true
 
   // ##########################
   // Obsolete bugfixes

--- a/KSPCommunityFixes/BugFixes/MapSOWrapping.cs
+++ b/KSPCommunityFixes/BugFixes/MapSOWrapping.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using HarmonyLib;
+using UnityEngine;
+
+namespace KSPCommunityFixes
+{
+    public class MapSOCorrectWrapping : BasePatch
+    {
+        protected override Version VersionMin => new Version(1, 10, 0);
+
+        protected override void ApplyPatches(List<PatchInfo> patches)
+        {
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(MapSO), nameof(MapSO.ConstructBilinearCoords), new Type[] { typeof(float), typeof(float) }),
+                this,
+                "MapSO_ConstructBilinearCoords_Float"));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(MapSO), nameof(MapSO.ConstructBilinearCoords), new Type[] { typeof(double), typeof(double) }),
+                this,
+                "MapSO_ConstructBilinearCoords_Double"));
+        }
+
+        static bool MapSO_ConstructBilinearCoords_Float(MapSO __instance, float x, float y)
+        {
+            // X wraps around as it is longitude.
+            x = Mathf.Abs(x - Mathf.Floor(x));
+            __instance.centerX = x * __instance._width;
+            __instance.minX = Mathf.FloorToInt(__instance.centerX);
+            __instance.maxX = Mathf.CeilToInt(__instance.centerX);
+            __instance.midX = __instance.centerX - __instance.minX;
+            if (__instance.maxX == __instance._width)
+                __instance.maxX = 0;
+
+            // Y clamps as it is latitude and the poles don't wrap to each other.
+            y = Mathf.Clamp(y, 0, 0.99999f);
+            __instance.centerY = y * __instance._height;
+            __instance.minY = Mathf.FloorToInt(__instance.centerY);
+            __instance.maxY = Mathf.CeilToInt(__instance.centerY);
+            __instance.midY = __instance.centerY - __instance.minY;
+            if (__instance.maxY >= __instance._height)
+                __instance.maxY = __instance._height - 1;
+
+            return false;
+        }
+
+        static bool MapSO_ConstructBilinearCoords_Double(MapSO __instance, double x, double y)
+        {
+            // X wraps around as it is longitude.
+            x = Math.Abs(x - Math.Floor(x));
+            __instance.centerXD = x * __instance._width;
+            __instance.minX = (int)Math.Floor(__instance.centerXD);
+            __instance.maxX = (int)Math.Ceiling(__instance.centerXD);
+            __instance.midX = (float)__instance.centerXD - __instance.minX;
+            if (__instance.maxX == __instance._width)
+                __instance.maxX = 0;
+
+            // Y clamps as it is latitude and the poles don't wrap to each other.
+            y = Math.Min(Math.Max(y, 0), 0.99999);
+            __instance.centerYD = y * __instance._height;
+            __instance.minY = (int)Math.Floor(__instance.centerYD);
+            __instance.maxY = (int)Math.Ceiling(__instance.centerYD);
+            __instance.midY = (float)__instance.centerYD - __instance.minY;
+            if (__instance.maxY >= __instance._height)
+                __instance.maxY = __instance._height - 1;
+
+            return false;
+        }
+    }
+}

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -92,6 +92,7 @@
   <ItemGroup>
     <Compile Include="BasePatch.cs" />
     <Compile Include="BugFixes\AsteroidInfiniteMining.cs" />
+    <Compile Include="BugFixes\MapSOWrapping.cs" />
     <Compile Include="BugFixes\UpgradeBugs.cs" />
     <Compile Include="BugFixes\PartTooltipUpgradesApplyToSubstituteParts.cs" />
     <Compile Include="BugFixes\CometMiningNotRemovingMass.cs" />


### PR DESCRIPTION
Fixes issues with biomes crossing the poles (South pole biome at north pole and vice versa). Fixes "polar spikes" in the terrain for 8-bit heightmaps (16-bit already fixed in RSS).