### PR TITLE
Fix Propellant's GetFlowModeDescription

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -179,6 +179,12 @@ KSP_COMMUNITY_FIXES
   // Fix leaking a camera and spotlight created by the thumbnail system on certain failures
   ThumbnailSpotlight = true
 
+  // Fix Propellant's GetFlowModeDescription (used when generating ModuleEngines ModuleInfo
+  // where it describes propellants) to use the propellant's flow mode, not the base resource
+  // flow mode.
+  PropellantFlowDescription = true
+
+
   // Make docking ports converve momentum by averaging acquire forces between the two ports.
   // Notably, docking port Kraken drives will no longer work.
   DockingPortConserveMomentum = true

--- a/KSPCommunityFixes/BugFixes/PropellantFlowDescription.cs
+++ b/KSPCommunityFixes/BugFixes/PropellantFlowDescription.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using HarmonyLib;
+using System.Collections.Generic;
+
+namespace KSPCommunityFixes.BugFixes
+{
+    class PropellantFlowDescription : BasePatch
+    {
+        protected override Version VersionMin => new Version(1, 8, 0);
+
+        protected override void ApplyPatches(List<PatchInfo> patches)
+        {
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(Propellant), nameof(Propellant.GetFlowModeDescription)),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Postfix,
+                AccessTools.Method(typeof(Propellant), nameof(Propellant.GetFlowModeDescription)),
+                this));
+        }
+
+        // doing this this way rather than via __state
+        // so we don't have to pass around structs or the like
+        private static PartResourceDefinition _def;
+        private static ResourceFlowMode _mode;
+
+        static void Propellant_GetFlowModeDescription_Prefix(Propellant __instance)
+        {
+            if (__instance.flowMode == ResourceFlowMode.NULL)
+                return;
+            var resDef = PartResourceLibrary.Instance.GetDefinition(__instance.id);
+            if (resDef == null)
+                return;
+
+            _def = resDef;
+            _mode = _def.resourceFlowMode;
+            _def._resourceFlowMode = __instance.flowMode;
+        }
+
+        static void Propellant_GetFlowModeDescription_Postfix(Propellant __instance)
+        {
+            if (_def != null)
+                _def._resourceFlowMode = _mode;
+
+            _def = null;
+        }
+    }
+}

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -103,6 +103,7 @@
     <Compile Include="BugFixes\AsteroidInfiniteMining.cs" />
     <Compile Include="BugFixes\ChutePhantomSymmetry.cs" />
     <Compile Include="BugFixes\CorrectDragForFlags.cs" />
+    <Compile Include="BugFixes\PropellantFlowDescription.cs" />
     <Compile Include="BugFixes\LadderToggleableLight.cs" />
     <Compile Include="BugFixes\MapSOCorrectWrapping.cs" />
     <Compile Include="BugFixes\FixGetUnivseralTime.cs" />

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ User options are available from the "ESC" in-game settings menu :<br/><img src="
 - [**ThumbnailSpotlight**](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/149) [KSP 1.12.0 - 1.12.5], fix rogue spotlight staying in the scene when a part thumbnail fails to be generated.
 - [**FixGetUnivseralTime**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/155) [KSP 1.8.0 - 1.12.5]<br/>Fix Planetarium.GetUniversalTime returning bad values in the editor.
 - [**DockingPortConserveMomentum**](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/160) [KSP 1.12.3 - 1.12.5]<br/>Make docking ports conserve momentum by averaging the acquire force between the two ports. Notably, docking port Kraken drives will no longer work.
-- **PropellantFlowDescription** [KSP 1.8.0 - KSP 1.12.5]<br/>Fix printing the resource's base flow mode instead of the (potentially overridden) propellant's flow mode when printing propellants in an engine's info panel in the Part Tooltip
+- [**PropellantFlowDescription**](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/165) [KSP 1.8.0 - KSP 1.12.5]<br/>Fix printing the resource's base flow mode instead of the (potentially overridden) propellant's flow mode when printing propellants in an engine's info panel in the Part Tooltip.
 
 #### Quality of Life tweaks 
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ User options are available from the "ESC" in-game settings menu :<br/><img src="
 - [**ThumbnailSpotlight**](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/149) [KSP 1.12.0 - 1.12.5], fix rogue spotlight staying in the scene when a part thumbnail fails to be generated.
 - [**FixGetUnivseralTime**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/155) [KSP 1.8.0 - 1.12.5]<br/>Fix Planetarium.GetUniversalTime returning bad values in the editor.
 - [**DockingPortConserveMomentum**](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/160) [KSP 1.12.3 - 1.12.5]<br/>Make docking ports conserve momentum by averaging the acquire force between the two ports. Notably, docking port Kraken drives will no longer work.
+- **PropellantFlowDescription** [KSP 1.8.0 - KSP 1.12.5]<br/>Fix printing the resource's base flow mode instead of the (potentially overridden) propellant's flow mode when printing propellants in an engine's info panel in the Part Tooltip
 
 #### Quality of Life tweaks 
 


### PR DESCRIPTION
Fix printing the resource's base flow mode instead of the (potentially overridden) propellant's flow mode when printing propellants in an engine's info panel in the Part Tooltip.