### PR TITLE
New QoL/Perf patch : OptionalMakingHistoryDLCFeatures

### DIFF
--- a/GameData/KSPCommunityFixes/Localization/en-us.cfg
+++ b/GameData/KSPCommunityFixes/Localization/en-us.cfg
@@ -12,6 +12,11 @@ Localization
     #KSPCF_AltimeterHorizontalPosition_SettingsTitle = Altimeter pos (Left<->Right)
     #KSPCF_AltimeterHorizontalPosition_SettingsTooltip = Set the horizontal position of the flight scene altimeter widget
 
+    // OptionalMakingHistoryDLCFeatures
+
+    #KSPCF_OptionalMakingHistoryDLCFeatures_MHDLC = Making History features
+    #KSPCF_OptionalMakingHistoryDLCFeatures_SettingsTooltip = Disable the Making History DLC mission editor and additional launch sites\nThe Making History parts will still be available\nWill reduce memory usage and increase loading speed\nChanges will take effect after restarting KSP
+
     // NoIVA
 
     #KSPCF_NoIVA_KeepAll = Keep all

--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -284,6 +284,14 @@ KSP_COMMUNITY_FIXES
   // Invert the editor undo state capturing logic so part tweaks aren't lost when undoing.
   BetterEditorUndoRedo = true
 
+  // Allow to disable the Making History DLC mission editor and additional launch sites features
+  // to decrease memory usage and increase loading speed. The Making History parts will still be 
+  // available. Can be toggled from the KSPCF in-game settings (requires a restart).
+  OptionalMakingHistoryDLCFeatures = true
+
+  // Optional MM-patcheable toggle to always disable the MH features
+  OptionalMakingHistoryDLCFeaturesAlwaysDisable = false
+
   // ##########################
   // Performance tweaks
   // ##########################

--- a/KSPCommunityFixes/Internal/PatchSettings.cs
+++ b/KSPCommunityFixes/Internal/PatchSettings.cs
@@ -18,6 +18,7 @@ namespace KSPCommunityFixes
         private static int entryCount = 0;
         private static AltimeterHorizontalPosition altimeterPatch;
         private static DisableManeuverTool maneuverToolPatch;
+        private static OptionalMakingHistoryDLCFeatures disableMHPatch;
 
         protected override void ApplyPatches(List<PatchInfo> patches)
         {
@@ -37,6 +38,10 @@ namespace KSPCommunityFixes
 
             maneuverToolPatch = KSPCommunityFixes.GetPatchInstance<DisableManeuverTool>();
             if (maneuverToolPatch != null)
+                entryCount++;
+
+            disableMHPatch = KSPCommunityFixes.GetPatchInstance<OptionalMakingHistoryDLCFeatures>();
+            if (disableMHPatch != null)
                 entryCount++;
 
             if (KSPCFFastLoader.IsPatchEnabled)
@@ -60,6 +65,22 @@ namespace KSPCommunityFixes
 
             modifiedResult[count] = new DialogGUIBox(KSPCommunityFixes.LOC_KSPCF_Title, -1f, 18f, null);
             count++;
+
+            if (disableMHPatch != null)
+            {
+                DialogGUIToggle toggle = new DialogGUIToggle(OptionalMakingHistoryDLCFeatures.isMHEnabled,
+                    () => (!OptionalMakingHistoryDLCFeatures.isMHEnabled)
+                        ? Localizer.Format("#autoLOC_6001071") //"Disabled"
+                        : Localizer.Format("#autoLOC_6001072"), //"Enabled"
+                    b => OptionalMakingHistoryDLCFeatures.isMHEnabled = b, 150f);
+                toggle.tooltipText = OptionalMakingHistoryDLCFeatures.LOC_SettingsTooltip;
+                toggle.OptionInteractableCondition = () => !OptionalMakingHistoryDLCFeatures.isMHDisabledFromConfig;
+
+                modifiedResult[count] = new DialogGUIHorizontalLayout(TextAnchor.MiddleLeft,
+                    new DialogGUILabel(() => Localizer.Format(OptionalMakingHistoryDLCFeatures.LOC_MHDLC), 150f), //"Maneuver Tool"
+                    toggle, new DialogGUIFlexibleSpace());
+                count++;
+            }
 
             if (maneuverToolPatch != null)
             {
@@ -120,6 +141,13 @@ namespace KSPCommunityFixes
 
         static void GameplaySettingsScreen_ApplySettings_Postfix()
         {
+            if (disableMHPatch != null)
+            {
+                ConfigNode node = new ConfigNode();
+                node.AddValue(nameof(OptionalMakingHistoryDLCFeatures.isMHEnabled), OptionalMakingHistoryDLCFeatures.isMHEnabled);
+                SaveData<OptionalMakingHistoryDLCFeatures>(node);
+            }
+
             if (maneuverToolPatch != null)
             {
                 ConfigNode node = new ConfigNode();

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -174,6 +174,7 @@
     <Compile Include="Performance\ProgressTrackingSpeedBoost.cs" />
     <Compile Include="QoL\AutostrutActions.cs" />
     <Compile Include="QoL\BetterEditorUndoRedo.cs" />
+    <Compile Include="QoL\OptionalMakingHistoryDLCFeatures.cs" />
     <Compile Include="QoL\ToolbarShowHide.cs" />
     <Compile Include="QoL\DisableNewGameIntro.cs" />
     <Compile Include="QoL\NoIVA.cs" />

--- a/KSPCommunityFixes/QoL/OptionalMakingHistoryDLCFeatures.cs
+++ b/KSPCommunityFixes/QoL/OptionalMakingHistoryDLCFeatures.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using Expansions;
+using HarmonyLib;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+
+namespace KSPCommunityFixes.QoL
+{
+    internal class OptionalMakingHistoryDLCFeatures : BasePatch
+    {
+        private const string MH_EXPANSION_FILE = "makinghistory.kspexpansion";
+        private const string SETTINGS_TOGGLE_VALUE_NAME = "OptionalMakingHistoryDLCFeaturesAlwaysDisable";
+        internal static string LOC_MHDLC = "Making History features";
+        internal static string LOC_SettingsTooltip = "Disable the Making History DLC mission editor and additional launch sites\nThe Making History parts will still be available\nWill reduce memory usage and increase loading speed\nChanges will take affect after restarting KSP";
+        internal static bool isMHEnabled = true;
+        internal static bool isMHDisabledFromConfig = false;
+
+        protected override Version VersionMin => new Version(1, 12, 3);
+
+        protected override void ApplyPatches(List<PatchInfo> patches)
+        {
+            if (KSPCommunityFixes.SettingsNode.TryGetValue(SETTINGS_TOGGLE_VALUE_NAME, ref isMHDisabledFromConfig) && isMHDisabledFromConfig)
+                isMHEnabled = false;
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(ExpansionsLoader), nameof(ExpansionsLoader.InitializeExpansion)),
+                this));
+        }
+
+        protected override void OnLoadData(ConfigNode node)
+        {
+            if (!isMHDisabledFromConfig)
+                node.TryGetValue(nameof(isMHEnabled), ref isMHEnabled);
+        }
+
+        protected override bool CanApplyPatch(out string reason)
+        {
+            if (Directory.Exists(KSPExpansionsUtils.ExpansionsGameDataPath))
+            {
+                foreach (string fileName in Directory.GetFiles(KSPExpansionsUtils.ExpansionsGameDataPath, "*" + ExpansionsLoader.expansionsMasterExtension, SearchOption.AllDirectories))
+                {
+                    if (fileName.EndsWith(MH_EXPANSION_FILE))
+                    {
+                        reason = null;
+                        return true;
+                    }
+                }
+            }
+
+            reason = "Making History DLC not installed";
+            return false;
+        }
+
+        static bool ExpansionsLoader_InitializeExpansion_Prefix(string expansionFile, ref IEnumerator __result)
+        {
+            if (!isMHEnabled && expansionFile.EndsWith(MH_EXPANSION_FILE))
+            {
+                __result = EmptyEnumerator();
+                return false;
+            }
+
+            return true;
+        }
+
+        static IEnumerator EmptyEnumerator()
+        {
+            yield break;
+        }
+    }
+}

--- a/KSPCommunityFixes/QoL/OptionalMakingHistoryDLCFeatures.cs
+++ b/KSPCommunityFixes/QoL/OptionalMakingHistoryDLCFeatures.cs
@@ -12,7 +12,7 @@ namespace KSPCommunityFixes.QoL
         private const string MH_EXPANSION_FILE = "makinghistory.kspexpansion";
         private const string SETTINGS_TOGGLE_VALUE_NAME = "OptionalMakingHistoryDLCFeaturesAlwaysDisable";
         internal static string LOC_MHDLC = "Making History features";
-        internal static string LOC_SettingsTooltip = "Disable the Making History DLC mission editor and additional launch sites\nThe Making History parts will still be available\nWill reduce memory usage and increase loading speed\nChanges will take affect after restarting KSP";
+        internal static string LOC_SettingsTooltip = "Disable the Making History DLC mission editor and additional launch sites\nThe Making History parts will still be available\nWill reduce memory usage and increase loading speed\nChanges will take effect after restarting KSP";
         internal static bool isMHEnabled = true;
         internal static bool isMHDisabledFromConfig = false;
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ User options are available from the "ESC" in-game settings menu :<br/><img src="
 - [**ToolbarShowHide**](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/53) [KSP 1.8.0 - 1.12.5]<br/>Add a button for hiding/showing the stock toolbar. Also allow accessing the toolbar while in the space center facilities windows (mission control, admin building, R&D...).
 - **ResourceLockActions** [KSP 1.8.0 - 1.12.5]<br/>Add part actions for locking/unlocking resources flow state.
 - [**BetterEditorUndoRedo**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/172) [KSP 1.12.3 - 1.12.5]<br/>Invert the editor undo state capturing logic so part tweaks aren't lost when undoing.  NOTE: this patch is disabled when TweakScale/L is installed.
+- [**OptionalMakingHistoryDLCFeatures**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/218) [KSP 1.12.3 - 1.12.5]<br/>Allow to disable the Making History DLC mission editor and additional launch sites features to decrease memory usage and increase loading speed. The Making History parts will still be available. Can be toggled from the KSPCF in-game settings (requires a restart), or from a MM patch (see `Settings.cfg`).
 
 #### Performance tweaks 
 
@@ -187,6 +188,9 @@ The `Start` action of the IDE will trigger a build, update the `GameData` files 
 If doing so in the `Debug` configuration and if your KSP install is modified to be debuggable, you will be able to debug the code from within your IDE (if your IDE provides Unity debugging support).
 
 ### Changelog
+
+##### next
+- New KSP QoL/performance patch : [**OptionalMakingHistoryDLCFeatures**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/218) [KSP 1.12.3 - 1.12.5] : Allow to disable the Making History DLC mission editor and additional launch sites features to decrease memory usage and increase loading speed. The Making History parts will still be available. Can be toggled from the KSPCF in-game settings (requires a restart), or from a MM patch (see `Settings.cfg`)
 
 ##### 1.34.1
 - Disable BetterEditorUndoRedo when TweakScale/L is installed due to introducing a bug with part attachments in the editor.


### PR DESCRIPTION
Implement patch requested in issue #218 

Allow to disable the Making History DLC mission editor and additional launch sites features to decrease memory usage and increase loading speed. The Making History parts will still be available. Can be toggled from the KSPCF in-game settings (requires a restart), or from a MM patch (see `Settings.cfg`)