### PR TITLE
Potential fix for issue #216

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -403,6 +403,8 @@ KSP_COMMUNITY_FIXES
   // Allow a min value of 0.02 instead of 0.03 for the "Max Physics Delta-Time Per Frame" main menu setting.
   LowerMinPhysicsDTPerFrame = true
 
+  OptimizedModuleRaycasts = true
+
   // ##########################
   // Modding
   // ##########################

--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -403,6 +403,8 @@ KSP_COMMUNITY_FIXES
   // Allow a min value of 0.02 instead of 0.03 for the "Max Physics Delta-Time Per Frame" main menu setting.
   LowerMinPhysicsDTPerFrame = true
 
+  // Improve engine exhaust damage and solar panel line of sight raycasts performance by avoiding extra physics
+  // state synchronization and caching solar panels scaled space raycasts results.
   OptimizedModuleRaycasts = true
 
   // ##########################

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -169,6 +169,7 @@
     <Compile Include="Modding\ReflectionTypeLoadExceptionHandler.cs" />
     <Compile Include="Performance\FewerSaves.cs" />
     <Compile Include="Performance\ConfigNodePerf.cs" />
+    <Compile Include="Performance\OptimizedModuleRaycasts.cs" />
     <Compile Include="Performance\PQSCoroutineLeak.cs" />
     <Compile Include="Performance\PQSUpdateNoMemoryAlloc.cs" />
     <Compile Include="Performance\ProgressTrackingSpeedBoost.cs" />

--- a/KSPCommunityFixes/Library/Extensions.cs
+++ b/KSPCommunityFixes/Library/Extensions.cs
@@ -28,5 +28,10 @@ namespace KSPCommunityFixes
             Type type = obj.GetType();
             return $"{type.Assembly.GetName().Name}:{type.Name}";
         }
+
+        public static bool IsPAWOpen(this Part part)
+        {
+            return part.PartActionWindow.IsNotNullOrDestroyed() && part.PartActionWindow.isActiveAndEnabled;
+        }
     }
 }

--- a/KSPCommunityFixes/Performance/OptimizedModuleRaycasts.cs
+++ b/KSPCommunityFixes/Performance/OptimizedModuleRaycasts.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System;
+using HarmonyLib;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
@@ -10,6 +11,8 @@ namespace KSPCommunityFixes.Performance
     {
         private static readonly WaitForFixedUpdate waitForFixedUpdate = new WaitForFixedUpdate();
         private static bool partModulesSyncedOnceInFixedUpdate = false;
+
+        protected override Version VersionMin => new Version(1, 12, 3);
 
         protected override void ApplyPatches(List<PatchInfo> patches)
         {

--- a/KSPCommunityFixes/Performance/OptimizedModuleRaycasts.cs
+++ b/KSPCommunityFixes/Performance/OptimizedModuleRaycasts.cs
@@ -1,0 +1,152 @@
+﻿using HarmonyLib;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+
+namespace KSPCommunityFixes.Performance
+{
+    internal class OptimizedModuleRaycasts : BasePatch
+    {
+        private static readonly WaitForFixedUpdate waitForFixedUpdate = new WaitForFixedUpdate();
+        private static bool partModulesSyncedOnceInFixedUpdate = false;
+
+        protected override void ApplyPatches(List<PatchInfo> patches)
+        {
+            patches.Add(
+                new PatchInfo(PatchMethodType.Transpiler,
+                    AccessTools.Method(typeof(ModuleEngines), nameof(ModuleEngines.EngineExhaustDamage)),
+                    this));
+
+            patches.Add(
+                new PatchInfo(PatchMethodType.Prefix,
+                    AccessTools.Method(typeof(ModuleDeployableSolarPanel), nameof(ModuleDeployableSolarPanel.CalculateTrackingLOS)),
+                    this));
+
+            KSPCommunityFixes.Instance.StartCoroutine(ResetSyncOnFixedEnd());
+        }
+
+        static IEnumerator ResetSyncOnFixedEnd()
+        {
+            while (true)
+            {
+                partModulesSyncedOnceInFixedUpdate = false;
+                lastVesselId = 0;
+                lastTrackingTransformId = 0;
+                yield return waitForFixedUpdate;
+            }
+        }
+
+        static IEnumerable<CodeInstruction> ModuleEngines_EngineExhaustDamage_Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            MethodInfo m_Physics_RayCast = AccessTools.Method(typeof(Physics), nameof(Physics.Raycast), new[] { typeof(Vector3), typeof(Vector3), typeof(RaycastHit).MakeByRefType(), typeof(float), typeof(int) });
+            MethodInfo m_RaycastNoSync = AccessTools.Method(typeof(OptimizedModuleRaycasts), nameof(RaycastNoSync));
+
+            foreach (CodeInstruction instruction in instructions)
+            {
+                if (instruction.Calls(m_Physics_RayCast))
+                {
+                    instruction.operand = m_RaycastNoSync;
+                }
+
+                yield return instruction;
+            }
+        }
+
+        private static int lastVesselId;
+        private static int lastTrackingTransformId;
+        private static bool lastHasLoS;
+        private static string lastBlocker;
+
+        private static bool ModuleDeployableSolarPanel_CalculateTrackingLOS_Prefix(ModuleDeployableSolarPanel __instance, Vector3 trackingDirection, ref string blocker, out bool __result)
+        {
+            if (__instance.part.ShieldedFromAirstream && __instance.applyShielding)
+            {
+                blocker = "aero shielding";
+                __result = false;
+                return false;
+            }
+
+            int trackingTransformId = __instance.trackingTransformLocal.GetInstanceID();
+            int vesselId = __instance.vessel.GetInstanceID();
+            if (lastTrackingTransformId == trackingTransformId && lastVesselId == vesselId)
+            {
+                if (!lastHasLoS)
+                {
+                    __result = false;
+                    blocker = lastBlocker;
+                    return false;
+                }
+            }
+            else
+            {
+                lastTrackingTransformId = trackingTransformId;
+                lastVesselId = vesselId;
+
+                Vector3 scaledVesselPos = ScaledSpace.LocalToScaledSpace(__instance.vessel.transform.position);
+                Vector3 scaledDirection = (ScaledSpace.LocalToScaledSpace(__instance.trackingTransformLocal.position) - scaledVesselPos).normalized;
+
+                if (Physics.Raycast(scaledVesselPos, scaledDirection, out RaycastHit scaledHit, float.MaxValue, __instance.planetLayerMask) && scaledHit.transform.NotDestroyedRefNotEquals(__instance.trackingTransformScaled))
+                {
+                    __instance.hit = scaledHit; // just to ensure this is populated
+                    lastBlocker = scaledHit.transform.gameObject.name; // allocates a string
+                    blocker = lastBlocker;
+                    lastHasLoS = false;
+                    __result = false;
+                    return false;
+                }
+
+                lastHasLoS = true;
+                lastBlocker = null;
+            }
+
+            Vector3 localPanelPos = __instance.secondaryTransform.position + trackingDirection * __instance.raycastOffset;
+            __result = !RaycastNoSync(localPanelPos, trackingDirection, out RaycastHit localhit, float.MaxValue, __instance.defaultLayerMask);
+            __instance.hit = localhit; // just to ensure this is populated
+
+            if (!__result 
+                && UIPartActionController.Instance.IsNotNullOrDestroyed()
+                && UIPartActionController.Instance.ItemListContains(__instance.part, false)
+                && localhit.transform.gameObject.IsNotNullOrDestroyed())
+            {
+                GameObject hitObject = localhit.transform.gameObject;
+                if (!ReferenceEquals(hitObject.GetComponent<PQ>(), null))
+                {
+                    blocker = ModuleDeployableSolarPanel.cacheAutoLOC_438839;
+                }
+                else
+                {
+                    Part partUpwardsCached = FlightGlobals.GetPartUpwardsCached(hitObject);
+                    if (partUpwardsCached.IsNotNullOrDestroyed())
+                    {
+                        blocker = partUpwardsCached.partInfo.title;
+                    }
+                    else
+                    {
+                        string tag = hitObject.tag; // allocates a string
+                        if (tag.Contains("KSC"))
+                            blocker = ResearchAndDevelopment.GetMiniBiomedisplayNameByUnityTag(tag, true);
+                        else
+                            blocker = hitObject.name;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public static bool RaycastNoSync(Vector3 origin, Vector3 direction, out RaycastHit hitInfo, float maxDistance, int layerMask)
+        {
+            if (!partModulesSyncedOnceInFixedUpdate)
+            {
+                Physics.SyncTransforms();
+                partModulesSyncedOnceInFixedUpdate = true;
+            }
+
+            Physics.autoSyncTransforms = false;
+            bool result = Physics.defaultPhysicsScene.Raycast(origin, direction, out hitInfo, maxDistance, layerMask);
+            Physics.autoSyncTransforms = true;
+            return result;
+        }
+    }
+}

--- a/KSPCommunityFixes/Performance/OptimizedModuleRaycasts.cs
+++ b/KSPCommunityFixes/Performance/OptimizedModuleRaycasts.cs
@@ -104,10 +104,7 @@ namespace KSPCommunityFixes.Performance
             __result = !RaycastNoSync(localPanelPos, trackingDirection, out RaycastHit localhit, float.MaxValue, __instance.defaultLayerMask);
             __instance.hit = localhit; // just to ensure this is populated
 
-            if (!__result 
-                && UIPartActionController.Instance.IsNotNullOrDestroyed()
-                && UIPartActionController.Instance.ItemListContains(__instance.part, false)
-                && localhit.transform.gameObject.IsNotNullOrDestroyed())
+            if (!__result && __instance.part.IsPAWOpen() && localhit.transform.gameObject.IsNotNullOrDestroyed())
             {
                 GameObject hitObject = localhit.transform.gameObject;
                 if (!ReferenceEquals(hitObject.GetComponent<PQ>(), null))

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ User options are available from the "ESC" in-game settings menu :<br/><img src="
 - **IMGUIOptimization** [KSP 1.8.0 - 1.12.5]<br/>Eliminate structural GC allocations and reduce performance overhead of OnGUI() methods. Can provide significant performance gains when having many mods using IMGUI heavily.
 - [**CollisionManagerFastUpdate**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/174) [KSP 1.11.0 - 1.12.5]<br/>3-4 times faster update of parts inter-collision state, significantly reduce stutter on docking, undocking, decoupling and joint failure events.
 - [**LowerMinPhysicsDTPerFrame**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/175) [KSP 1.12.3 - 1.12.5]<br/>Allow a min value of 0.02 instead of 0.03 for the "Max Physics Delta-Time Per Frame" main menu setting.  This allows for higher and smoother framerate at the expense of the game lagging behind real time.
-
+- [**OptimizedModuleRaycasts**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/216) [KSP 1.12.3 - 1.12.5]<br/>Improve engine exhaust damage and solar panel line of sight raycasts performance by avoiding extra physics state synchronization and caching solar panels scaled space raycasts results.
 
 #### API and modding tools
 - **MultipleModuleInPartAPI** [KSP 1.8.0 - 1.12.5]<br/>This API allow other plugins to implement PartModules that can exist in multiple occurrence in a single part and won't suffer "module indexing mismatch" persistent data losses following part configuration changes. [See documentation on the wiki](https://github.com/KSPModdingLibs/KSPCommunityFixes/wiki/MultipleModuleInPartAPI).
@@ -187,6 +187,9 @@ The `Start` action of the IDE will trigger a build, update the `GameData` files 
 If doing so in the `Debug` configuration and if your KSP install is modified to be debuggable, you will be able to debug the code from within your IDE (if your IDE provides Unity debugging support).
 
 ### Changelog
+
+##### 1.35.0
+- New KSP performance patch : [**OptimizedModuleRaycasts**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/216) : Improve engine exhaust damage and solar panel line of sight raycasts performance by avoiding extra physics state synchronization and caching solar panels scaled space raycasts results.
 
 ##### 1.34.1
 - Disable BetterEditorUndoRedo when TweakScale/L is installed due to introducing a bug with part attachments in the editor.


### PR DESCRIPTION
Optimization of raycasts in `ModuleEngines.EngineExhaustDamage()` and `ModuleDeployableSolarPanel.CalculateTrackingLOS()` :
- Only synchronize transforms on the first raycast from any of those modules, mainly relevant when something else is moving transforms in between calls, which is often the case for active engines with gimbals, with a call time divided by 4-5 for `ModuleEngines.FixedUpdate()` when engines are actively gimballing (which is almost always the case as long as the SAS is activated)
- Cached ScaledSpace raycast results for solar panels (alongside some other smaller optimizations) : `ModuleDeployableSolarPanel.FixedUpdate()` call time is divided by between 4 (when blocked by a scaled space object) and 2 (when not blocked)

On a side note, it seems there are some unrelated optimizations opportunities in `ModuleDeployablePart.FixedUpdate()` (which is the base class of solar panels, also shared by radiators and antennas), as when profiling (static) solar panels, the bulk of the call time was spent there doing more or less nothing. I suspect continuously (and uselessly) setting the drag cube weights is in large part responsible.