### PR TITLE
PAWGroupMemory is no longer per-window, but rather per-group

### DIFF
--- a/KSPCommunityFixes/BugFixes/PAWGroupMemory.cs
+++ b/KSPCommunityFixes/BugFixes/PAWGroupMemory.cs
@@ -10,7 +10,7 @@ namespace KSPCommunityFixes
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        private static Dictionary<int, Dictionary<string, bool>> collapseState;
+        private static Dictionary<string, bool> collapseState;
 
         protected override void ApplyPatches(List<PatchInfo> patches)
         {
@@ -29,14 +29,7 @@ namespace KSPCommunityFixes
                 AccessTools.Method(typeof(UIPartActionGroup), nameof(UIPartActionGroup.Expand)),
                 this));
 
-            collapseState = new Dictionary<int, Dictionary<string, bool>>();
-
-            GameEvents.onGameSceneSwitchRequested.Add(OnSceneSwitch);
-        }
-
-        private void OnSceneSwitch(GameEvents.FromToAction<GameScenes, GameScenes> data)
-        {
-            collapseState.Clear();
+            collapseState = new Dictionary<string, bool>();
         }
 
         static IEnumerable<CodeInstruction> UIPartActionGroup_Initialize_Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator il)
@@ -168,8 +161,7 @@ namespace KSPCommunityFixes
 
         static bool IsGroupCollapsed(UIPartActionWindow pawWindow, string groupName, out bool collapsed)
         {
-            int id = pawWindow.part?.GetInstanceID() ?? 0;
-            if (id != 0 && collapseState.TryGetValue(id, out Dictionary<string, bool> groups) && groups.TryGetValue(groupName, out collapsed))
+            if (collapseState.TryGetValue(groupName, out collapsed))
                 return true;
 
             collapsed = false;
@@ -181,16 +173,7 @@ namespace KSPCommunityFixes
             if (string.IsNullOrEmpty(___groupName))
                 return;
 
-            int id = __instance.Window?.part?.GetInstanceID() ?? 0;
-            if (id == 0)
-                return;
-
-            if (!collapseState.TryGetValue(id, out Dictionary<string, bool> partGroups))
-            {
-                partGroups = new Dictionary<string, bool>();
-                collapseState[id] = partGroups;
-            }
-            partGroups[___groupName] = true;
+            collapseState[___groupName] = true;
         }
 
         static void UIPartActionGroup_Expand_Postfix(UIPartActionGroup __instance, string ___groupName)
@@ -198,16 +181,7 @@ namespace KSPCommunityFixes
             if (string.IsNullOrEmpty(___groupName))
                 return;
 
-            int id = __instance.Window?.part?.GetInstanceID() ?? 0;
-            if (id == 0)
-                return;
-
-            if (!collapseState.TryGetValue(id, out Dictionary<string, bool> partGroups))
-            {
-                partGroups = new Dictionary<string, bool>();
-                collapseState[id] = partGroups;
-            }
-            partGroups[___groupName] = false;
+            collapseState[___groupName] = false;
         }
     }
 }

--- a/KSPCommunityFixes/BugFixes/PAWGroupMemory.cs
+++ b/KSPCommunityFixes/BugFixes/PAWGroupMemory.cs
@@ -30,6 +30,19 @@ namespace KSPCommunityFixes
                 this));
 
             collapseState = new Dictionary<string, bool>();
+
+            GameEvents.onPartActionUIShown.Add(OnPartActionUIShown);
+        }
+
+        private void OnPartActionUIShown(UIPartActionWindow paw, Part part)
+        {
+            foreach (var groupPair in paw.parameterGroups.dict)
+            {
+                if (collapseState.TryGetValue(groupPair.Key, out bool state) && state != groupPair.Value.isContentCollapsed)
+                {
+                    groupPair.Value.CollapseGroupToggle();
+                }
+            }
         }
 
         static IEnumerable<CodeInstruction> UIPartActionGroup_Initialize_Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator il)


### PR DESCRIPTION
This sort of addresses issue #50 , but as of right now we don't persist this state to disk.  This seems very similar to the intended behavior of `GameSettings.collpasedPAWGroups`, but that system can only collapse groups that the user had collapsed, not expand ones that had been manually expanded.