### PR TITLE
FastBiomeQuery

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -154,7 +154,7 @@ KSP_COMMUNITY_FIXES
   // Avoids big spikes on the poles and incorrect biomes where the oles have disparate biomes.
   MapSOCorrectWrapping = true
   // The Mohole is a result of the bug the MapSOCorrectWrapping patch is fixing. If set to
-  // true, the patch won't apply to the stock Moho height/biome maps
+  // true, the patch won't apply to the stock Moho height map
   MapSOCorrectWrappingIgnoreMoho = true
 
   // Fix spread angle still being applied after decoupling symmetry-placed parachutes.

--- a/KSPCommunityFixes/BugFixes/MapSOCorrectWrapping.cs
+++ b/KSPCommunityFixes/BugFixes/MapSOCorrectWrapping.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using UnityEngine;
 
 namespace KSPCommunityFixes
@@ -26,8 +27,8 @@ namespace KSPCommunityFixes
             // see https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/121
             // The patched ConstructBilinearCoords() methods will have the side effect of removing the Mohole because Squad
             // choose that "this is not a bug, it's a feature".
-            // To prevent it, we acquire references to the Moho MapSO instances (biome map and height map) and fall back
-            // to the original stock implementation if the method is called on those instances.
+            // To prevent it, we acquire references to the Moho MapSO heightmap instance and fall back to the original stock
+            // implementation if the method is called on those instances.
             // Note that all stock bodies will actually get a significantly different terrain at the poles due to this patch,
             // but due to how performance sensitive those method are, checking all stock MapSO instances (there are 40 of them)
             // isn't really an option.
@@ -46,8 +47,9 @@ namespace KSPCommunityFixes
             }
         }
 
-        private static MapSO moho_biomes;
         private static MapSO moho_height;
+        private static readonly double lessThanOneDouble = StaticHelpers.BitDecrement(1.0);
+        private static readonly float lessThanOneFloat = StaticHelpers.BitDecrement(1f);
 
         static void PSystemSetup_Awake_Postfix(PSystemSetup __instance)
         {
@@ -58,15 +60,7 @@ namespace KSPCommunityFixes
 
             foreach (MapSO mapSo in so)
             {
-                if (mapSo.MapName == "moho_biomes"
-                    && mapSo.Size == 6291456
-                    && mapSo._data[0] == 216
-                    && mapSo._data[1] == 178
-                    && mapSo._data[2] == 144)
-                {
-                    moho_biomes = mapSo;
-                }
-                else if (mapSo.MapName == "moho_height"
+                if (mapSo.MapName == "moho_height"
                          && mapSo.Size == 2097152
                          && mapSo._data[1509101] == 146
                          && mapSo._data[1709108] == 162
@@ -79,54 +73,70 @@ namespace KSPCommunityFixes
 
         static bool MapSO_ConstructBilinearCoords_Float(MapSO __instance, float x, float y)
         {
-            if (ReferenceEquals(__instance, moho_biomes) || ReferenceEquals(__instance, moho_height))
-                return true;
-
             // X wraps around as it is longitude.
             x = Mathf.Abs(x - Mathf.Floor(x));
+
             __instance.centerX = x * __instance._width;
-            __instance.minX = Mathf.FloorToInt(__instance.centerX);
-            __instance.maxX = Mathf.CeilToInt(__instance.centerX);
+            __instance.minX = (int)__instance.centerX;
+            __instance.maxX = __instance.minX + 1;
             __instance.midX = __instance.centerX - __instance.minX;
             if (__instance.maxX == __instance._width)
                 __instance.maxX = 0;
 
             // Y clamps as it is latitude and the poles don't wrap to each other.
-            y = Mathf.Clamp(y, 0, 0.99999f);
-            __instance.centerY = y * __instance._height;
-            __instance.minY = Mathf.FloorToInt(__instance.centerY);
-            __instance.maxY = Mathf.CeilToInt(__instance.centerY);
-            __instance.midY = __instance.centerY - __instance.minY;
-            if (__instance.maxY >= __instance._height)
-                __instance.maxY = __instance._height - 1;
+            if (y >= 1f) 
+                y = lessThanOneFloat;
+            else if (y < 0f) 
+                y = 0f;
 
+            __instance.centerY = y * __instance._height;
+            __instance.minY = (int)__instance.centerY;
+            __instance.maxY = __instance.minY + 1;
+            __instance.midY = __instance.centerY - __instance.minY;
+            if (__instance.maxY == __instance._height)
+            {
+                if (ReferenceEquals(__instance, moho_height))
+                    __instance.maxY = 0; // use incorrect wrapping for moho
+                else
+                    __instance.maxY = __instance._height - 1;
+            }
+            
             return false;
         }
 
         static bool MapSO_ConstructBilinearCoords_Double(MapSO __instance, double x, double y)
         {
-            if (ReferenceEquals(__instance, moho_biomes) || ReferenceEquals(__instance, moho_height))
-                return true;
-
             // X wraps around as it is longitude.
             x = Math.Abs(x - Math.Floor(x));
+
             __instance.centerXD = x * __instance._width;
-            __instance.minX = (int)Math.Floor(__instance.centerXD);
-            __instance.maxX = (int)Math.Ceiling(__instance.centerXD);
+            __instance.minX = (int)__instance.centerXD;
+            __instance.maxX = __instance.minX + 1;
             __instance.midX = (float)__instance.centerXD - __instance.minX;
             if (__instance.maxX == __instance._width)
                 __instance.maxX = 0;
 
             // Y clamps as it is latitude and the poles don't wrap to each other.
-            y = Math.Min(Math.Max(y, 0), 0.99999);
+            if (y >= 1.0) 
+                y = lessThanOneDouble;
+            else if (y < 0.0) 
+                y = 0.0;
+
             __instance.centerYD = y * __instance._height;
-            __instance.minY = (int)Math.Floor(__instance.centerYD);
-            __instance.maxY = (int)Math.Ceiling(__instance.centerYD);
+            __instance.minY = (int)__instance.centerYD;
+            __instance.maxY = __instance.minY + 1;
             __instance.midY = (float)__instance.centerYD - __instance.minY;
-            if (__instance.maxY >= __instance._height)
-                __instance.maxY = __instance._height - 1;
+            if (__instance.maxY == __instance._height)
+            {
+                if (ReferenceEquals(__instance, moho_height))
+                    __instance.maxY = 0; // use incorrect wrapping for moho
+                else
+                    __instance.maxY = __instance._height - 1;
+            }
 
             return false;
         }
+
+
     }
 }

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Performance\DisableHiddenPortraits.cs" />
     <Compile Include="Performance\DisableMapUpdateInFlight.cs" />
     <Compile Include="Performance\DragCubeGeneration.cs" />
+    <Compile Include="Performance\FastBiomeQuery.cs" />
     <Compile Include="Performance\FastLoader.cs" />
     <Compile Include="Performance\LocalizerPerf.cs" />
     <Compile Include="Performance\MemoryLeaks.cs" />

--- a/KSPCommunityFixes/Library/StaticHelpers.cs
+++ b/KSPCommunityFixes/Library/StaticHelpers.cs
@@ -1,4 +1,7 @@
-﻿namespace KSPCommunityFixes
+﻿using System.Runtime.CompilerServices;
+using System;
+
+namespace KSPCommunityFixes
 {
     static class StaticHelpers
     {
@@ -37,6 +40,80 @@
             readable /= 1024.0;
             // Return formatted number with suffix
             return readable.ToString("0.### ") + suffix;
+        }
+
+        // https://github.com/dotnet/runtime/blob/af4efb1936b407ca5f4576e81484cf5687b79a26/src/libraries/System.Private.CoreLib/src/System/Math.cs#L210
+        public static double BitDecrement(double x)
+        {
+            long bits = BitConverter.DoubleToInt64Bits(x);
+
+            if (((bits >> 32) & 0x7FF00000) >= 0x7FF00000)
+            {
+                // NaN returns NaN
+                // -Infinity returns -Infinity
+                // +Infinity returns double.MaxValue
+                return (bits == 0x7FF00000_00000000) ? double.MaxValue : x;
+            }
+
+            if (bits == 0x00000000_00000000)
+            {
+                // +0.0 returns -double.Epsilon
+                return -double.Epsilon;
+            }
+
+            // Negative values need to be incremented
+            // Positive values need to be decremented
+
+            bits += ((bits < 0) ? +1 : -1);
+            return BitConverter.Int64BitsToDouble(bits);
+        }
+
+        // https://github.com/dotnet/runtime/blob/af4efb1936b407ca5f4576e81484cf5687b79a26/src/libraries/System.Private.CoreLib/src/System/MathF.cs#L52
+        public static float BitDecrement(float x)
+        {
+            int bits = SingleToInt32Bits(x);
+
+            if ((bits & 0x7F800000) >= 0x7F800000)
+            {
+                // NaN returns NaN
+                // -Infinity returns -Infinity
+                // +Infinity returns float.MaxValue
+                return (bits == 0x7F800000) ? float.MaxValue : x;
+            }
+
+            if (bits == 0x00000000)
+            {
+                // +0.0 returns -float.Epsilon
+                return -float.Epsilon;
+            }
+
+            // Negative values need to be incremented
+            // Positive values need to be decremented
+
+            bits += ((bits < 0) ? +1 : -1);
+            return Int32BitsToSingle(bits);
+        }
+
+        /// <summary>
+        /// Converts the specified single-precision floating point number to a 32-bit signed integer.
+        /// </summary>
+        /// <param name="value">The number to convert.</param>
+        /// <returns>A 32-bit signed integer whose bits are identical to <paramref name="value"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe int SingleToInt32Bits(float value)
+        {
+            return *((int*)&value);
+        }
+
+        /// <summary>
+        /// Converts the specified 32-bit signed integer to a single-precision floating point number.
+        /// </summary>
+        /// <param name="value">The number to convert.</param>
+        /// <returns>A single-precision floating point number whose bits are identical to <paramref name="value"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe float Int32BitsToSingle(int value)
+        {
+            return *((float*)&value);
         }
     }
 }

--- a/KSPCommunityFixes/Library/StaticHelpers.cs
+++ b/KSPCommunityFixes/Library/StaticHelpers.cs
@@ -42,7 +42,12 @@ namespace KSPCommunityFixes
             return readable.ToString("0.### ") + suffix;
         }
 
-        // https://github.com/dotnet/runtime/blob/af4efb1936b407ca5f4576e81484cf5687b79a26/src/libraries/System.Private.CoreLib/src/System/Math.cs#L210
+        /// <summary>
+        /// Returns the largest value that compares less than a specified value.
+        /// </summary>
+        /// <param name="x">The value to decrement.</param>
+        /// <returns>The largest value that compares less than x, or NegativeInfinity if x equals NegativeInfinity, or NaN if x equals NaN.</returns>
+        /// // https://github.com/dotnet/runtime/blob/af4efb1936b407ca5f4576e81484cf5687b79a26/src/libraries/System.Private.CoreLib/src/System/Math.cs#L210
         public static double BitDecrement(double x)
         {
             long bits = BitConverter.DoubleToInt64Bits(x);

--- a/KSPCommunityFixes/Performance/FastBiomeQuery.cs
+++ b/KSPCommunityFixes/Performance/FastBiomeQuery.cs
@@ -1,0 +1,523 @@
+﻿using Smooth.Algebraics;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Text;
+using System.Threading.Tasks;
+using Steamworks;
+using UnityEngine;
+using VehiclePhysics;
+using Debug = UnityEngine.Debug;
+using Random = UnityEngine.Random;
+
+namespace KSPCommunityFixes.Performance
+{
+    [KSPAddon(KSPAddon.Startup.MainMenu, false)]
+    internal class BiomeMapOptimizer : MonoBehaviour
+    {
+        const float Byte2Float = 0.003921569f;
+
+        public static byte[][] biomeMaps;
+
+        void Start()
+        {
+            biomeMaps = new byte[FlightGlobals.Bodies.Count][];
+
+            foreach (CelestialBody body in FlightGlobals.Bodies)
+            {
+                if (body.BiomeMap != null)
+                {
+                    byte[] newMap = Optimize(body.BiomeMap);
+                    biomeMaps[body.flightGlobalsIndex] = newMap;
+                }
+            }
+        }
+
+        void Update()
+        {
+
+        }
+
+        private byte[] Optimize(CBAttributeMapSO biomeMap)
+        {
+            int biomeCount = biomeMap.Attributes.Length;
+            Color[] biomeColors = new Color[biomeCount];
+            for (int i = 0; i < biomeCount; i++)
+            {
+                biomeColors[i] = biomeMap.Attributes[i].mapColor;
+            }
+
+            byte[] oldMap = biomeMap._data;
+            int bpp = biomeMap._bpp;
+
+            byte[] newMap = new byte[biomeMap._height * biomeMap._width];
+
+            for (int i = 0; i < newMap.Length; i++)
+            {
+                int colorIndex = i * bpp;
+                float r = oldMap[colorIndex] * Byte2Float;
+                float g = oldMap[colorIndex + 1] * Byte2Float;
+                float b = oldMap[colorIndex + 2] * Byte2Float;
+
+                int biomeIndex = TryGetExactBiomeColorIndex(r, g, b, biomeColors);
+                if (biomeIndex > -1)
+                {
+                    newMap[i] = (byte)biomeIndex;
+                    continue;
+                }
+
+                biomeIndex = TryGetNearBiomeColorIndex(r, g, b, biomeMap.neighborColorThresh, biomeColors);
+                if (biomeIndex > -1)
+                {
+                    newMap[i] = (byte)biomeIndex;
+                    continue;
+                }
+
+                biomeIndex = GetBestNeighborBiomeColorIndex(r, g, b, i, biomeMap, biomeColors);
+                newMap[i] = (byte)biomeIndex;
+            }
+
+            return newMap;
+        }
+
+        private int TryGetExactBiomeColorIndex(float r, float g, float b, Color[] biomeColors)
+        {
+            for (int i = 0; i < biomeColors.Length; i++)
+            {
+                Color biomeColor = biomeColors[i];
+                if (biomeColor.r == r && biomeColor.g == g && biomeColor.b == b)
+                    return i;
+            }
+
+            return -1;
+        }
+
+        private static int TryGetNearBiomeColorIndex(float r, float g, float b, float threshold, Color[] biomeColors)
+        {
+            int bestIndex = -1;
+            float bestColorDiff = float.MaxValue;
+
+            for (int i = 0; i < biomeColors.Length; i++)
+            {
+                Color biomeColor = biomeColors[i];
+                float colorDiff = EuclideanColorDiff(r, g, b, biomeColor.r, biomeColor.g, biomeColor.b);
+                if (colorDiff < threshold && colorDiff < bestColorDiff)
+                {
+                    bestColorDiff = colorDiff;
+                    bestIndex = i;
+                }
+            }
+
+            return bestIndex;
+        }
+
+        private static int[] neighborIndices = new int[9];
+        private static List<Color> colorBuffer = new List<Color>(9);
+
+        private static int GetBestNeighborBiomeColorIndex(float r, float g, float b, int pixelIndex, CBAttributeMapSO biomeMap, Color[] biomeColors)
+        {
+            int width = biomeMap._width;
+            neighborIndices[0] = pixelIndex - 1 - width; // top-left
+            neighborIndices[1] = pixelIndex - width; // top
+            neighborIndices[2] = pixelIndex + 1 - width; // top-right
+            neighborIndices[3] = pixelIndex + 1; // right
+            neighborIndices[4] = pixelIndex + 1 + width; // bottom-right
+            neighborIndices[5] = pixelIndex + width; // bottom
+            neighborIndices[6] = pixelIndex - 1 + width; // bottom-left
+            neighborIndices[7] = pixelIndex - 1; // left
+            neighborIndices[8] = pixelIndex; // center
+
+            colorBuffer.Clear();
+            int textureSize = biomeMap._width * biomeMap._height;
+            int bpp = biomeMap._bpp;
+            byte[] data = biomeMap._data;
+            for (int i = 0; i < 8; i++)
+            {
+                int neighborIndex = neighborIndices[i];
+                if (neighborIndex < 0)
+                    neighborIndex += textureSize;
+                else if (neighborIndex >= textureSize)
+                    neighborIndex -= textureSize;
+
+                int colorIndex = neighborIndex * bpp;
+
+                Color neighborColor = new Color(data[colorIndex] * Byte2Float, data[colorIndex + 1] * Byte2Float, data[colorIndex + 2] * Byte2Float, 1f);
+                if (!colorBuffer.Contains(neighborColor))
+                    colorBuffer.Add(neighborColor);
+            }
+
+            int bestIndex = 0;
+            float bestColorWeight = float.MaxValue;
+
+            for (int i = 0; i < biomeColors.Length; i++)
+            {
+                float colorWeight = 0f;
+                Color biomeColor = biomeColors[i];
+                for (int j = 0; j < colorBuffer.Count; j++)
+                {
+                    colorWeight += EuclideanColorDiff(colorBuffer[j], biomeColor);
+                }
+
+                if (colorWeight < bestColorWeight)
+                {
+                    bestIndex = i;
+                    bestColorWeight = colorWeight;
+                }
+            }
+
+            return bestIndex;
+        }
+
+        private static float EuclideanColorDiff(float r1, float g1, float b1, float r2, float g2, float b2)
+        {
+            float r = r1 - r2;
+            float g = g1 - g2;
+            float b = b1 - b2;
+            return r * r + g * g + b * b;
+        }
+
+        private static float EuclideanColorDiff(Color colA, Color colB)
+        {
+            float r = colA.r - colB.r;
+            float g = colA.g - colB.g;
+            float b = colA.b - colB.b;
+            return r * r + g * g + b * b;
+        }
+    }
+
+
+    //[KSPAddon(KSPAddon.Startup.MainMenu, false)]
+    internal class FastBiomeQuery : MonoBehaviour
+    {
+        private static RGBA32[][] biomeColorsByBody;
+
+        IEnumerator Start()
+        {
+            for (int i = 0; i < 60; i++)
+            {
+                yield return null;
+            }
+
+            biomeColorsByBody = new RGBA32[FlightGlobals.Bodies.Count][];
+
+            foreach (CelestialBody body in FlightGlobals.Bodies)
+            {
+                CBAttributeMapSO biomeMap = body.BiomeMap;
+                if (biomeMap == null)
+                    continue;
+
+                RGBA32[] biomeColors = new RGBA32[biomeMap.Attributes.Length];
+                biomeColorsByBody[body.flightGlobalsIndex] = biomeColors;
+
+                for (int i = 0; i < biomeMap.Attributes.Length; i++)
+                {
+                    biomeColors[i] = biomeMap.Attributes[i].mapColor;
+                }
+            }
+
+            List<double> ratios = new List<double>();
+
+            foreach (CelestialBody body in FlightGlobals.Bodies)
+            {
+                if (body.BiomeMap == null)
+                    continue;
+
+                CBAttributeMapSO biomeMap = body.BiomeMap;
+                Debug.Log($"[{body.name}] exactSearch={biomeMap.exactSearch}, neighborColorThresh={biomeMap.neighborColorThresh}, nonExactThreshold={biomeMap.nonExactThreshold}, bpp={biomeMap._bpp}");
+
+                int sampleCount = 1000000;
+                Vector2d[] coords = new Vector2d[sampleCount];
+                for (int i = 0; i < sampleCount; i++)
+                {
+                    double lat = ResourceUtilities.Deg2Rad(ResourceUtilities.clampLat(Random.Range(-90f, 90f)));
+                    double lon = ResourceUtilities.Deg2Rad(ResourceUtilities.clampLon(Random.Range(-180f, 180f)));
+                    coords[i] = new Vector2d(lat, lon);
+                }
+
+                CBAttributeMapSO.MapAttribute[] stockBiomes = new CBAttributeMapSO.MapAttribute[sampleCount];
+                Stopwatch stockWatch = new Stopwatch();
+
+                stockWatch.Start();
+                for (int i = 0; i < sampleCount; i++)
+                {
+                    Vector2d latLon = coords[i];
+                    stockBiomes[i] = biomeMap.GetAtt(latLon.x, latLon.y);
+                }
+                stockWatch.Stop();
+                //Debug.Log($"[FastBiomeQuery] Stock sampling : {stockWatch.Elapsed.TotalMilliseconds:F3}ms");
+
+                CBAttributeMapSO.MapAttribute[] cfBiomes = new CBAttributeMapSO.MapAttribute[sampleCount];
+                Stopwatch cfWatch = new Stopwatch();
+
+                cfWatch.Start();
+                for (int i = 0; i < sampleCount; i++)
+                {
+                    Vector2d latLon = coords[i];
+                    cfBiomes[i] = GetAttInt(biomeMap, body.flightGlobalsIndex, latLon.x, latLon.y);
+                    //cfBiomes[i] = GetAtt(biomeMap, latLon.x, latLon.y);
+                }
+                cfWatch.Stop();
+
+                double ratio = stockWatch.Elapsed.TotalMilliseconds / cfWatch.Elapsed.TotalMilliseconds;
+                ratios.Add(ratio);
+                Debug.Log($"[FastBiomeQuery] Sampling {sampleCount} biomes on {body.name,10} : {cfWatch.Elapsed.TotalMilliseconds,8:F2}ms vs {stockWatch.Elapsed.TotalMilliseconds,8:F2}ms, ratio:{ratio:F1}");
+
+                //for (int i = 0; i < sampleCount; i++)
+                //{
+                //    if (stockBiomes[i] != cfBiomes[i])
+                //    {
+                //        Debug.LogWarning($"[FastBiomeQuery] Result mismatch at coords {coords[i]}, stock={stockBiomes[i].name}, kspcf={cfBiomes[i].name}");
+                //    }
+                //}
+
+                int mismatchCount = 0;
+                for (int i = 0; i < sampleCount; i++)
+                {
+                    if (stockBiomes[i] != cfBiomes[i])
+                    {
+                        mismatchCount++;
+                    }
+                }
+
+                Debug.LogWarning($"[FastBiomeQuery] {mismatchCount} mismatchs ({mismatchCount/sampleCount:P3})");
+            }
+
+            Debug.Log($"[FastBiomeQuery] Average ratio : {ratios.Average():F2}");
+        }
+
+
+
+
+
+        private const double HalfPI = Math.PI / 2.0;
+        private const double DoublePI = Math.PI * 2.0;
+        private const double InversePI = 1.0 / Math.PI;
+        private const double InverseDoublePI = 1.0 / (2.0 * Math.PI);
+
+        public static CBAttributeMapSO.MapAttribute GetAttInt(CBAttributeMapSO biomeMap, int bodyIndex, double lat, double lon)
+        {
+            //if (biomeMap.exactSearch || biomeMap.nonExactThreshold != -1f)
+            //{
+            //    return biomeMap.GetAtt(lat, lon);
+            //}
+
+            lon -= HalfPI;
+            if (lon < 0.0)
+                lon += DoublePI;
+            lon %= DoublePI;
+            double x = 1.0 - lon * InverseDoublePI;
+            double y = lat * InversePI + 0.5;
+
+            biomeMap.ConstructBilinearCoords(x, y);
+            RGBA32 c0 = GetColorRGBA32(biomeMap, biomeMap.minX, biomeMap.minY);
+            RGBA32 c1 = GetColorRGBA32(biomeMap, biomeMap.maxX, biomeMap.minY);
+            RGBA32 c2 = GetColorRGBA32(biomeMap, biomeMap.minX, biomeMap.maxY);
+            RGBA32 c3 = GetColorRGBA32(biomeMap, biomeMap.maxX, biomeMap.maxY);
+
+            RGBA32 pixelColor;
+
+            if (c0 == c1 && c0 == c2 && c0 == c3)
+            {
+                pixelColor = c0;
+            }
+            else
+            {
+                Color cf0 = c0;
+                Color cf1 = c1;
+                Color cf2 = c2;
+                Color cf3 = c3;
+
+                Color lerpColor = BilinearColor(cf0, cf1, cf2, cf3, biomeMap.midX, biomeMap.midY);
+                pixelColor = c0;
+                float maxMag = RGBADiffSqrMag(cf0, lerpColor);
+                float mag = RGBADiffSqrMag(cf1, lerpColor);
+                if (mag < maxMag)
+                {
+                    maxMag = mag;
+                    pixelColor = c1;
+                }
+
+                mag = RGBADiffSqrMag(cf2, lerpColor);
+                if (mag < maxMag)
+                {
+                    maxMag = mag;
+                    pixelColor = c2;
+                }
+
+                // There is a bug in the stock method, where it doesn't check the fourth color...
+                //mag = RGBADiffSqrMag(cf3, lerpColor);
+                //if (mag < maxMag)
+                //{
+                //    pixelColor = c3;
+                //}
+            }
+
+            RGBA32[] biomeColors = biomeColorsByBody[bodyIndex];
+            int length = biomeColors.Length;
+            for (int i = 0; i < length; i++)
+            {
+                if (biomeColors[i] == pixelColor)
+                {
+                    return biomeMap.Attributes[i];
+                }
+            }
+
+            // fallback path if the color doesn't match exactly for some reason, this is the default stock code
+            CBAttributeMapSO.MapAttribute result = biomeMap.Attributes[0];
+            float maxColorMag = float.MaxValue;
+            for (int i = 0; i < length; i++)
+            {
+                float colorMag = EuclideanColorDiff(pixelColor, biomeColors[i]);
+                if (colorMag < maxColorMag)
+                {
+                    result = biomeMap.Attributes[i];
+                    maxColorMag = colorMag;
+                }
+            }
+
+            return result;
+        }
+
+        private static Color BilinearColor(Color col0, Color col1, Color col2, Color col3, double midX, double midY)
+        {
+            double r0 = col0.r + (col1.r - col0.r) * midX;
+            double r1 = col2.r + (col3.r - col2.r) * midX;
+            double r = r0 + (r1 - r0) * midY;
+
+            double g0 = col0.g + (col1.g - col0.g) * midX;
+            double g1 = col2.g + (col3.g - col2.g) * midX;
+            double g = g0 + (g1 - g0) * midY;
+
+            double b0 = col0.b + (col1.b - col0.b) * midX;
+            double b1 = col2.b + (col3.b - col2.b) * midX;
+            double b = b0 + (b1 - b0) * midY;
+
+            //double a0 = col0.a + (col1.a - col0.a) * midX;
+            //double a1 = col2.a + (col3.a - col2.a) * midX;
+            //double a = a0 + (a1 - a0) * midY;
+
+            return new Color((float)r, (float)g, (float)b, 1f);
+        }
+
+        private static float EuclideanColorDiff(Color colA, Color colB)
+        {
+            float r = colA.r - colB.r;
+            float g = colA.g - colB.g;
+            float b = colA.b - colB.b;
+            return r * r + g * g + b * b;
+        }
+
+        private static float RGBADiffSqrMag(Color colA, Color colB)
+        {
+            float r = colA.r - colB.r;
+            float g = colA.g - colB.g;
+            float b = colA.b - colB.b;
+            float a = colA.a - colB.a;
+            return r * r + g * g + b * b + a * a;
+        }
+
+        private static RGBA32 BilinearRGBA32(RGBA32 col0, RGBA32 col1, RGBA32 col2, RGBA32 col3, double midX, double midY)
+        {
+            double r0 = col0.r + (col1.r - col0.r) * midX;
+            double r1 = col2.r + (col3.r - col2.r) * midX;
+            double r = r0 + (r1 - r0) * midY;
+
+            double g0 = col0.g + (col1.g - col0.g) * midX;
+            double g1 = col2.g + (col3.g - col2.g) * midX;
+            double g = g0 + (g1 - g0) * midY;
+
+            double b0 = col0.b + (col1.b - col0.b) * midX;
+            double b1 = col2.b + (col3.b - col2.b) * midX;
+            double b = b0 + (b1 - b0) * midY;
+
+            //double a0 = col0.a + (col1.a - col0.a) * midX;
+            //double a1 = col2.a + (col3.a - col2.a) * midX;
+            //double a = a0 + (a1 - a0) * midY;
+
+            return new RGBA32((byte)r, (byte)g, (byte)b, 255);
+        }
+
+        private static int RGBA32DiffSqrMag(RGBA32 colA, RGBA32 colB)
+        {
+            int r = colA.r - colB.r;
+            int g = colA.g - colB.g;
+            int b = colA.b - colB.b;
+            return r * r + g * g + b * b;
+        }
+
+        private static RGBA32 GetColorRGBA32(CBAttributeMapSO biomeMap, int x, int y)
+        {
+            int index = biomeMap.PixelIndex(x, y);
+            byte[] data = biomeMap._data;
+
+            switch (biomeMap._bpp)
+            {
+                case 3:
+                    return new RGBA32(data[index], data[index + 1], data[index + 2], 255);
+                case 4:
+                    return new RGBA32(data[index], data[index + 1], data[index + 2], data[index + 3]);
+                case 2:
+                {
+                    byte rgb = data[index];
+                    return new RGBA32(rgb, rgb, rgb, data[index + 1]);
+                }
+                default:
+                {
+                    byte rgb = data[index];
+                    return new RGBA32(rgb, rgb, rgb, 255);
+                }
+            }
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        private struct RGBA32
+        {
+            private const float Byte2Float = 0.003921569f;
+
+            [FieldOffset(0)]
+            public int rgba;
+
+            [FieldOffset(0)]
+            public byte r;
+
+            [FieldOffset(1)]
+            public byte g;
+
+            [FieldOffset(2)]
+            public byte b;
+
+            [FieldOffset(3)]
+            public byte a;
+
+            public RGBA32(byte r, byte g, byte b, byte a)
+            {
+                rgba = 0;
+                this.r = r;
+                this.g = g;
+                this.b = b;
+                this.a = a;
+            }
+
+            public static implicit operator RGBA32(Color c)
+            {
+                return new RGBA32((byte)(c.r * 255f), (byte)(c.g * 255f), (byte)(c.b * 255f), (byte)(c.a * 255f));
+            }
+
+            public static implicit operator Color(RGBA32 c)
+            {
+                return new Color(c.r * Byte2Float, c.g * Byte2Float, c.b * Byte2Float, c.a * Byte2Float);
+            }
+
+            public bool Equals(RGBA32 other) => rgba == other.rgba;
+            public override bool Equals(object obj) => obj is RGBA32 other && Equals(other);
+            public static bool operator ==(RGBA32 lhs, RGBA32 rhs) => lhs.rgba == rhs.rgba;
+            public static bool operator !=(RGBA32 lhs, RGBA32 rhs) => lhs.rgba != rhs.rgba;
+            public override int GetHashCode() => rgba;
+        }
+    }
+}

--- a/KSPCommunityFixes/Performance/FastBiomeQuery.cs
+++ b/KSPCommunityFixes/Performance/FastBiomeQuery.cs
@@ -23,7 +23,7 @@ namespace KSPCommunityFixes.Performance
     /// calling the GetAtt() method.
     /// Notable changes are :<br/>
     /// - Storing directly the Attribute index in the byte array (instead of a color), reducing memory usage
-    /// to 8bpp instead of 24bpp, and making the array a lookup table instead of having to compare colors.<br/>
+    /// to 8Bpp instead of 24Bpp, and making the array a lookup table instead of having to compare colors.<br/>
     /// - Fixed a bug in the stock bilinear interpolation, causing incorrect results in a specific direction
     /// on biome transitions.
     /// </summary>


### PR DESCRIPTION
The stock biome maps (`CBAttributeMapSO` class) store a texture as RGB color data in a byte array where every pixel takes 3 bytes. Each biome definition (`CBAttributeMapSO.MapAttribute`) is given a specific color, and is stored in an array.
Querying a biome at a position (`CBAttributeMapSO.GetAtt()`) is a complex method that perform bilinear interpolation on that color array, attempts to find the closest color in the biome definition array, and does a bunch of heuristics in case the texture colors don't exactly match the ones defined in the biome definitions.

Some issues with this :
- Biome querying is quite slow as a result, which can be a bottleneck with mods doing a lot of such queries (Kerbalism, ScanSAT, Parallax scatters, ContractConfigurator...) , but with some stock code too (Contracts, KerbNet...).
- Storing full pixel color data takes up a lot of unnecessary RAM
- The stock bilinear interpolation has a bug resulting in jagged transitions between biomes along a specific direction

This is a replacement for the stock class, implemented as a `KSPCFFastBiomeMap` class deriving from `CBAttributeMapSO` :
- Instead of storing color data taking 3 bytes per pixel, store biome indices, taking 1 byte per pixel, reducing memory usage by a factor 3.
- Ability to reinterpret the pixel color data as biome indices (either from an already compiled `CBAttributeMapSO` or from a `Texture2D`), following the same heuristics as the stock `GetAtt()` method, allowing upfront validation of biome map, and preventing having to do it on every query.
- Reimplement the `CBAttributeMapSO.GetAtt()` method doing a direct lookup for the biome index instead of parsing colors, performing a correct bilinear interpolation.
- Fix incorrect coordinate wrapping at the north pole (stock bug), resulting in the south pole biome being returned near the north pole.

The benefits are :
- Reduced memory usage : 
  - Stock : from 189MB to 63MB
  - RSS : from 82MB to 27MB
  - OPM : from 549MB to 183MB
- An order of magnitude faster, and constant time biome querying (`GetAtt()`), unaffected by biome count. On average 15-20x faster than the stock implementation, up to 30x on bodies with a large amount of biomes.

Drawbacks :
- This introduce a limitation in that amount of biomes per body is limited to 256 whereas the stock implementation supports a virtually infinite amount (2^24). I doubt this can be an issue in practice.
- This require an upfront conversion of all the `CBAttributeMapSO` instances into a `KSPCFFastBiomeMap`. This is performed after `PSystemSetup` to catch Kopernicus changes, and before the main menu is loaded. The conversion is multithreaded, but it will introduce a perceptible delay on lower end machines. For reference, on a 5800X3D : 
  - Stock maps conversion, 1 thread : 1.4s
  - Stock maps conversion, 16 threads :  0.2s
  - Stock + OPM maps conversion, 1 thread : 3.2s
  - Stock + OPM maps conversion, 16 threads : 0.5s

While I think this is acceptable, it should be noted that doing this in the context of biome maps loaded by Kopernicus is utterly inefficient, as the complete chain of events is something like : 
- Kopernicus load the biome texture files as a `byte[]` from disk
- For some texture formats, it first parse it as a `Color32[]`, then copy it as a `Texture2D`, in other cases it relies on Unity to perform the conversion from the `byte[]` to a `Texture2D`.
- It feed that texture to the stock `CBAttributeMapSO` parser, which : 
  - Convert it as a `Color32[]`
  - Convert the `Color32[]`  to a 3Bpp RGB data `byte[]`
- Then KSPCF uses that RGB 3 Bpp `byte[]` to produce a biome indices 1Bpp `byte[]`, with a `Color32[]` conversion in between.

It would be vastly more efficient for Kopernicus to directly feed the KSPCF implementation the `Texture2D` or `Color32[]` without the useless conversion to a `CBAttributeMapSO` in between. This is difficult to implement from the KSPCF side (at least efficiently). Aside, Kopernicus would benefit from an overhaul of its biome querying stuff, so it seems more sensible to actually have a side by side implementation of the KSPCF fast biome in Kopernicus.

From a practial PoV, I will be AWOL from the KSP modding scene for some time, effective right now. Consequently, I will delay pushing this patch to KSPCF in case there are issues popping up that require some fixing. Plus I would like to contribute that work to Kopernicus, ideally synchronizing that feature release both in KSPCF and Kopernicus.

In the meantime, here is a build with the changes, for those willing to test it : 
[KSPCommunityFixes_1.29.0_FastBiomeQueryPR.zip](https://github.com/KSPModdingLibs/KSPCommunityFixes/files/11651341/KSPCommunityFixes_1.29.0_FastBiomeQueryPR.zip)

For reference, this illustrate the bug with biome transitions in the stock bilinear sampler :
![image](https://github.com/KSPModdingLibs/KSPCommunityFixes/assets/24925209/b63a081d-b971-4c7a-b2de-166a1fe0a78f)
