### PR TITLE
New patch : fix the SAS inconsistency when kerbal XP is off

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -168,6 +168,10 @@ KSP_COMMUNITY_FIXES
   // ladder is retracted, and implements manual control of the light.
   LadderToggleableLight = true
 
+  // Fix for "Why can Bill SAS?" and other SAS inconsistencies in science/sandbox modes
+  // false by default to prevent disorientation or regression in the gameplay
+  NoExperienceSASFix = false
+
   // ##########################
   // Obsolete bugfixes
   // ##########################

--- a/KSPCommunityFixes/BugFixes/NoExperienceSASFix.cs
+++ b/KSPCommunityFixes/BugFixes/NoExperienceSASFix.cs
@@ -1,0 +1,78 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+
+namespace KSPCommunityFixes.BugFixes
+{
+    public class NoExperienceSASFix : BasePatch
+    {
+        protected override Version VersionMin => new Version(1, 11, 1);
+
+        protected override void ApplyPatches(List<PatchInfo> patches)
+        {
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(APSkillExtensions), nameof(APSkillExtensions.AvailableAtLevel), new Type[] { typeof(VesselAutopilot.AutopilotMode), typeof(Vessel)}),
+                this));
+        }
+
+        private static bool APSkillExtensions_AvailableAtLevel_Prefix(VesselAutopilot.AutopilotMode mode, Vessel vessel, ref bool __result)
+        {
+            // Fixes the SAS inconsistency when the Kerbal experience setting is off (default in science and sandbox mode)
+            // More info : https://wiki.kerbalspaceprogram.com/wiki/Specialization#No_experience_specialization_override
+            // Therefore
+            // - Only pilots can SAS
+            // - Probe's SAS level is compared with the pilot's to see which is the best
+            // - Manages the "Probes can fully SAS" in the difficulty settings
+            // Doesn't fix the parachute repack and part repair which can be roleplayed easily
+
+            //Debug.Log("AutopilotKerbal = " + vessel.VesselValues.AutopilotKerbalSkill.value);
+            //Debug.Log("AutopilotSASSKill = " + vessel.VesselValues.AutopilotSASSkill.value);
+
+            int pilotSkill = vessel.VesselValues.AutopilotKerbalSkill.value;
+            int probeSkill = vessel.VesselValues.AutopilotSASSkill.value;
+            
+            // that's the name of the setting, but we'll use it for every non-mission mode
+            bool fullSASInSandbox = HighLogic.CurrentGame.Parameters.CustomParams<GameParameters.AdvancedParams>().EnableFullSASInSandbox;
+            // mission mode, don't know where to set it (except directly in the savefile) and ESA stock missions don't have this setting
+            bool fullSASInMissions = HighLogic.CurrentGame.Parameters.CustomParams<GameParameters.AdvancedParams>().EnableFullSASInMissions;
+
+            // checks if a probe is available on the ship
+            // we can't rely on the ModuleSAS because the Stayputnik doesn't have that
+            bool hasProbe = false;
+            for(int i = 0; i < vessel.Parts.Count; i++)
+            {
+                var myPart = vessel.Parts[i];
+                for(int j = 0; j < myPart.Modules.Count; j++)
+                {
+                    var myModule = myPart.Modules[j];
+                    // a command module which doesn't require a kerbal, which is a probe
+                    if (myModule.GetType() == typeof(ModuleCommand) && ((ModuleCommand)myModule).minimumCrew == 0)
+                    {
+                        hasProbe = true;
+                        break;
+                    }
+                }
+                if (hasProbe)
+                {
+                    break;
+                }
+            }
+            
+            // probes can fully SAS in sandbox setting (applied to all game modes except mission)
+            if (fullSASInSandbox && HighLogic.CurrentGame.Mode != Game.Modes.MISSION && hasProbe)
+            {
+                probeSkill = 3;
+            }
+            // probes can fully SAS in missions
+            if (fullSASInMissions && HighLogic.CurrentGame.Mode == Game.Modes.MISSION && hasProbe)
+            {
+                probeSkill = 3;
+            }
+
+            __result = Math.Max(pilotSkill, probeSkill) >= mode.GetRequiredSkill();
+
+            return false;
+        }
+    }
+}

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -104,6 +104,7 @@
     <Compile Include="BugFixes\CorrectDragForFlags.cs" />
     <Compile Include="BugFixes\LadderToggleableLight.cs" />
     <Compile Include="BugFixes\MapSOCorrectWrapping.cs" />
+    <Compile Include="BugFixes\NoExperienceSASFix.cs" />
     <Compile Include="BugFixes\UpgradeBugs.cs" />
     <Compile Include="BugFixes\PartTooltipUpgradesApplyToSubstituteParts.cs" />
     <Compile Include="BugFixes\CometMiningNotRemovingMass.cs" />


### PR DESCRIPTION
Hello,

Here's a patch to fix the inconsistent SAS locks between game modes, probes and kerbals. It just puts back SAS as a default career behavior for any game mode and wether the Enable Kerbal experience setting is on or off.

[More info](https://wiki.kerbalspaceprogram.com/wiki/Specialization#No_experience_specialization_override) and [6-year old bug report](https://bugs.kerbalspaceprogram.com/issues/10845). In short scientists and engineers can fully SAS when the Enable Kerbal experience is off when starting a save.  According to the ingame KSPedia only pilots (and probes) can SAS and there is no specific way to fine tune this trait in the game. Career players need to add probes (the lightest is the Okto2 which weights 40kg and doesn't have maneuver lock).

Parachutes and part repair have the same problem but these can easily be roleplayed and don't require to check and compare everytime the probes and pilots that are on the ship, so they are not covered by this patch.

I think it's better to leave it deactivated by default to prevent a strict gameplay change for players used to it. Everyone sends Bob on missions because he can SAS, repack parachutes and restore science. 

The minimum version is 1.11.1 because I started working on this fix when [SAS was completely broken for several months](https://bugs.kerbalspaceprogram.com/issues/27162), but it should work on previous versions.

Smoke test : 
* Activate the patch
* Start a new sandbox save
* Put Bill in a Mk1 pod
* Try to SAS => Bill cannot SAS because he's an engineer

Quick Note: a mod called [BetterSpecializationSettings](https://forum.kerbalspaceprogram.com/index.php?/topic/183776-17x-~-13x-better-specialization-settings-v004-2019-05-22/) exists which addresses this problem but goes further on overriding settings like a special setting for all kerbals to SAS or level repair override for engineers, doesn't manage the new 1.11 repair system and  looks [unmaintained](https://forum.kerbalspaceprogram.com/index.php?/topic/183776-17x-~-13x-better-specialization-settings-v004-2019-05-22/&do=findComment&comment=3995214) (works until 1.7) .

Thanks!
