### PR TITLE
More ConfigNode perf

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -287,17 +287,6 @@ KSP_COMMUNITY_FIXES
   // and every time you delete a vessel in the Tracking Station
   FewerSaves = false
 
-  // These settings will make ConfigNode's loader not bother doing
-  // Extended checking during parsing for keys named ths
-  CONFIGNODE_PERF_SKIP_PROCESSING_KEYS
-  {
-    serialized_plugin = true
-  }
-  // or for keys that start with this.
-  CONFIGNODE_PERF_SKIP_PROCESSING_SUBSTRINGS
-  {
-  }
-
   // ##########################
   // Modding
   // ##########################

--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -291,12 +291,11 @@ KSP_COMMUNITY_FIXES
   // Extended checking during parsing for keys named ths
   CONFIGNODE_PERF_SKIP_PROCESSING_KEYS
   {
-    item = serialized_plugin
+    serialized_plugin = true
   }
   // or for keys that start with this.
   CONFIGNODE_PERF_SKIP_PROCESSING_SUBSTRINGS
   {
-    item = **skipProc**
   }
 
   // ##########################

--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -287,6 +287,11 @@ KSP_COMMUNITY_FIXES
   // and every time you delete a vessel in the Tracking Station
   FewerSaves = false
 
+  // This tweak will skip writing indents when saving craft files and
+  // savegames (sfs files). This will speed up writing (and slightly
+  // speed up reading) at the cost of human readability.
+  SkipIndentsOnSavesAndCraftFiles = false
+
   // ##########################
   // Modding
   // ##########################

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -26,6 +26,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>portable</DebugType>

--- a/KSPCommunityFixes/Modding/ModUpgradePipeline.cs
+++ b/KSPCommunityFixes/Modding/ModUpgradePipeline.cs
@@ -171,10 +171,13 @@ namespace KSPCommunityFixes.Modding
 
         private static void AddVersions(ConfigNode node, LoadContext loadContext)
         {
-            if(loadContext == LoadContext.SFS)
+            var oldDoClean = Performance.ConfigNodePerf._doClean;
+            Performance.ConfigNodePerf._doClean = false;
+            if (loadContext == LoadContext.SFS)
                 node.GetNode("GAME").SetValue("_modVersions", _versionString, true);
             else
                 node.SetValue("_modVersions", _versionString, true);
+            Performance.ConfigNodePerf._doClean = oldDoClean;
         }
 
         private static void ShipConstruct_SaveShip_Postfix(ref ConfigNode __result)

--- a/KSPCommunityFixes/Modding/PersistentIConfigNode.cs
+++ b/KSPCommunityFixes/Modding/PersistentIConfigNode.cs
@@ -1,8 +1,10 @@
 ﻿// - Add support for IConfigNode serialization
 // - Add support for Guid serialization
-
+// - Rewrite Object reading and writing for perf, clarity, and reuse
+#define DEBUG_PERSISTENTICONFIGNODE
 using HarmonyLib;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using UnityEngine;
@@ -93,206 +95,859 @@ namespace KSPCommunityFixes.Modding
             readLinks = __state.links;
         }
 
-        private static bool ConfigNode_WriteObject_Prefix(object obj, ConfigNode node, int pass)
+        // used by TypeCache since we can't make the below method return a value.
+        public static bool WriteSuccess;
+
+        public static bool ConfigNode_WriteObject_Prefix(object obj, ConfigNode node, int pass)
         {
-            (obj as IPersistenceSave)?.PersistenceSave();
-            if (HasAttribute(obj.GetType(), typeof(PersistentLinkable)))
-            {
-                node.AddValue("link_uid", writeLinks.AssignTarget(obj));
-            }
+            if (obj is IPersistenceSave persistenceSave)
+                persistenceSave.PersistenceSave();
+
             Type type = obj.GetType();
-            MemberInfo[] fields = type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy);
-            MemberInfo[] array = fields;
-            int num = array.Length;
-            for (int i = 0; i < num; i++)
+            var typeCache = TypeCache.GetOrCreate(type);
+            if (typeCache == null)
             {
-                MemberInfo memberInfo = array[i];
-                Persistent[] array2 = (Persistent[])memberInfo.GetCustomAttributes(typeof(Persistent), inherit: true);
-                int num2 = array2.Length;
-                for (int j = 0; j < num2; j++)
-                {
-                    Persistent persistent = array2[j];
-                    if (!persistent.isPersistant || (pass != 0 && persistent.pass != 0 && (persistent.pass & pass) == 0))
-                    {
-                        continue;
-                    }
-                    string fieldName = RetrieveFieldName(memberInfo, persistent);
-                    FieldInfo field = type.GetField(memberInfo.Name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-                    object value = field.GetValue(obj);
-                    Type fieldType = field.FieldType;
-                    if (value == null)
-                    {
-                        continue;
-                    }
-                    if (persistent.link)
-                    {
-                        if (!HasAttribute(obj.GetType(), typeof(PersistentLinkable)))
-                        {
-                            Debug.LogWarning("Field: '" + memberInfo.Name + "' does not reference a PersistentLinkable type");
-                        }
-                        else
-                        {
-                            WriteValue(fieldName, typeof(int), writeLinks.AssignLink(value), node);
-                        }
-                    }
-                    // begin edit
-                    else if (IsIConfigNode(fieldType))
-                    {
-                        WriteIConfigNode(fieldName, value, node);
-                    }
-                    else if (fieldType == typeof(Guid))
-                    {
-                        node.AddValue(fieldName, ((Guid)value).ToString());
-                    }
-                    // end edit
-                    else if (IsValue(fieldType))
-                    {
-                        WriteValue(fieldName, fieldType, value, node);
-                    }
-                    else if (IsArrayType(fieldType))
-                    {
-                        WriteArrayTypes(fieldName, fieldType, value, node, persistent);
-                    }
-                    else
-                    {
-                        WriteStruct(fieldName, field, value, node, pass);
-                        
-                    }
-                }
+                WriteSuccess = false;
+                return false;
             }
+
+            WriteSuccess = typeCache.Write(obj, node, pass);
 
             return false;
         }
 
-        private static bool IsIConfigNode(Type fieldType)
+        
+        public static bool ConfigNode_ReadObject_Prefix(object obj, ConfigNode node, out bool __result)
         {
-            return typeof(IConfigNode).IsAssignableFrom(fieldType);
-        }
-
-        private static void WriteIConfigNode(string fieldName, object value, ConfigNode node)
-        {
-            IConfigNode icn = (IConfigNode) value;
-            ConfigNode n = node.GetNode(fieldName);
-            if (n == null)
+            Type type = obj.GetType();
+            var typeCache = TypeCache.GetOrCreate(type);
+            if (typeCache == null)
             {
-                n = new ConfigNode(fieldName);
-                node.AddNode(n);
-            }
-            else
-            {
-                n.ClearData();
+                __result = false;
+                return false;
             }
 
-            icn.Save(n);
-        }
-
-        private static bool ConfigNode_ReadObject_Prefix(object obj, ConfigNode node, out bool __result)
-        {
-            ReadFieldList readFieldList = new ReadFieldList(obj);
-            if (HasAttribute(obj.GetType(), typeof(PersistentLinkable)))
-            {
-                if (!node.HasValue("link_uid"))
-                {
-                    readLinks.AssignLinkable(-1, obj);
-                }
-                else
-                {
-                    int linkID = int.Parse(node.GetValue("link_uid"));
-                    readLinks.AssignLinkable(linkID, obj);
-                }
-            }
-            int count = node.values.Count;
-            for (int i = 0; i < count; i++)
-            {
-                Value value = node.values[i];
-                ReadFieldList.FieldItem fieldItem = readFieldList[value.name];
-                if (fieldItem == null)
-                {
-                    continue;
-                }
-                if (fieldItem.kspField.link)
-                {
-                    int linkID2 = int.Parse(value.value);
-                    readLinks.AssignLink(linkID2, fieldItem, -1);
-                    if (removeAfterUse)
-                    {
-                        value.name = "";
-                    }
-                }
-                // begin edit 1
-                else if (fieldItem.fieldType == typeof(Guid))
-                {
-                    fieldItem.fieldInfo.SetValue(fieldItem.host, new Guid(value.value));
-                }
-                // end edit
-                else if (IsValue(fieldItem.fieldType))
-                {
-                    object obj2 = ReadValue(fieldItem.fieldType, value.value);
-                    if (obj2 != null)
-                    {
-                        fieldItem.fieldInfo.SetValue(fieldItem.host, obj2);
-                    }
-                    if (removeAfterUse)
-                    {
-                        value.name = "";
-                    }
-                }
-            }
-            count = node.nodes.Count;
-            for (int j = 0; j < count; j++)
-            {
-                ConfigNode configNode = node.nodes[j];
-                ReadFieldList.FieldItem fieldItem2 = readFieldList[configNode.name];
-                if (fieldItem2 != null)
-                {
-                    // begin edit 2
-                    if (IsIConfigNode(fieldItem2.fieldType))
-                    {
-                        ReadIConfigNode(fieldItem2, configNode);
-                    }
-                    // end edit
-                    else if (IsArrayType(fieldItem2.fieldType))
-                    {
-                        ReadArray(fieldItem2, configNode);
-                    }
-                    else
-                    {
-                        ReadObject(fieldItem2, configNode);
-                    }
-                    if (removeAfterUse)
-                    {
-                        configNode.name = "";
-                    }
-                }
-            }
+            bool readResult = typeCache.Read(obj, node);
 
             if (obj is IPersistenceLoad persistenceLoad)
             {
                 iPersistentLoaders.Add(persistenceLoad);
             }
 
-            __result = true;
+            __result = readResult;
             return false;
-        }
-
-        private static void ReadIConfigNode(ReadFieldList.FieldItem fieldItem, ConfigNode configNode)
-        {
-            IConfigNode icn;
-            try
-            {
-                icn = (IConfigNode)Activator.CreateInstance(fieldItem.fieldType);
-            }
-            catch
-            {
-                Debug.LogError($"Couldn't deserialize field {fieldItem.name} on {fieldItem.host}, field value is null and {fieldItem.fieldType} has no parameterless constructor");
-                return;
-            }
-            icn.Load(configNode);
-            fieldItem.fieldInfo.SetValue(fieldItem.host, icn);
         }
     }
 
-#if DEBUG
+    // This is an expanded version of System.TypeCode
+    public enum DataType : uint
+    {
+        INVALID = 0,
+        IConfigNode,
+        ValueString,
+        ValueGuid,
+        ValueBool,
+        ValueByte,
+        ValueSByte,
+        ValueChar,
+        ValueDecimal,
+        ValueDouble,
+        ValueFloat,
+        ValueInt,
+        ValueUInt,
+        ValueLong,
+        ValueULong,
+        ValueShort,
+        ValueUShort,
+        ValueVector2,
+        ValueVector3,
+        ValueVector3d,
+        ValueVector4,
+        ValueQuaternion,
+        ValueQuaternionD,
+        ValueMatrix4x4,
+        ValueColor,
+        ValueColor32,
+        ValueEnum,
+        Array,
+        IList,
+        Component,
+        Object,
+
+        FirstValueType = ValueString,
+        LastValueType = ValueEnum,
+    }
+
+    public class FieldData
+    {
+        private static readonly System.Globalization.CultureInfo _Invariant = System.Globalization.CultureInfo.InvariantCulture;
+        public string[] persistentNames;
+        public Type fieldType;
+        public FieldInfo fieldInfo;
+        public Persistent[] attribs;
+        public DataType dataType;
+        public bool isLinkable;
+
+        public FieldData arrayType;
+
+        public FieldData(Type t, Persistent[] attribs)
+        {
+            fieldType = t;
+
+            int len = attribs.Length;
+            persistentNames = new string[len];
+            for (int i = len; i-- > 0;)
+            {
+                string itemName = attribs[i].collectionIndex;
+                if (itemName != null && itemName.Length > 0)
+                    persistentNames[i] = itemName;
+                // else leave it null
+            }
+
+            SetDataType(false);
+        }
+
+        public FieldData(MemberInfo memberInfo, Persistent[] attribs)
+        {
+            this.attribs = attribs;
+            int len = attribs.Length;
+            persistentNames = new string[len];
+            for (int i = len; i-- > 0;)
+            {
+                string pName = attribs[i].name;
+                persistentNames[i] = pName != null && pName.Length > 0 ? pName : memberInfo.Name;
+            }
+
+            fieldInfo = memberInfo.DeclaringType.GetField(memberInfo.Name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            fieldType = fieldInfo.FieldType;
+            arrayType = null;
+
+            isLinkable = HasAttribute(memberInfo.DeclaringType, typeof(PersistentLinkable));
+
+            SetDataType(true);
+        }
+
+        public bool Read(Value value, object host, int index)
+        {
+            if (attribs[index].link)
+            {
+                if (!isLinkable || !int.TryParse(value.value, out int linkID))
+                    return false;
+
+                readLinks.AssignLink(linkID, new ReadFieldList.FieldItem(fieldInfo, attribs[index], host), -1);
+                if (removeAfterUse)
+                    value.name = string.Empty;
+
+                return true;
+            }
+
+            object val = ReadValue(value.value, dataType, fieldType);
+            if (removeAfterUse)
+                value.value = string.Empty;
+
+            if (val == null)
+                return false;
+
+            fieldInfo.SetValue(host, val);
+            return true;
+        }
+
+        public bool Read(ConfigNode node, object host, int index)
+        {
+            int vCount = node._values.values.Count;
+            int nCount = node._nodes.nodes.Count;
+
+            if (dataType == DataType.Object || dataType == DataType.IConfigNode)
+            {
+                object obj = ReadObject(node, dataType, fieldType, out bool success);
+                if (obj == null)
+                    return false;
+
+                fieldInfo.SetValue(host, obj);
+                return success;
+            }
+
+            if (dataType == DataType.Component)
+            {
+                MonoBehaviour behv = CreateComponent(host, fieldType, attribs[index], node, out bool success);
+                if (behv == null)
+                    return false;
+                fieldInfo.SetValue(host, behv);
+                return success;
+            }
+
+            Array arr = null;
+            IList list = null;
+            if (attribs[index].link)
+            {
+                int fieldIndex = 0;
+
+                Value value;
+                for (int i = 0; i < vCount; ++i)
+                {
+                    value = node._values.values[i];
+
+                    _readLinks.AssignLink(int.Parse(value.value), new ReadFieldList.FieldItem(fieldInfo, attribs[index], host), fieldIndex++);
+                }
+
+                if (dataType == DataType.Array)
+                {
+                    arr = Array.CreateInstance(arrayType.fieldType, vCount);
+                    for (int i = 0; i < vCount; ++i)
+                    {
+                        arr.SetValue(null, i);
+                    }
+                    fieldInfo.SetValue(host, arr);
+                }
+                else
+                {
+                    list = (IList)Activator.CreateInstance(fieldType);
+                    for (int i = 0; i < vCount; ++i)
+                    {
+                        list.Add(null);
+                    }
+                    fieldInfo.SetValue(host, list);
+                }
+                return true;
+            }
+            if (arrayType.dataType == DataType.INVALID)
+                return false;
+
+            if (arrayType.dataType == DataType.Component)
+                return ReadComponentArray(node, host, index);
+
+            bool isArr = dataType == DataType.Array;
+            bool arrReadSuccess = true;
+            if (arrayType.dataType >= DataType.FirstValueType && arrayType.dataType <= DataType.LastValueType)
+            {
+                
+                if (isArr)
+                    arr = Array.CreateInstance(arrayType.fieldType, vCount);
+                else
+                    list = (IList)Activator.CreateInstance(fieldType);
+
+                for (int i = 0; i < vCount; ++i)
+                {
+                    object val = ReadValue(node._values.values[i].value, arrayType.dataType, arrayType.fieldType);
+                    if (isArr)
+                        arr.SetValue(val, i);
+                    else
+                        list.Add(val);
+                }
+            }
+            else
+            {
+                if (isArr)
+                    arr = Array.CreateInstance(arrayType.fieldType, nCount);
+                else
+                    list = (IList)Activator.CreateInstance(fieldType);
+
+                for (int i = 0; i < nCount; ++i)
+                {
+                    object val = ReadObject(node._nodes.nodes[i], arrayType.dataType, arrayType.fieldType, out bool readSuccess);
+                    arrReadSuccess &= readSuccess;
+                    if (isArr)
+                        arr.SetValue(val, i);
+                    else
+                        list.Add(val);
+                }
+            }
+            if (isArr)
+                fieldInfo.SetValue(host, arr);
+            else
+                fieldInfo.SetValue(host, list);
+            return arrReadSuccess;
+        }
+
+        public bool Write(string fieldName, object value, ConfigNode node, int attribIndex, int pass)
+        {
+            if (dataType >= DataType.FirstValueType && dataType <= DataType.LastValueType)
+            {
+                return WriteValue(fieldName, value, dataType, node);
+            }
+
+            var subNode = new ConfigNode(fieldName);
+
+            switch (dataType)
+            {
+                // Node types
+                case DataType.IConfigNode:
+                    (value as IConfigNode).Save(subNode);
+                    if (subNode.HasData)
+                        node._nodes.nodes.Add(subNode);
+                    return true;
+                case DataType.IList:
+                case DataType.Array:
+                    var list = value as IList;
+                    if (list == null || arrayType == null)
+                        return false;
+                    string itemName = arrayType.persistentNames[attribIndex] ?? "item";
+                    foreach (var item in list)
+                    {
+                        arrayType.Write(itemName, item, subNode, attribIndex, pass);
+                    }
+                    if (subNode.HasData)
+                        node._nodes.nodes.Add(subNode);
+                    return true;
+
+                case DataType.Object:
+                case DataType.Component:
+                    PersistentIConfigNode.ConfigNode_WriteObject_Prefix(value, subNode, pass);
+                    return PersistentIConfigNode.WriteSuccess;
+            }
+            return false;
+        }
+
+        public static object ReadObject(ConfigNode node, DataType dataType, Type fieldType, out bool success)
+        {
+            success = false;
+            switch(dataType)
+            {
+                case DataType.IConfigNode:
+                    success = true;
+                    IConfigNode icn = (IConfigNode)Activator.CreateInstance(fieldType);
+                    icn.Load(node);
+                    return icn;
+                case DataType.Object:
+                    object newObj = Activator.CreateInstance(fieldType);
+                    PersistentIConfigNode.ConfigNode_ReadObject_Prefix(newObj, node, out success);
+                    return newObj;
+            }
+            return null;
+        }
+
+        public static MonoBehaviour CreateComponent(object host, Type fieldType, Persistent attrib, ConfigNode node, out bool success)
+        {
+            success = false;
+            MonoBehaviour hostComponent = host as MonoBehaviour;
+            if (hostComponent == null)
+            {
+                Debug.LogWarning("Cannot instantiate a MonoBehaviour type inside a non-MonoBehaviour class (or a destroyed MonoBehaviour)");
+                return null;
+            }
+
+            GameObject hostObject = null;
+            switch (attrib.relationship)
+            {
+                case PersistentRelation.NoRelation:
+                    hostObject = new GameObject();
+                    break;
+                case PersistentRelation.SameObject:
+                    hostObject = hostComponent.gameObject;
+                    break;
+                case PersistentRelation.ChildObject:
+                    hostObject = new GameObject();
+                    hostObject.transform.parent = hostComponent.transform;
+                    hostObject.transform.localPosition = Vector3.zero;
+                    hostObject.transform.localRotation = Quaternion.identity;
+                    break;
+            }
+            MonoBehaviour child = (MonoBehaviour)hostObject.AddComponent(fieldType);
+            if (child == null)
+            {
+                Debug.LogError("Cannot create component of type '" + fieldType.Name + "'");
+                if (hostObject != hostComponent.gameObject)
+                {
+                    GameObject.DestroyImmediate(hostObject);
+                    return null;
+                }
+            }
+
+            // We're not reading directly here because the class might have
+            // other interfaces/links/etc.
+            PersistentIConfigNode.ConfigNode_ReadObject_Prefix(child, node, out success);
+            return child;
+        }
+
+        private bool ReadComponentArray(ConfigNode node, object host, int index)
+        {
+            int nCount = node._nodes.Count;
+            List<object> objects = new List<object>();
+
+            ConfigNode subNode;
+            bool allSucceeded = true;
+            for (int i = 0; i < nCount; ++i)
+            {
+                subNode = node.nodes[i];
+                MonoBehaviour child = CreateComponent(host, arrayType.fieldType, attribs[index], subNode, out bool success);
+                if (child == null)
+                    continue;
+
+                allSucceeded &= success;
+                objects.Add(child);
+            }
+
+            int len = objects.Count;
+            if (dataType == DataType.Array)
+            {
+                Array arr = Array.CreateInstance(arrayType.fieldType, len);
+                for (int i = 0; i < len; ++i)
+                {
+                    arr.SetValue(objects[i], i);
+                }
+                fieldInfo.SetValue(host, arr);
+            }
+            else
+            {
+                IList list = (IList)Activator.CreateInstance(fieldType);
+                for (int i = 0; i < len; ++i)
+                {
+                    list.Add(objects[i]);
+                }
+                fieldInfo.SetValue(host, list);
+            }
+            return allSucceeded;
+        }
+
+        public static object ReadValue(string value, DataType dataType, Type fieldType)
+        {
+            switch (dataType)
+            {
+                case DataType.ValueString:
+                    return value;
+                case DataType.ValueGuid:
+                    return  new Guid(value);
+                case DataType.ValueBool:
+                    if (bool.TryParse(value, out var b))
+                        return b;
+                    return null;
+                case DataType.ValueDouble:
+                    if (double.TryParse(value, out var d))
+                        return d;
+                    return null;
+                case DataType.ValueFloat:
+                    if (float.TryParse(value, out var f))
+                        return f;
+                    return null;
+                case DataType.ValueDecimal:
+                    if (decimal.TryParse(value, out var dc))
+                        return dc;
+                    return null;
+                case DataType.ValueInt:
+                    if (int.TryParse(value, out var i))
+                        return i;
+                    return null;
+                case DataType.ValueUInt:
+                    if (uint.TryParse(value, out var ui))
+                        return ui;
+                    return null;
+                case DataType.ValueChar:
+                    return value.Length > 0 ? value[0] : '\0';
+                case DataType.ValueShort:
+                    if (short.TryParse(value, out var s))
+                        return s;
+                    return null;
+                case DataType.ValueUShort:
+                    if (ushort.TryParse(value, out var us))
+                        return us;
+                    return null;
+                case DataType.ValueLong:
+                    if (long.TryParse(value, out var l))
+                        return l;
+                    return null;
+                case DataType.ValueULong:
+                    if (ulong.TryParse(value, out var ul))
+                        return ul;
+                    return null;
+                case DataType.ValueByte:
+                    if (byte.TryParse(value, out var by))
+                        return by;
+                    return null;
+                case DataType.ValueSByte:
+                    if (sbyte.TryParse(value, out var sb))
+                        return sb;
+                    return null;
+                case DataType.ValueEnum:
+                    try
+                    {
+                        return Enum.Parse(fieldType, value);
+                    }
+                    catch
+                    {
+                        return null;
+                    }
+                case DataType.ValueVector2:
+                    return ParseVector2(value);
+                case DataType.ValueVector3:
+                    return ParseVector3(value);
+                case DataType.ValueVector3d:
+                    return ParseVector3D(value);
+                case DataType.ValueVector4:
+                    return ParseVector4(value);
+                case DataType.ValueQuaternion:
+                    return ParseQuaternion(value);
+                case DataType.ValueQuaternionD:
+                    return ParseQuaternionD(value);
+                case DataType.ValueMatrix4x4:
+                    return ParseMatrix4x4(value);
+                case DataType.ValueColor:
+                    return ParseColor(value);
+                case DataType.ValueColor32:
+                    return ParseColor32(value);
+            }
+            return null;
+        }
+
+        public static bool WriteValue(string fieldName, object value, DataType dataType, ConfigNode node)
+        {
+            switch (dataType)
+            {
+                case DataType.ValueString:
+                    node._values.values.Add(new Value(fieldName, (string)value));
+                    return true;
+                case DataType.ValueGuid:
+                    node._values.values.Add(new Value(fieldName, ((Guid)value).ToString()));
+                    return true;
+                case DataType.ValueBool:
+                    node._values.values.Add(new Value(fieldName, ((bool)value).ToString(_Invariant)));
+                    return true;
+                case DataType.ValueDouble:
+                    node._values.values.Add(new Value(fieldName, ((double)value).ToString("G17")));
+                    return true;
+                case DataType.ValueFloat:
+                    node._values.values.Add(new Value(fieldName, ((float)value).ToString("G9")));
+                    return true;
+                case DataType.ValueDecimal:
+                    node._values.values.Add(new Value(fieldName, ((decimal)value).ToString(_Invariant)));
+                    return true;
+                case DataType.ValueInt:
+                    node._values.values.Add(new Value(fieldName, ((int)value).ToString(_Invariant)));
+                    return true;
+                case DataType.ValueUInt:
+                    node._values.values.Add(new Value(fieldName, ((uint)value).ToString(_Invariant)));
+                    return true;
+                case DataType.ValueChar:
+                    node._values.values.Add(new Value(fieldName, ((char)value).ToString(_Invariant)));
+                    return true;
+                case DataType.ValueShort:
+                    node._values.values.Add(new Value(fieldName, ((short)value).ToString(_Invariant)));
+                    return true;
+                case DataType.ValueUShort:
+                    node._values.values.Add(new Value(fieldName, ((ushort)value).ToString(_Invariant)));
+                    return true;
+                case DataType.ValueLong:
+                    node._values.values.Add(new Value(fieldName, ((long)value).ToString(_Invariant)));
+                    return true;
+                case DataType.ValueULong:
+                    node._values.values.Add(new Value(fieldName, ((ulong)value).ToString(_Invariant)));
+                    return true;
+                case DataType.ValueByte:
+                    node._values.values.Add(new Value(fieldName, ((byte)value).ToString(_Invariant)));
+                    return true;
+                case DataType.ValueSByte:
+                    node._values.values.Add(new Value(fieldName, ((sbyte)value).ToString(_Invariant)));
+                    return true;
+                case DataType.ValueEnum:
+                    node._values.values.Add(new Value(fieldName, ((System.Enum)value).ToString()));
+                    return true;
+                case DataType.ValueVector2:
+                    node._values.values.Add(new Value(fieldName, WriteVector((Vector2)value)));
+                    return true;
+                case DataType.ValueVector3:
+                    node._values.values.Add(new Value(fieldName, WriteVector((Vector3)value)));
+                    return true;
+                case DataType.ValueVector3d:
+                    node._values.values.Add(new Value(fieldName, WriteVector((Vector3)value)));
+                    return true;
+                case DataType.ValueVector4:
+                    node._values.values.Add(new Value(fieldName, WriteVector((Vector4)value)));
+                    return true;
+                case DataType.ValueQuaternion:
+                    node._values.values.Add(new Value(fieldName, WriteQuaternion((Quaternion)value)));
+                    return true;
+                case DataType.ValueQuaternionD:
+                    node._values.values.Add(new Value(fieldName, WriteQuaternion((QuaternionD)value)));
+                    return true;
+                case DataType.ValueMatrix4x4:
+                    node._values.values.Add(new Value(fieldName, WriteMatrix4x4((Matrix4x4)value)));
+                    return true;
+                case DataType.ValueColor:
+                    node._values.values.Add(new Value(fieldName, WriteColor((Color)value)));
+                    return true;
+                case DataType.ValueColor32:
+                    node._values.values.Add(new Value(fieldName, WriteColor((Color32)value)));
+                    return true;
+            }
+            return false;
+        }
+
+        public static DataType ValueDataType(Type fieldType)
+        {
+            if (!fieldType.IsValueType)
+            {
+                if (fieldType == typeof(string))
+                    return DataType.ValueString;
+
+                return DataType.INVALID;
+            }
+            if (fieldType == typeof(Guid))
+                return DataType.ValueGuid;
+            if (fieldType == typeof(bool))
+                return DataType.ValueBool;
+            if (fieldType == typeof(byte))
+                return DataType.ValueByte;
+            if (fieldType == typeof(sbyte))
+                return DataType.ValueSByte;
+            if (fieldType == typeof(char))
+                return DataType.ValueChar;
+            if (fieldType == typeof(decimal))
+                return DataType.ValueDecimal;
+            if (fieldType == typeof(double))
+                return DataType.ValueDouble;
+            if (fieldType == typeof(float))
+                return DataType.ValueFloat;
+            if (fieldType == typeof(int))
+                return DataType.ValueInt;
+            if (fieldType == typeof(uint))
+                return DataType.ValueUInt;
+            if (fieldType == typeof(long))
+                return DataType.ValueLong;
+            if (fieldType == typeof(ulong))
+                return DataType.ValueULong;
+            if (fieldType == typeof(short))
+                return DataType.ValueShort;
+            if (fieldType == typeof(ushort))
+                return DataType.ValueUShort;
+            if (fieldType == typeof(Vector2))
+                return DataType.ValueVector2;
+            if (fieldType == typeof(Vector3))
+                return DataType.ValueVector3;
+            if (fieldType == typeof(Vector3d))
+                return DataType.ValueVector3d;
+            if (fieldType == typeof(Vector4))
+                return DataType.ValueVector4;
+            if (fieldType == typeof(Quaternion))
+                return DataType.ValueQuaternion;
+            if (fieldType == typeof(QuaternionD))
+                return DataType.ValueQuaternionD;
+            if (fieldType == typeof(Matrix4x4))
+                return DataType.ValueMatrix4x4;
+            if (fieldType == typeof(Color))
+                return DataType.ValueColor;
+            if (fieldType == typeof(Color32))
+                return DataType.ValueColor32;
+            if (fieldType.IsEnum)
+                return DataType.ValueEnum;
+
+            return DataType.INVALID;
+        }
+
+        private void SetDataType(bool allowArrays)
+        {
+            if (typeof(IConfigNode).IsAssignableFrom(fieldType))
+                dataType = DataType.IConfigNode;
+            else if (ValueDataType(fieldType) is var dt && dt != DataType.INVALID)
+                dataType = dt;
+            else if (!allowArrays || !FindSetArrayType(fieldType))
+            {
+                if (fieldType.IsAssignableFrom(typeof(MonoBehaviour)) || fieldType.IsSubclassOf(typeof(MonoBehaviour)))
+                    dataType = DataType.Component;
+                else
+                    dataType = DataType.Object;
+            }
+        }
+
+        private bool FindSetArrayType(Type seqType)
+        {
+            if (seqType.IsArray)
+            {
+                arrayType = new FieldData(seqType.GetElementType(), attribs);
+                dataType = DataType.Array;
+                return true;
+            }
+
+            if (seqType.IsGenericType)
+            {
+                Type[] args = seqType.GetGenericArguments();
+                if (args != null && args.Length > 0)
+                {
+                    int iC = args.Length;
+                    for (int i = 0; i < iC; ++i)
+                    {
+                        Type ienum = typeof(IEnumerable<>).MakeGenericType(args[i]);
+                        if (ienum.IsAssignableFrom(seqType))
+                        {
+                            arrayType = new FieldData(args[i], attribs);
+                            dataType = DataType.IList;
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            Type[] ifaces = seqType.GetInterfaces();
+            if (ifaces != null && ifaces.Length > 0)
+            {
+                int iC = ifaces.Length;
+                for (int i = 0; i < iC; ++i)
+                {
+                    Type ienum = FindIEnumerable(ifaces[i]);
+                    if (ienum != null)
+                    {
+                        arrayType = new FieldData(ienum, attribs);
+                        dataType = DataType.IList;
+                        return true;
+                    }
+                }
+            }
+            if (seqType.BaseType != null && seqType.BaseType != typeof(object))
+            {
+                return FindSetArrayType(seqType.BaseType);
+            }
+
+            return false;
+        }
+    }
+
+    public class TypeCache
+    {
+        private static readonly Dictionary<Type, TypeCache> cache = new Dictionary<Type, TypeCache>();
+
+        private List<FieldData> _fields = new List<FieldData>();
+        private Dictionary<string, FieldData> _nameToField = new Dictionary<string, FieldData>();
+        private Dictionary<string, int> _seenFieldCounts = new Dictionary<string, int>();
+
+        private bool _isPersistentLinkable;
+
+        public TypeCache(Type t)
+        {
+            _isPersistentLinkable = HasAttribute(t, typeof(PersistentLinkable));
+
+            MemberInfo[] members = t.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy);
+            for (int i = 0, iC = members.Length; i < iC; ++i)
+            {
+                var attribs = (Persistent[])members[i].GetCustomAttributes(typeof(Persistent), inherit: true);
+                if (attribs.Length == 0)
+                    continue;
+
+                var data = new FieldData(members[i], attribs);
+                if (data.dataType != DataType.INVALID)
+                {
+                    _fields.Add(data);
+                    foreach (var s in data.persistentNames)
+                        _nameToField[s] = data;
+                }
+            }
+        }
+
+        private int SeenFieldIndex(string fieldName)
+        {
+            // We need to track how many times we've seen this field name
+            // because fields can have >1 Persistent attribute and we
+            // need to index.
+            _seenFieldCounts.TryGetValue(fieldName, out int numSeen);
+            _seenFieldCounts[fieldName] = numSeen + 1;
+            return numSeen;
+        }
+
+        public bool Read(object host, ConfigNode node)
+        {
+            if (_isPersistentLinkable)
+            {
+                string linkUID = node.GetValue("link_uid");
+                int linkID = -1;
+                if (linkUID != null)
+                    linkID = int.Parse(linkUID);
+
+                readLinks.AssignLinkable(linkID, host);
+            }
+
+            bool allSucceeded = true;
+            int count = node.values.Count;
+            for (int i = 0; i < count; ++i)
+            {
+                Value value = node.values[i];
+                if (!_nameToField.TryGetValue(value.name, out FieldData fieldItem))
+                    continue;
+
+                int index = SeenFieldIndex(value.name);
+                // Leaving this check commented since the stock code
+                // handles this dumbly too.
+                //if (value.name != fieldItem.persistentNames[index])
+                //    Debug.LogError($"[KSPCommunityFixes] ConfigNode.ReadObject: seeing value {value.name} for time {index} but expected name for field {fieldItem.field.Name} is {fieldItem.persistentNames[index]");
+
+                allSucceeded &= fieldItem.Read(value, host, index);
+            }
+            count = node.nodes.Count;
+            for (int j = 0; j < count; j++)
+            {
+                ConfigNode subNode = node.nodes[j];
+                if (!_nameToField.TryGetValue(subNode.name, out FieldData fieldItem))
+                    continue;
+
+                allSucceeded &= fieldItem.Read(subNode, host, SeenFieldIndex(subNode.name));
+            }
+            _seenFieldCounts.Clear();
+            return allSucceeded;
+        }
+
+        public bool Write(object obj, ConfigNode node, int pass)
+        {
+            if (_isPersistentLinkable)
+            {
+                node.AddValue("link_uid", writeLinks.AssignTarget(obj));
+            }
+
+            int num = _fields.Count;
+            bool allSucceeded = true;
+            for (int i = 0; i < num; i++)
+            {
+                FieldData fieldData = _fields[i];
+                
+                object value = fieldData.fieldInfo.GetValue(obj);
+                if (value == null)
+                {
+                    continue;
+                }
+
+                int persistentCount = fieldData.attribs.Length;
+                for (int j = 0; j < persistentCount; j++)
+                {
+                    Persistent persistent = fieldData.attribs[j];
+                    if (!persistent.isPersistant || (pass != 0 && persistent.pass != 0 && (persistent.pass & pass) == 0))
+                    {
+                        continue;
+                    }   
+                    
+                    string fieldName = fieldData.persistentNames[j];
+                    if (persistent.link)
+                    {
+                        if (!fieldData.isLinkable)
+                        {
+                            Debug.LogWarning("Field: '" + fieldData.fieldInfo.Name + "' does not reference a PersistentLinkable type");
+                        }
+                        else
+                        {
+                            allSucceeded &= FieldData.WriteValue(fieldName, writeLinks.AssignLink(value), DataType.ValueInt, node);
+                        }
+                        continue;
+                    }
+                    allSucceeded &= fieldData.Write(fieldName, value, node, j, pass);
+                }
+            }
+            return allSucceeded;
+        }
+
+        public static TypeCache GetOrCreate(Type t)
+        {
+            if (cache.TryGetValue(t, out var tc))
+                return tc;
+
+            return CreateAndAdd(t);
+        }
+
+        public static TypeCache CreateAndAdd(Type t)
+        {
+            var tc = new TypeCache(t);
+            if (tc._fields.Count == 0)
+                return null;
+
+            cache[t] = tc;
+            return tc;
+        }
+    }
+
+#if DEBUG_PERSISTENTICONFIGNODE
 
     public class PersistentIConfigNodeTestModule : PartModule
     {

--- a/KSPCommunityFixes/Performance/ConfigNodePerf.cs
+++ b/KSPCommunityFixes/Performance/ConfigNodePerf.cs
@@ -257,7 +257,7 @@ namespace KSPCommunityFixes.Performance
             }
             catch (Exception e)
             {
-                Debug.LogError("[KSPCommunityFixes] ConfigNodePerf: Exception reading file, using fallback ConfigNode reader. Exception: " + e);
+                Debug.LogError($"[KSPCommunityFixes] ConfigNodePerf: Exception reading file {fileFullName}, using fallback ConfigNode reader. Exception: " + e);
                 __result = LoadFromStringArray(File.ReadAllLines(fileFullName), true);
             }
             bool hasData = __result._nodes.nodes.Count > 0 || __result._values.values.Count > 0;
@@ -393,11 +393,17 @@ namespace KSPCommunityFixes.Performance
 #endif
             if (sanitizeName)
             {
+                if (__instance.name == null)
+                    return false;
+
+                int len = __instance.name.Length;
+                if (len == 0)
+                    return false;
+                
+                string result = null;
+                bool sanitize = false;
                 fixed (char* pszSanitize = __instance.name)
                 {
-                    // It's cheaper to just do this than to do a skipcheck.
-                    int len = __instance.name.Length;
-                    bool sanitize = false;
                     for (int i = 0; i < len; ++i)
                     {
                         switch (pszSanitize[i])
@@ -411,8 +417,8 @@ namespace KSPCommunityFixes.Performance
                     }
                     if (sanitize)
                     {
-                        __instance.name = new string(' ', len);
-                        fixed (char* pszNewStr = __instance.name)
+                        result = new string(' ', len);
+                        fixed (char* pszNewStr = result)
                         {
                             for (int i = 0; i < len; ++i)
                             {
@@ -428,13 +434,22 @@ namespace KSPCommunityFixes.Performance
                         }
                     }
                 }
+                if (sanitize)
+                    __instance.name = result;
             }
             else if (_doClean)
             {
+                if (__instance.value == null)
+                    return false;
+
+                int len = __instance.value.Length;
+                if (len == 0)
+                    return false;
+
+                string result = null;
+                bool sanitize = false;
                 fixed (char* pszSanitize = __instance.value)
-                {
-                    int len = __instance.name.Length;
-                    bool sanitize = false;
+                {    
                     for (int i = 0; i < len; ++i)
                     {
                         switch (pszSanitize[i])
@@ -447,8 +462,8 @@ namespace KSPCommunityFixes.Performance
                     }
                     if (sanitize)
                     {
-                        __instance.value = new string(' ', len);
-                        fixed (char* pszNewStr = __instance.value)
+                        result = new string(' ', len);
+                        fixed (char* pszNewStr = result)
                         {
                             for (int i = 0; i < len; ++i)
                             {
@@ -463,6 +478,8 @@ namespace KSPCommunityFixes.Performance
                         }
                     }
                 }
+                if (sanitize)
+                    __instance.value = result;
             }
             return false;
         }

--- a/KSPCommunityFixes/Performance/ConfigNodePerf.cs
+++ b/KSPCommunityFixes/Performance/ConfigNodePerf.cs
@@ -699,7 +699,7 @@ namespace KSPCommunityFixes.Performance
 #endif
             char[] chars = null;
             int numChars = 0;
-            using (var reader = new StreamReader(path, _UTF8NoBOM, true, 1024 * 1024))
+            using (var reader = new StreamReader(path, Encoding.UTF8, true, 1024 * 1024))
             {
                 FileInfo fi = new FileInfo(path);
                 if (fi.Length > int.MaxValue)

--- a/KSPCommunityFixes/Properties/AssemblyInfo.cs
+++ b/KSPCommunityFixes/Properties/AssemblyInfo.cs
@@ -31,3 +31,5 @@ using System.Runtime.InteropServices;
 //
 [assembly: AssemblyVersion("1.22.0.0")]
 [assembly: AssemblyFileVersion("1.22.0.0")]
+
+[assembly: KSPAssembly("KSPCommunityFixes", 1, 22, 0)]

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ If doing so in the `Debug` configuration and if your KSP install is modified to 
 
 ##### 1.22.0
 - New modding patch : [ModUpgradePipeline](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/91) (@NathanKell)
-Further improve ConfigNode performance. The tunable settings blocks have been removed since base performance is high enough now. (@NathanKell)
+- Further improve ConfigNode performance. The tunable settings blocks have been removed since base performance is high enough now. They've been replaced by a single setting that enables not indenting save games and craft files on save, which offers a slight performance boost reading and writing and a fair amount of savings on disk. (@NathanKell)
 
 ##### 1.21.0
 - New performance / KSP bugfix patch : [PQSCoroutineLeak](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/85) (issue discovered by @Gameslinx)

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ If doing so in the `Debug` configuration and if your KSP install is modified to 
 
 ##### 1.22.0
 - New modding patch : [ModUpgradePipeline](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/91) (@NathanKell)
-- Further improve ConfigNode performance (@NathanKell)
+Further improve ConfigNode performance. The tunable settings blocks have been removed since base performance is high enough now. (@NathanKell)
 
 ##### 1.21.0
 - New performance / KSP bugfix patch : [PQSCoroutineLeak](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/85) (issue discovered by @Gameslinx)

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ User options are available from the "ESC" in-game settings menu :<br/><img src="
 - [**CommNetThrottling**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/56) [KSP 1.12.0 - 1.12.3]<br/>Disabled by default, you can enable it with a MM patch. Prevent full CommNet network updates from happening every frame, but instead to happen at a regular real-world time interval of 5 seconds while in flight. Enabling this can provide a decent performance uplift in games having an large amount of celestial bodies and/or vessels, but has a detrimental impact on the precision of the simulation and can potentially cause issues with mods relying on the stock behavior.
 - [**AsteroidAndCometDrillCache**](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/67) [KSP 1.12.3]<br/>Reduce constant overhead of ModuleAsteroidDrill and ModuleCometDrill by using the cached asteroid/comet part lookup results from ModuleResourceHarvester. Improves performance with large part count vessels having at least one drill part.
 - [**FewerSaves**](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/80) [KSP 1.8.0 - KSP 1.12.3]<br/>Disables saving on exiting Space Center minor buildings (Mission Control etc) and when deleting vessels in Tracking Station. Disabled by default.
-- [**ConfigNodePerf**](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/88) [KSP 1.8.0 - KSP 1.12.3]<br/>Speeds up loading and saving of ConfigNodes, allows skipping processing on certain known-good keys (like Principia's serialized data).
+- [**ConfigNodePerf**](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/88) [see also](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/90) [KSP 1.8.0 - KSP 1.12.3]<br/>Speeds up many ConfigNode methods, especially reading and writing ConfigNodes.
 
 #### API and modding tools
 - **MultipleModuleInPartAPI** [KSP 1.8.0 - 1.12.3]<br/>This API allow other plugins to implement PartModules that can exist in multiple occurrence in a single part and won't suffer "module indexing mismatch" persistent data losses following part configuration changes. [See documentation on the wiki](https://github.com/KSPModdingLibs/KSPCommunityFixes/wiki/MultipleModuleInPartAPI).
@@ -155,7 +155,8 @@ If doing so in the `Debug` configuration and if your KSP install is modified to 
 
 ##### 1.22.0
 - New modding patch : [ModUpgradePipeline](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/91) (@NathanKell)
-- Further improve ConfigNode performance. The tunable settings blocks have been removed since base performance is high enough now. They've been replaced by a single setting that enables not indenting save games and craft files on save, which offers a slight performance boost reading and writing and a fair amount of savings on disk. (@NathanKell)
+- Further improve ConfigNode performance. The tunable settings blocks have been removed since base performance is high enough now. They've been replaced by a single setting that enables not indenting save games and craft files on save, which offers a slight performance boost reading and writing and a fair amount of savings on disk. See https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/90 for full details (@NathanKell)
+- Add a KSPAssembly attribute to the dll.
 
 ##### 1.21.0
 - New performance / KSP bugfix patch : [PQSCoroutineLeak](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/85) (issue discovered by @Gameslinx)


### PR DESCRIPTION
* Complete parser rewrite (again) entirely eliminating recursion. This makes the previous 'skip' methodology unnecessary since the speedup is sufficient.
* Also overrides other string-based methods in ConfigNode like the sanitize/clean methods and ToString.
* sfs and craft files skip some sanity checking on node and value strings.
* Rewrite reading and writing objects via Persistent attributes
* Allow skipping writing indents when saving ConfigNodes
* Add KSPAssembly attribute so other mods can bind (and use the rewritten ConfigNode read/write stuff, i.e. TypeCache).