### PR TITLE
Improve ConfigNode load/save perf

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -287,14 +287,16 @@ KSP_COMMUNITY_FIXES
   // and every time you delete a vessel in the Tracking Station
   FewerSaves = false
 
-  ConfigNodePerf = false
+  // These settings will make ConfigNode's loader not bother doing
+  // Extended checking during parsing for keys named ths
   CONFIGNODE_PERF_SKIP_PROCESSING_KEYS
   {
     item = serialized_plugin
   }
+  // or for keys that start with this.
   CONFIGNODE_PERF_SKIP_PROCESSING_SUBSTRINGS
   {
-    item = __skipProc__
+    item = **skipProc**
   }
 
   // ##########################

--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -287,6 +287,16 @@ KSP_COMMUNITY_FIXES
   // and every time you delete a vessel in the Tracking Station
   FewerSaves = false
 
+  ConfigNodePerf = false
+  CONFIGNODE_PERF_SKIP_PROCESSING_KEYS
+  {
+    item = serialized_plugin
+  }
+  CONFIGNODE_PERF_SKIP_PROCESSING_SUBSTRINGS
+  {
+    item = __skipProc__
+  }
+
   // ##########################
   // Modding
   // ##########################

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Modding\OnSymmetryFieldChanged.cs" />
     <Compile Include="Modding\ReflectionTypeLoadExceptionHandler.cs" />
     <Compile Include="Performance\FewerSaves.cs" />
+    <Compile Include="Performance\ConfigNodePerf.cs" />
     <Compile Include="Performance\PQSCoroutineLeak.cs" />
     <Compile Include="Performance\PQSUpdateNoMemoryAlloc.cs" />
     <Compile Include="Performance\ProgressTrackingSpeedBoost.cs" />

--- a/KSPCommunityFixes/Performance/ConfigNodePerf.cs
+++ b/KSPCommunityFixes/Performance/ConfigNodePerf.cs
@@ -1,0 +1,442 @@
+﻿// - Add support for IConfigNode serialization
+// - Add support for Guid serialization
+
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using UnityEngine;
+using static ConfigNode;
+using Random = System.Random;
+
+namespace KSPCommunityFixes.Modding
+{
+    class ConfigNodePerf : BasePatch
+    {
+        static string[] _skipKeys;
+        static string[] _skipPrefixes;
+        static bool _valid = false;
+
+        protected override Version VersionMin => new Version(1, 8, 0);
+
+        protected override void ApplyPatches(List<PatchInfo> patches)
+        {
+            ConfigNode settingsNodeKeys = KSPCommunityFixes.SettingsNode.GetNode("CONFIGNODE_PERF_SKIP_PROCESSING_KEYS");
+            ConfigNode settingsNodePrefixes = KSPCommunityFixes.SettingsNode.GetNode("CONFIGNODE_PERF_SKIP_PROCESSING_SUBSTRINGS");
+
+            if (settingsNodeKeys != null)
+            {
+                _skipKeys = new string[settingsNodeKeys.values.Count];
+                int i = 0;
+                foreach (ConfigNode.Value v in settingsNodeKeys.values)
+                    _skipKeys[i++] = v.value;
+            }
+            else
+                _skipKeys = new string[0];
+
+            if (settingsNodePrefixes != null)
+            {
+                _skipPrefixes = new string[settingsNodePrefixes.values.Count];
+                int i = 0;
+                foreach (ConfigNode.Value v in settingsNodePrefixes.values)
+                    _skipPrefixes[i++] = v.value;
+            }
+            else
+                _skipPrefixes = new string[0];
+
+            _valid = _skipKeys.Length > 0 || _skipPrefixes.Length > 0;
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(ConfigNode), nameof(PreFormatConfig)),
+                this));
+        }
+
+        // This will fail if nested, so we cache off the old writeLinks.
+        private static bool ConfigNode_PreFormatConfig_Prefix(string[] cfgData, ref List<string[]> __result)
+        {
+            __result = _PreFormatConfig(cfgData);
+#if DEBUG_CONFIGNODE_PERF
+            var old = OldPreFormat(cfgData);
+            string str = string.Empty;
+            if (__result.Count != old.Count)
+            {
+                str = $"\nMismatch in length! Ours {__result.Count}, old {old.Count}";
+                for (int i = 0; i < old.Count; ++i)
+                {
+                    int rL = __result[i].Length;
+                    int oL = old[i].Length;
+                    str += $"\nLine {i}:";
+                    for (int j = 0; j < Math.Max(rL, oL); ++j)
+                    {
+                        str += "\n";
+                        str += j < rL ? __result[i][j] : "<>";
+                        str += " |||| ";
+                        str += j < oL ? old[i][j] : "<>";
+                    }
+                }
+            }
+            else
+            {
+                for (int i = 0; i < old.Count; ++i)
+                {
+                    int rL = __result[i].Length;
+                    int oL = old[i].Length;
+                    if (rL != oL)
+                    {
+                        str += $"\nLength mismatch on line {i}. Dumping:";
+                        for (int j = 0; j < Math.Max(rL, oL); ++j)
+                        {
+                            str += "\n";
+                            str += j < rL ? __result[i][j] : "<>";
+                            str += " |||| ";
+                            str += j < oL ? old[i][j] : "<>";
+                        }
+                        break;
+                    }
+                    for (int j = 0; j < rL; ++j)
+                    {
+                        if (__result[i][j] != old[i][j])
+                        {
+                            str += $"\nValue mismatch on line {i}, value {j}:\n{__result[i][j]} |||| {old[i][j]}";
+                        }
+                    }
+                }
+            }
+            if (str != string.Empty)
+            {
+                Debug.Log("$$$$ mismatch:" + str);
+                __result = old;
+            }
+#endif
+            return false;
+        }
+
+        private static void AddKVP(List<string[]> output, string line, int keyStart, int keyLast, int valueStart, int valueLast)
+        {
+            var pair = new string[2];
+            if (keyLast < keyStart)
+                pair[0] = string.Empty;
+            else
+                pair[0] = line.Substring(keyStart, keyLast - keyStart + 1);
+
+            if (valueLast < valueStart)
+                pair[1] = string.Empty;
+            else
+                pair[1] = line.Substring(valueStart, valueLast - valueStart + 1);
+
+            output.Add(pair);
+        }
+
+        private static unsafe void ProcessValueRaw(List<string[]> output, string line, char* pszLine, int start, int lineLen, int idxKeyStart, int idxKeyLast)
+        {
+            int idxValueStart = start;
+            for (; idxValueStart < lineLen; ++idxValueStart)
+            {
+                if (!char.IsWhiteSpace(pszLine[idxValueStart]))
+                    break;
+            }
+
+            int idxValueLast;
+            if (idxValueStart == lineLen)
+            {
+                // Empty value
+                idxValueLast = -1;
+            }
+            else
+            {
+                idxValueLast = lineLen - 1;
+                for (; idxValueLast > idxValueStart; --idxValueLast)
+                {
+                    if (!char.IsWhiteSpace(pszLine[idxValueLast]))
+                        break;
+                }
+            }
+
+            AddKVP(output, line, idxKeyStart, idxKeyLast, idxValueStart, idxValueLast);
+        }
+
+        private static unsafe void ProcessValue(List<string[]> output, string line, char* pszLine, int start, int lineLen, int idxKeyStart, int idxKeyLast)
+        {
+            int idxValueStart = start;
+
+            for (; idxValueStart < lineLen; ++idxValueStart)
+            {
+                char c = pszLine[idxValueStart];
+                if (c == '{' || c == '}')
+                {
+                    // There is nothing left of the brace, so add an empty value.
+                    AddKVP(output, line, idxKeyStart, idxKeyLast, 0, -1);
+                    // next, add the brace.
+                    output.Add(new string[1] { c.ToString() }); // hopefully this is faster than substring
+                    // finally, process the rest of the line.
+                    ProcessLine(output, line, pszLine, idxValueStart + 1, lineLen);
+                    return;
+                }
+
+                if (idxValueStart < lineLen - 1 && c == '/' && pszLine[idxValueStart + 1] == '/')
+                {
+                    lineLen = idxValueStart; // ignore whatever follows
+                    break;
+                }
+
+                if (!char.IsWhiteSpace(c))
+                    break;
+            }
+
+            int idxValueLast;
+            if (idxValueStart == lineLen)
+            {
+                // Empty value
+                idxValueLast = -1;
+            }
+            else
+            {
+                idxValueLast = idxValueStart;
+                for (; idxValueLast < lineLen - 1; ++idxValueLast)
+                {
+                    char c = pszLine[idxValueLast];
+                    if (c == '{' || c == '}')
+                    {
+                        // Welp, we found the end of the value.
+                        AddKVP(output, line, idxKeyStart, idxKeyLast, idxValueStart, idxValueLast - 1);
+                        // next, add the brace.
+                        output.Add(new string[1] { c.ToString() }); // hopefully this is faster than substring
+                        // finally, process the rest of the line.
+                        ProcessLine(output, line, pszLine, idxValueStart + 1, lineLen);
+                        return;
+                    }
+
+                    if (c == '/' && pszLine[idxValueLast + 1] == '/')
+                    {
+                        --idxValueLast;
+                        break;
+                    }
+                }
+
+                for (; idxValueLast > idxValueStart; --idxValueLast)
+                {
+                    if (!char.IsWhiteSpace(pszLine[idxValueLast]))
+                        break;
+                }
+            }
+
+            AddKVP(output, line, idxKeyStart, idxKeyLast, idxValueStart, idxValueLast);
+        }
+
+        private static unsafe void ProcessLine(List<string[]> output, string line, char* pszLine, int start, int lineLen)
+        {
+            if (start == lineLen)
+                return;
+
+            // Find first nonwhitespace char
+            int idxKeyStart = start;
+            for (; idxKeyStart < lineLen; ++idxKeyStart)
+            {
+                char c = pszLine[idxKeyStart];
+                if (!char.IsWhiteSpace(c))
+                    break;
+            }
+
+            // If we didn't find any non-whitespace, or it's only a comment, bail
+            if (idxKeyStart == lineLen
+                || (idxKeyStart < lineLen - 1 && pszLine[idxKeyStart] == '/' && pszLine[idxKeyStart + 1] == '/'))
+                return;
+
+            // Find equals, if it exists. We'll divert if we find a brace, and truncate if we find a comment.
+            int idxEquals = idxKeyStart;
+            int idxKeyLast = idxEquals;
+            for (; idxEquals < lineLen; ++idxEquals)
+            {
+                char c = pszLine[idxEquals];
+                if (c == '=')
+                    break;
+
+                if (c == '{' || c == '}')
+                {
+                    // First, process what's left of the brace, using our known first-non-whitespace char
+                    ProcessLine(output, line, pszLine, idxKeyStart, idxEquals);
+                    // next, add the brace.
+                    output.Add(new string[1] { pszLine[idxEquals].ToString() }); // hopefully this is faster than substring
+                    // finally, process the rest of the line.
+                    ProcessLine(output, line, pszLine, idxEquals + 1, lineLen);
+                    return;
+                }
+
+                if (idxEquals < lineLen - 1 && c == '/' && pszLine[idxEquals + 1] == '/')
+                {
+                    lineLen = idxEquals; // ignore whatever follows
+                    break;
+                }
+                if (!char.IsWhiteSpace(c))
+                    idxKeyLast = idxEquals;
+            }
+            if (idxEquals == lineLen)
+            {
+                // this is a nonempty line with no equals, and we've already stripped the comment and any braces.
+                // We know the last non-WS character index, too, so let's just add it and return.
+                output.Add(new string[1] { line.Substring(idxKeyStart, idxKeyLast - idxKeyStart + 1) });
+                return;
+            }
+            else
+            {
+                // See if we should skip further processing.
+                int keyLen = idxKeyLast - idxKeyStart + 1;
+                if (keyLen > 0)
+                {
+                    foreach (string s in _skipKeys)
+                    {
+                        if (keyLen != s.Length)
+                            continue;
+
+                        bool match = true;
+                        fixed (char* pszComp = s)
+                        {
+                            for (int j = 0; j < keyLen; ++j)
+                            {
+                                if (pszLine[idxKeyStart + j] != pszComp[j])
+                                {
+                                    match = false;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (match)
+                        {
+#if DEBUG
+                            Debug.Log("$$$ Skipped processing key " + s);
+#endif
+                            ProcessValueRaw(output, line, pszLine, idxEquals + 1, lineLen, idxKeyStart, idxKeyLast);
+                            return;
+                        }
+                    }
+                    foreach (string s in _skipPrefixes)
+                    {
+                        if (keyLen < s.Length)
+                            continue;
+
+                        bool match = true;
+                        int sLen = s.Length;
+                        fixed (char* pszComp = s)
+                        {
+                            for (int j = 0; j < sLen; ++j)
+                            {
+                                if (pszLine[idxKeyStart + j] != pszComp[j])
+                                {
+                                    match = false;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (match)
+                        {
+#if DEBUG
+                            Debug.Log($"$$$ Skipped processing key matching {s} (full key is {line.Substring(idxKeyStart, idxKeyLast - idxKeyStart + 1)})");
+#endif
+                            ProcessValueRaw(output, line, pszLine, idxEquals + 1, lineLen, idxKeyStart, idxKeyLast);
+                            return;
+                        }
+                    }
+                }
+                ProcessValue(output, line, pszLine, idxEquals + 1, lineLen, idxKeyStart, idxKeyLast);
+            }
+        }
+
+        private static unsafe List<string[]> _PreFormatConfig(string[] cfgData)
+        {
+            if (cfgData != null && cfgData.Length >= 1)
+            {
+                int lineCount = cfgData.Length;
+                List<string[]> output = new List<string[]>(lineCount);
+
+                for (int i = 0; i < lineCount; ++i)
+                {
+                    fixed (char* pszLine = cfgData[i])
+                    {
+                        ProcessLine(output, cfgData[i], pszLine, 0, cfgData[i].Length);
+                    }
+                }
+
+                return output;
+            }
+            Debug.LogError("Error: Empty part config file");
+            return null;
+        }
+
+        private static List<string[]> OldPreFormat(string[] cfgData)
+        {
+            if (cfgData != null && cfgData.Length >= 1)
+            {
+                List<string> list = new List<string>(cfgData);
+                int num = list.Count;
+                while (--num >= 0)
+                {
+                    list[num] = list[num];
+                    int num2;
+                    if ((num2 = list[num].IndexOf("//")) != -1)
+                    {
+                        if (num2 == 0)
+                        {
+                            list.RemoveAt(num);
+                            continue;
+                        }
+                        list[num] = list[num].Remove(num2);
+                    }
+                    list[num] = list[num].Trim();
+                    if (list[num].Length == 0)
+                    {
+                        list.RemoveAt(num);
+                    }
+                    else if ((num2 = list[num].IndexOf("}", 0)) != -1 && (num2 != 0 || list[num].Length != 1))
+                    {
+                        if (num2 > 0)
+                        {
+                            list.Insert(num, list[num].Substring(0, num2));
+                            num++;
+                            list[num] = list[num].Substring(num2);
+                            num2 = 0;
+                        }
+                        if (num2 < list[num].Length - 1)
+                        {
+                            list.Insert(num + 1, list[num].Substring(num2 + 1));
+                            list[num] = "}";
+                            num += 2;
+                        }
+                    }
+                    else if ((num2 = list[num].IndexOf("{", 0)) != -1 && (num2 != 0 || list[num].Length != 1))
+                    {
+                        if (num2 > 0)
+                        {
+                            list.Insert(num, list[num].Substring(0, num2));
+                            num++;
+                            list[num] = list[num].Substring(num2);
+                            num2 = 0;
+                        }
+                        if (num2 < list[num].Length - 1)
+                        {
+                            list.Insert(num + 1, list[num].Substring(num2 + 1));
+                            list[num] = "{";
+                            num += 2;
+                        }
+                    }
+                }
+                List<string[]> list2 = new List<string[]>(list.Count);
+                int i = 0;
+                for (int count = list.Count; i < count; i++)
+                {
+                    string[] array = CustomEqualSplit(list[i]);
+                    if (array != null && array.Length != 0)
+                    {
+                        list2.Add(array);
+                    }
+                }
+                return list2;
+            }
+            Debug.LogError("Error: Empty part config file");
+            return null;
+        }
+    }
+}

--- a/KSPCommunityFixes/Performance/ConfigNodePerf.cs
+++ b/KSPCommunityFixes/Performance/ConfigNodePerf.cs
@@ -180,6 +180,7 @@ namespace KSPCommunityFixes.Performance
                 sw.Write("// ");
                 sw.Write(header);
                 sw.Write(_Newline);
+                sw.Write(_Newline);
             }
             _WriteRootNode(__instance, sw);
             sw.Close();

--- a/KSPCommunityFixes/Properties/AssemblyInfo.cs
+++ b/KSPCommunityFixes/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("1.20.4.0")]
-[assembly: AssemblyFileVersion("1.20.4.0")]
+[assembly: AssemblyVersion("1.21.0.0")]
+[assembly: AssemblyFileVersion("1.21.0.0")]

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ User options are available from the "ESC" in-game settings menu :<br/><img src="
 - [**CommNetThrottling**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/56) [KSP 1.12.0 - 1.12.3]<br/>Disabled by default, you can enable it with a MM patch. Prevent full CommNet network updates from happening every frame, but instead to happen at a regular real-world time interval of 5 seconds while in flight. Enabling this can provide a decent performance uplift in games having an large amount of celestial bodies and/or vessels, but has a detrimental impact on the precision of the simulation and can potentially cause issues with mods relying on the stock behavior.
 - [**AsteroidAndCometDrillCache**](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/67) [KSP 1.12.3]<br/>Reduce constant overhead of ModuleAsteroidDrill and ModuleCometDrill by using the cached asteroid/comet part lookup results from ModuleResourceHarvester. Improves performance with large part count vessels having at least one drill part.
 - [**FewerSaves**](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/80) [KSP 1.8.0 - KSP 1.12.3]<br/>Disables saving on exiting Space Center minor buildings (Mission Control etc) and when deleting vessels in Tracking Station. Disabled by default.
+- [**ConfigNodePerf**](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/88) [KSP 1.8.0 - KSP 1.12.3]<br/>Speeds up loading and saving of ConfigNodes, allows skipping processing on certain known-good keys (like Principia's serialized data).
 
 #### API and modding tools
 - **MultipleModuleInPartAPI** [KSP 1.8.0 - 1.12.3]<br/>This API allow other plugins to implement PartModules that can exist in multiple occurrence in a single part and won't suffer "module indexing mismatch" persistent data losses following part configuration changes. [See documentation on the wiki](https://github.com/KSPModdingLibs/KSPCommunityFixes/wiki/MultipleModuleInPartAPI).
@@ -155,6 +156,7 @@ If doing so in the `Debug` configuration and if your KSP install is modified to 
 - New performance / KSP bugfix patch : [PQSCoroutineLeak](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/85) (issue discovered by @Gameslinx)
 - Fixed the ToolbarShowHide patch partially failing due to an ambigious match exception when searching the no args `ApplicationLauncher.ShouldItHide()` method overload.
 - PersistentIConfigNode patch : added support for nested Persistent IConfigNode, see associated [PR](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/86) (@NathanKell).
+- New performance patch : [ConfigNodePerf](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/88) (@NathanKell)
 
 ##### 1.20.4
 - Restrict UpgradeBugs to KSP 1.12+ since it is compiled against the new combined editor class.


### PR DESCRIPTION
Rewrite PreFormatConfig to iterate through strings less and to support skipping checking for {} and //
Also patch writing for a little bit of extra perf.

The preformat patch includes, disabled, siimav's parallel implementaiton; it's disabled because at the moment it's strictly slower than stock code AFAICT.

For testing, add this to a file in gamedata and then load craft/saves.
```
@KSP_COMMUNITY_FIXES:FINAL
{
	@CONFIGNODE_PERF_SKIP_PROCESSING_KEYS
	{
		item = attPos0
	}
	@CONFIGNODE_PERF_SKIP_PROCESSING_SUBSTRINGS
	{
		item = attRot
	}
}
```

Note that the skip nodes will only apply after MM loads; before that you'll just get the regular speedup.