### PR TITLE
Set name for substitute part

### DIFF
--- a/KSPCommunityFixes/BugFixes/PartTooltipUpgradesApplyToSubstituteParts.cs
+++ b/KSPCommunityFixes/BugFixes/PartTooltipUpgradesApplyToSubstituteParts.cs
@@ -100,6 +100,7 @@ namespace KSPCommunityFixes
                 }
                 Part p = GameObject.Instantiate(ap.partPrefab);
                 p.gameObject.transform.SetParent(_substitutePartRoot.transform, true);
+                p.name = ap.name;
                 p.partInfo = ap;
                 try
                 {


### PR DESCRIPTION
When the substitute part for the editor part tooltip window is created, the name of the part is not set. This means that the substitute part gets the default Unity name of "{prefabName}(Clone)". With this PR, the part name gets set correctly to the `AvailablePart`'s `name` field, as is done elsewhere where a new part is instantiated from the prefab (e.g. at https://github.com/KSPModdingLibs/KSPCommunityFixes/blob/a411542b0897770c59dce0408b2569d7200635f9/KSPCommunityFixes/BugFixes/UpgradeBugs.cs#L377-L380).

I noticed this when investigating an issue in RP-1: it shows an "Unlock requirements" entry in the tooltip, which (among other things) contains the part name. 

![PartnameErrorExample](https://github.com/KSPModdingLibs/KSPCommunityFixes/assets/11440812/253a54ce-715e-45cb-ba29-955774b47798)