### PR TITLE
Fix MapSOCorrectWrapping removing stock MoHole

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -154,6 +154,10 @@ KSP_COMMUNITY_FIXES
   // Avoids big spikes on the poles and incorrect biomes where the oles have disparate biomes.
   MapSOCorrectWrapping = true
 
+  // Fix biome and heightmap texture wrapping from pole to pole, even on Moho
+  // This may wipe out the Mohole which is based on said bug.
+  MapSOCorrectWrappingPlusMoho = false
+
   // Fix spread angle still being applied after decoupling symmetry-placed parachutes.
   ChutePhantomSymmetry = true
 

--- a/KSPCommunityFixes/BugFixes/MapSOCorrectWrapping.cs
+++ b/KSPCommunityFixes/BugFixes/MapSOCorrectWrapping.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using HarmonyLib;
 using UnityEngine;
@@ -26,6 +26,14 @@ namespace KSPCommunityFixes
 
         static bool MapSO_ConstructBilinearCoords_Float(MapSO __instance, float x, float y)
         {
+            try //in case FlightGlobals.currentMainBody is null or something
+            {
+                if (FlightGlobals.currentMainBody.name.Equals("Moho") && FlightGlobals.currentMainBody.displayName.Equals("Moho"))
+                {
+                    return true;
+                }
+            }
+            catch { }
             // X wraps around as it is longitude.
             x = Mathf.Abs(x - Mathf.Floor(x));
             __instance.centerX = x * __instance._width;
@@ -49,6 +57,14 @@ namespace KSPCommunityFixes
 
         static bool MapSO_ConstructBilinearCoords_Double(MapSO __instance, double x, double y)
         {
+            try //in case FlightGlobals.currentMainBody is null or something
+            {
+                if (FlightGlobals.currentMainBody.name.Equals("Moho") && FlightGlobals.currentMainBody.displayName.Equals("Moho"))
+                {
+                    return true;
+                }
+            }
+            catch { }
             // X wraps around as it is longitude.
             x = Math.Abs(x - Math.Floor(x));
             __instance.centerXD = x * __instance._width;

--- a/KSPCommunityFixes/BugFixes/MapSOCorrectWrapping.cs
+++ b/KSPCommunityFixes/BugFixes/MapSOCorrectWrapping.cs
@@ -28,7 +28,7 @@ namespace KSPCommunityFixes
         {
             try //in case FlightGlobals.currentMainBody is null or something
             {
-                if (FlightGlobals.currentMainBody.name.Equals("Moho") && FlightGlobals.currentMainBody.displayName.Equals("Moho"))
+                if (FlightGlobals.currentMainBody.name.Equals("Moho") && FlightGlobals.currentMainBody.displayName.Equals("Moho") && (!KSPCommunityFixes.SettingsNode.GetValue("MapSOCorrectWrappingPlusMoho").ToLower().Equals("true")))
                 {
                     return true;
                 }
@@ -59,7 +59,7 @@ namespace KSPCommunityFixes
         {
             try //in case FlightGlobals.currentMainBody is null or something
             {
-                if (FlightGlobals.currentMainBody.name.Equals("Moho") && FlightGlobals.currentMainBody.displayName.Equals("Moho"))
+                if (FlightGlobals.currentMainBody.name.Equals("Moho") && FlightGlobals.currentMainBody.displayName.Equals("Moho") && (!KSPCommunityFixes.SettingsNode.GetValue("MapSOCorrectWrappingPlusMoho").ToLower().Equals("true")))
                 {
                     return true;
                 }


### PR DESCRIPTION
Just blacklists the fix from a body named Moho.  Thought it might be handy.