### PR TITLE
On-demand part textures

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -4,6 +4,9 @@
 
 KSP_COMMUNITY_FIXES
 {
+    OnDemandPartTextures = true
+
+
   // ##########################
   // Major bugfixes
   // ##########################

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -170,6 +170,7 @@
     <Compile Include="Modding\ReflectionTypeLoadExceptionHandler.cs" />
     <Compile Include="Performance\FewerSaves.cs" />
     <Compile Include="Performance\ConfigNodePerf.cs" />
+    <Compile Include="Performance\OnDemandPartTextures.cs" />
     <Compile Include="Performance\OptimizedModuleRaycasts.cs" />
     <Compile Include="Performance\PQSCoroutineLeak.cs" />
     <Compile Include="Performance\PQSUpdateNoMemoryAlloc.cs" />

--- a/KSPCommunityFixes/Library/StaticHelpers.cs
+++ b/KSPCommunityFixes/Library/StaticHelpers.cs
@@ -7,6 +7,36 @@ using UnityEngine;
 
 namespace KSPCommunityFixes
 {
+    // see https://learn.microsoft.com/en-us/windows/win32/direct3ddds/dx-graphics-dds-pguide
+    internal enum DDSFourCC : uint
+    {
+        DXT1 = 0x31545844, // "DXT1"
+        DXT2 = 0x32545844, // "DXT2"
+        DXT3 = 0x33545844, // "DXT3"
+        DXT4 = 0x34545844, // "DXT4"
+        DXT5 = 0x35545844, // "DXT5"
+        BC4U_ATI = 0x31495441, // "ATI1" (actually BC4U)
+        BC4U = 0x55344342, // "BC4U"
+        BC4S = 0x53344342, // "BC4S"
+        BC5U_ATI = 0x32495441, // "ATI2" (actually BC5U)
+        BC5U = 0x55354342, // "BC5U"
+        BC5S = 0x53354342, // "BC5S"
+        RGBG = 0x47424752, // "RGBG"
+        GRGB = 0x42475247, // "GRGB"
+        UYVY = 0x59565955, // "UYVY"
+        YUY2 = 0x32595559, // "YUY2"
+        DX10 = 0x30315844, // "DX10", actual DXGI format specified in DX10 header
+        R16G16B16A16_UNORM = 36,
+        R16G16B16A16_SNORM = 110,
+        R16_FLOAT = 111,
+        R16G16_FLOAT = 112,
+        R16G16B16A16_FLOAT = 113,
+        R32_FLOAT = 114,
+        R32G32_FLOAT = 115,
+        R32G32B32A32_FLOAT = 116,
+        CxV8U8 = 117,
+    }
+
     static class StaticHelpers
     {
         public static string HumanReadableBytes(long bytes)

--- a/KSPCommunityFixes/Performance/FastLoader.cs
+++ b/KSPCommunityFixes/Performance/FastLoader.cs
@@ -303,6 +303,8 @@ namespace KSPCommunityFixes.Performance
             gdb.progressTitle = "Searching assets to load...";
             yield return null;
 
+            OnDemandPartTextures.GetTextures(out HashSet<string> allPartTextures);
+
             double nextFrameTime = ElapsedTime + minFrameTimeD;
 
             // Files loaded by our custom loaders
@@ -350,26 +352,29 @@ namespace KSPCommunityFixes.Performance
                             }
                             break;
                         case FileType.Texture:
+
+                            bool isOnDemand = allPartTextures.Contains(file.url);
+
                             switch (file.fileExtension)
                             {
                                 case "dds":
-                                    textureAssets.Add(new RawAsset(file, RawAsset.AssetType.TextureDDS));
+                                    textureAssets.Add(new RawAsset(file, RawAsset.AssetType.TextureDDS, isOnDemand));
                                     break;
                                 case "jpg":
                                 case "jpeg":
-                                    textureAssets.Add(new RawAsset(file, RawAsset.AssetType.TextureJPG));
+                                    textureAssets.Add(new RawAsset(file, RawAsset.AssetType.TextureJPG, isOnDemand));
                                     break;
                                 case "mbm":
-                                    textureAssets.Add(new RawAsset(file, RawAsset.AssetType.TextureMBM));
+                                    textureAssets.Add(new RawAsset(file, RawAsset.AssetType.TextureMBM, isOnDemand));
                                     break;
                                 case "png":
-                                    textureAssets.Add(new RawAsset(file, RawAsset.AssetType.TexturePNG));
+                                    textureAssets.Add(new RawAsset(file, RawAsset.AssetType.TexturePNG, isOnDemand));
                                     break;
                                 case "tga":
-                                    textureAssets.Add(new RawAsset(file, RawAsset.AssetType.TextureTGA));
+                                    textureAssets.Add(new RawAsset(file, RawAsset.AssetType.TextureTGA, isOnDemand));
                                     break;
                                 case "truecolor":
-                                    textureAssets.Add(new RawAsset(file, RawAsset.AssetType.TextureTRUECOLOR));
+                                    textureAssets.Add(new RawAsset(file, RawAsset.AssetType.TextureTRUECOLOR, isOnDemand));
                                     break;
                                 default:
                                     unsupportedTextureFiles.Add(file);
@@ -802,6 +807,12 @@ namespace KSPCommunityFixes.Performance
         {
             foreach (RawAsset rawAsset in files)
             {
+                if (rawAsset.IsOnDemand)
+                {
+                    buffer.AddToFront(rawAsset);
+                    continue;
+                }
+
                 rawAsset.ReadFromDiskWorkerThread();
 
                 SpinWait spin = new SpinWait();
@@ -836,7 +847,7 @@ namespace KSPCommunityFixes.Performance
         /// <summary>
         /// Asset wrapper class, actual implementation of the disk reader, individual texture/model formats loaders
         /// </summary>
-        private class RawAsset
+        internal class RawAsset
         {
             public enum AssetType
             {
@@ -881,18 +892,21 @@ namespace KSPCommunityFixes.Performance
             private BinaryReader binaryReader;
             private Result result;
             private string resultMessage;
+            private bool isOnDemand;
 
             public UrlFile File => file;
             public Result State => result;
             public string Message => resultMessage;
             public int DataLength => dataLength;
             public string TypeName => assetTypeNames[(int)assetType];
+            public bool IsOnDemand => isOnDemand;
 
-            public RawAsset(UrlFile file, AssetType assetType)
+            public RawAsset(UrlFile file, AssetType assetType, bool isOnDemand = false)
             {
                 this.result = Result.Valid;
                 this.file = file;
                 this.assetType = assetType;
+                this.isOnDemand = isOnDemand;
             }
 
             private void SetError(string message)
@@ -1002,35 +1016,49 @@ namespace KSPCommunityFixes.Performance
                     if (file.fileType == FileType.Texture)
                     {
                         TextureInfo textureInfo;
-                        switch (assetType)
+
+                        if (isOnDemand)
                         {
-                            case AssetType.TextureDDS:
-                                textureInfo = LoadDDS();
-                                break;
-                            case AssetType.TextureJPG:
-                                textureInfo = LoadJPG();
-                                break;
-                            case AssetType.TextureMBM:
-                                textureInfo = LoadMBM();
-                                break;
-                            case AssetType.TexturePNG:
-                                textureInfo = LoadPNG();
-                                break;
-                            case AssetType.TexturePNGCached:
-                                textureInfo = LoadPNGCached();
-                                break;
-                            case AssetType.TextureTGA:
-                                textureInfo = LoadTGA();
-                                break;
-                            case AssetType.TextureTRUECOLOR:
-                                textureInfo = LoadTRUECOLOR();
-                                break;
-                            default:
-                                SetError("Unknown texture format");
-                                return;
+                            textureInfo = new OnDemandTextureInfo(file, assetType);
+                        }
+                        else
+                        {
+                            switch (assetType)
+                            {
+                                case AssetType.TextureDDS:
+                                    textureInfo = LoadDDS();
+                                    break;
+                                case AssetType.TextureJPG:
+                                    textureInfo = LoadJPG();
+                                    break;
+                                case AssetType.TextureMBM:
+                                    textureInfo = LoadMBM();
+                                    break;
+                                case AssetType.TexturePNG:
+                                    textureInfo = LoadPNG();
+                                    break;
+                                case AssetType.TexturePNGCached:
+                                    textureInfo = LoadPNGCached();
+                                    break;
+                                case AssetType.TextureTGA:
+                                    textureInfo = LoadTGA();
+                                    break;
+                                case AssetType.TextureTRUECOLOR:
+                                    textureInfo = LoadTRUECOLOR();
+                                    break;
+                                default:
+                                    SetError("Unknown texture format");
+                                    return;
+                            }
+
+                            if (textureInfo.texture.IsNullOrDestroyed())
+                                result = Result.Failed;
+
+                            textureInfo.texture.name = file.url;
+                            textureInfo.name = file.url;
                         }
 
-                        if (result == Result.Failed || textureInfo == null || textureInfo.texture.IsNullOrDestroyed())
+                        if (result == Result.Failed || textureInfo == null)
                         {
                             result = Result.Failed;
                             if (string.IsNullOrEmpty(resultMessage))
@@ -1038,8 +1066,6 @@ namespace KSPCommunityFixes.Performance
                         }
                         else
                         {
-                            textureInfo.name = file.url;
-                            textureInfo.texture.name = file.url;
                             Instance.databaseTexture.Add(textureInfo);
                         }
                     }

--- a/KSPCommunityFixes/Performance/FastLoader.cs
+++ b/KSPCommunityFixes/Performance/FastLoader.cs
@@ -1136,36 +1136,6 @@ namespace KSPCommunityFixes.Performance
                 this.cachedTextureInfo = cachedTextureInfo;
             }
 
-            // see https://learn.microsoft.com/en-us/windows/win32/direct3ddds/dx-graphics-dds-pguide
-            private enum DDSFourCC : uint
-            {
-                DXT1 = 0x31545844, // "DXT1"
-                DXT2 = 0x32545844, // "DXT2"
-                DXT3 = 0x33545844, // "DXT3"
-                DXT4 = 0x34545844, // "DXT4"
-                DXT5 = 0x35545844, // "DXT5"
-                BC4U_ATI = 0x31495441, // "ATI1" (actually BC4U)
-                BC4U = 0x55344342, // "BC4U"
-                BC4S = 0x53344342, // "BC4S"
-                BC5U_ATI = 0x32495441, // "ATI2" (actually BC5U)
-                BC5U = 0x55354342, // "BC5U"
-                BC5S = 0x53354342, // "BC5S"
-                RGBG = 0x47424752, // "RGBG"
-                GRGB = 0x42475247, // "GRGB"
-                UYVY = 0x59565955, // "UYVY"
-                YUY2 = 0x32595559, // "YUY2"
-                DX10 = 0x30315844, // "DX10", actual DXGI format specified in DX10 header
-                R16G16B16A16_UNORM = 36,
-                R16G16B16A16_SNORM = 110,
-                R16_FLOAT = 111,
-                R16G16_FLOAT = 112,
-                R16G16B16A16_FLOAT = 113,
-                R32_FLOAT = 114,
-                R32G32_FLOAT = 115,
-                R32G32B32A32_FLOAT = 116,
-                CxV8U8 = 117,
-            }
-
             private TextureInfo LoadDDS()
             {
                 memoryStream = new MemoryStream(buffer, 0, dataLength);

--- a/KSPCommunityFixes/Performance/OnDemandPartTextures.cs
+++ b/KSPCommunityFixes/Performance/OnDemandPartTextures.cs
@@ -1,0 +1,470 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using HarmonyLib;
+using KSP.UI.Screens;
+using KSPCommunityFixes.QoL;
+using UnityEngine;
+using static KSP.UI.Screens.Settings.SettingsSetup;
+using static KSPCommunityFixes.Performance.KSPCFFastLoader;
+using static KSPCommunityFixes.QoL.NoIVA;
+using static ProceduralSpaceObject;
+
+namespace KSPCommunityFixes.Performance
+{
+    public class OnDemandPartTextures : BasePatch
+    {
+        internal static Dictionary<string, List<string>> partsTextures;
+        internal static Dictionary<AvailablePart, PrefabData> prefabsData = new Dictionary<AvailablePart, PrefabData>();
+
+        protected override void ApplyPatches(List<PatchInfo> patches)
+        {
+            MethodInfo m_Instantiate = null;
+            foreach (MethodInfo methodInfo in typeof(UnityEngine.Object).GetMethods(BindingFlags.Public | BindingFlags.Static))
+            {
+                if (methodInfo.IsGenericMethod
+                    && methodInfo.Name == nameof(UnityEngine.Object.Instantiate) 
+                    && methodInfo.GetParameters().Length == 1)
+                {
+                    m_Instantiate = methodInfo.MakeGenericMethod(typeof(UnityEngine.Object));
+                    break;
+                }
+            }
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                m_Instantiate,
+                this, nameof(Instantiate_Prefix)));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Postfix,
+                AccessTools.Method(typeof(PartLoader), nameof(PartLoader.ParsePart)),
+                this));
+        }
+
+        static void Instantiate_Prefix(UnityEngine.Object original)
+        {
+            if (original is Part part 
+                && part.partInfo != null 
+                && part.partInfo.partPrefab.IsNotNullRef() // skip instantiation of the special prefabs (kerbals, flag) during loading
+                && prefabsData.TryGetValue(part.partInfo, out PrefabData prefabData)
+                && !prefabData.areTexturesLoaded)
+            {
+                // load textures
+                // set them on the prefab
+                prefabData.areTexturesLoaded = true;
+            }
+        }
+
+        static void PartLoader_ParsePart_Postfix(AvailablePart __result)
+        {
+            if (!partsTextures.TryGetValue(__result.name, out List<string> textures))
+                return;
+
+            Transform modelTransform = __result.partPrefab.transform.Find("model");
+            if (modelTransform == null)
+                return;
+
+            PrefabData prefabData = null;
+
+            foreach (Renderer renderer in modelTransform.GetComponentsInChildren<Renderer>(true))
+            {
+                if (renderer is ParticleSystemRenderer || renderer.sharedMaterial.IsNullOrDestroyed())
+                    continue;
+
+                Material material = renderer.sharedMaterial;
+                MaterialTextures materialTextures = null;
+
+                if (material.HasProperty("_MainTex"))
+                {
+                    Texture currentTex = material.GetTexture("_MainTex");
+                    if (currentTex.IsNotNullRef())
+                    {
+                        string currentTexName = currentTex.name;
+                        if (OnDemandTextureInfo.texturesByUrl.TryGetValue(currentTexName, out OnDemandTextureInfo textureInfo))
+                        {
+                            if (prefabData == null)
+                                prefabData = new PrefabData();
+
+                            if (materialTextures == null)
+                                materialTextures = new MaterialTextures(material);
+
+                            prefabData.materials.Add(materialTextures);
+                            materialTextures.mainTex = textureInfo;
+                        }
+
+                    }
+                }
+
+                if (material.HasProperty("_BumpMap"))
+                {
+                    Texture currentTex = material.GetTexture("_BumpMap");
+                    if (currentTex.IsNotNullRef())
+                    {
+                        string currentTexName = currentTex.name;
+                        if (OnDemandTextureInfo.texturesByUrl.TryGetValue(currentTexName, out OnDemandTextureInfo textureInfo))
+                        {
+                            if (prefabData == null)
+                                prefabData = new PrefabData();
+
+                            if (materialTextures == null)
+                                materialTextures = new MaterialTextures(material);
+
+                            prefabData.materials.Add(materialTextures);
+                            materialTextures.bumpMap = textureInfo;
+                        }
+
+                    }
+                }
+
+                if (material.HasProperty("_Emissive"))
+                {
+                    Texture currentTex = material.GetTexture("_Emissive");
+                    if (currentTex.IsNotNullRef())
+                    {
+                        string currentTexName = currentTex.name;
+                        if (OnDemandTextureInfo.texturesByUrl.TryGetValue(currentTexName, out OnDemandTextureInfo textureInfo))
+                        {
+                            if (prefabData == null)
+                                prefabData = new PrefabData();
+
+                            if (materialTextures == null)
+                                materialTextures = new MaterialTextures(material);
+
+                            prefabData.materials.Add(materialTextures);
+                            materialTextures.emissive = textureInfo;
+                        }
+
+                    }
+                }
+
+                if (material.HasProperty("_SpecMap"))
+                {
+                    Texture currentTex = material.GetTexture("_SpecMap");
+                    if (currentTex.IsNotNullRef())
+                    {
+                        string currentTexName = currentTex.name;
+                        if (OnDemandTextureInfo.texturesByUrl.TryGetValue(currentTexName, out OnDemandTextureInfo textureInfo))
+                        {
+                            if (prefabData == null)
+                                prefabData = new PrefabData();
+
+                            if (materialTextures == null)
+                                materialTextures = new MaterialTextures(material);
+
+                            prefabData.materials.Add(materialTextures);
+                            materialTextures.specMap = textureInfo;
+                        }
+
+                    }
+                }
+            }
+
+            if (prefabData != null)
+                prefabsData[__result] = prefabData;
+        }
+
+        private static readonly char[] textureSplitChars = { ':', ',', ';' };
+
+        public static void GetTextures(out HashSet<string> allPartTextures)
+        {
+            Dictionary<string, List<string>> modelParts = new Dictionary<string, List<string>>();
+            Dictionary<string, List<TextureReplacement>> partTextureReplacements = new Dictionary<string, List<TextureReplacement>>();
+
+            foreach (UrlDir.UrlConfig urlConfig in GameDatabase.Instance.root.AllConfigs)
+            {
+                if (urlConfig.type != "PART")
+                    continue;
+
+                bool hasModelInModelNode = false;
+
+                string partName = urlConfig.config.GetValue("name");
+                if (partName == null)
+                    continue;
+
+                partName = partName.Replace('_', '.');
+
+                foreach (ConfigNode partNode in urlConfig.config.nodes)
+                {
+                    if (partNode.name == "MODEL")
+                    {
+                        List<TextureReplacement> texturePaths = null;
+                        foreach (ConfigNode.Value modelValue in partNode.values)
+                        {
+                            if (modelValue.name == "model")
+                            {
+                                hasModelInModelNode = true;
+
+                                if (!modelParts.TryGetValue(modelValue.value, out List<string> parts))
+                                {
+                                    parts = new List<string>();
+                                    modelParts[modelValue.value] = parts;
+                                }
+
+                                parts.Add(partName);
+                            }
+                            else if (modelValue.name == "texture")
+                            {
+                                string[] array = modelValue.value.Split(textureSplitChars, StringSplitOptions.RemoveEmptyEntries);
+                                if (array.Length != 2)
+                                    continue;
+
+                                if (texturePaths == null)
+                                    texturePaths = new List<TextureReplacement>();
+
+                                texturePaths.Add(new TextureReplacement(array[0].Trim(), array[1].Trim()));
+                            }
+                        }
+
+                        if (texturePaths != null)
+                            partTextureReplacements[partName] = texturePaths;
+                    }
+                }
+
+                if (!hasModelInModelNode)
+                {
+                    foreach (UrlDir.UrlFile urlFile in urlConfig.parent.parent.files)
+                    {
+                        if (urlFile.fileExtension == "mu")
+                        {
+                            if (!modelParts.TryGetValue(urlFile.url, out List<string> parts))
+                            {
+                                parts = new List<string>();
+                                modelParts[urlFile.url] = parts;
+                            }
+
+                            parts.Add(partName);
+                            break; // only first model found should be added
+                        }
+                    }
+                }
+            }
+
+            partsTextures = new Dictionary<string, List<string>>(500);
+            allPartTextures = new HashSet<string>(500);
+
+            HashSet<string> allTextures = new HashSet<string>(2000);
+            HashSet<string> allReplacedTextures = new HashSet<string>(500);
+            List<string> texturePathsBuffer = new List<string>();
+            List<string> textureFileNameBuffer = new List<string>();
+
+            foreach (UrlDir.UrlFile urlFile in GameDatabase.Instance.root.AllFiles)
+            {
+                if (urlFile.fileType == UrlDir.FileType.Texture)
+                {
+                    allTextures.Add(urlFile.url);
+                    continue;
+                }
+
+                if (urlFile.fileType != UrlDir.FileType.Model)
+                    continue;
+
+                if (!modelParts.TryGetValue(urlFile.url, out List<string> parts))
+                    continue;
+
+                foreach (string textureFile in MuParser.GetModelTextures(urlFile.fullPath))
+                {
+                    string textureFileName = Path.GetFileNameWithoutExtension(textureFile);
+                    textureFileNameBuffer.Add(textureFileName);
+                    texturePathsBuffer.Add(urlFile.parent.url + "/" + textureFileName);
+                }
+
+                if (texturePathsBuffer.Count == 0)
+                {
+                    modelParts.Remove(urlFile.url);
+                    continue;
+                }
+
+                foreach (string part in parts)
+                {
+                    if (partTextureReplacements.TryGetValue(part, out List<TextureReplacement> textureReplacements))
+                    {
+                        foreach (TextureReplacement textureReplacement in textureReplacements)
+                        {
+                            for (int i = 0; i < textureFileNameBuffer.Count; i++)
+                            {
+                                if (textureReplacement.textureName == textureFileNameBuffer[i])
+                                {
+                                    allReplacedTextures.Add(texturePathsBuffer[i]);
+                                    texturePathsBuffer[i] = textureReplacement.replacementUrl;
+                                }
+                            }
+                        }
+                    }
+
+                    if (!partsTextures.TryGetValue(part, out List<string> textures))
+                    {
+                        textures = new List<string>(texturePathsBuffer);
+                        partsTextures[part] = textures;
+                    }
+                    else
+                    {
+                        textures.AddRange(texturePathsBuffer);
+                    }
+                }
+
+                texturePathsBuffer.Clear();
+                textureFileNameBuffer.Clear();
+            }
+
+            List<string> stringBuffer = new List<string>();
+            foreach (KeyValuePair<string, List<string>> partTextures in partsTextures)
+            {
+                for (int i = partTextures.Value.Count; i-- > 0;)
+                {
+                    string texture = partTextures.Value[i];
+                    if (!allTextures.Contains(texture))
+                    {
+                        partTextures.Value.RemoveAt(i);
+                    }
+                    else
+                    {
+                        allPartTextures.Add(texture);
+                    }
+                }
+
+                if (partTextures.Value.Count == 0)
+                    stringBuffer.Add(partTextures.Key);
+            }
+
+            for (int i = stringBuffer.Count; i-- > 0;)
+                partsTextures.Remove(stringBuffer[i]);
+
+            stringBuffer.Clear();
+            foreach (string replacedTexture in allReplacedTextures)
+                if (allPartTextures.Contains(replacedTexture))
+                    stringBuffer.Add(replacedTexture);
+
+            for (int i = stringBuffer.Count; i-- > 0;)
+                allReplacedTextures.Remove(stringBuffer[i]);
+        }
+    }
+
+
+    //[KSPAddon(KSPAddon.Startup.Instantly, true)]
+    public class OnDemandPartTexturesLoader// : MonoBehaviour
+    {
+
+
+
+
+        // 1
+        // build a <PartPrefab, List<Texture2D>> dictionary
+        // 1.a.
+        // - Parse part configs
+        //   - find MODEL > model reference
+        //   - find MODEL > texture refernces
+        //   - find ModulePartVariants > TEXTURE references
+        // - In all found model references :
+        //   - find all texture references
+        // Patch Part.Awake(), after RelinkPrefab()
+        //   - swap the model textures
+
+        // overview of where textures can come from :
+        // - defined in the model(s) materials
+        //   - PART > "mesh" : depreciated/unused
+        //   - If no PART > MODEL node : the first found (as ordered in GameDatabase.databaseModel) *.mu model placed in the same directory as the part config (cfg.parent.parent.url)
+        //   - If PART > MODEL node(s) : the model defined in the "model" value
+        //   - not sure if it is possible to set a path to the texture in the model ? I don't think so, but...
+        // - defined as a texture replacement in the PART > MODEL node
+        //   - the replacement is done on the prefab renderers sharedMaterial
+        //   - as far as I can tell, this require (a potentially dummy) texture with the same name as what is backed in the model to be sitting next to the model in the same directory
+
+
+    }
+
+    internal class TextureReplacement
+    {
+        public string textureName;
+        public string replacementUrl;
+
+        public TextureReplacement(string textureName, string replacementUrl)
+        {
+            this.textureName = textureName;
+            this.replacementUrl = replacementUrl;
+        }
+    }
+
+    internal class PrefabData
+    {
+        public bool areTexturesLoaded;
+        public List<MaterialTextures> materials;
+
+        public void LoadTextures()
+        {
+
+        }
+    }
+
+    internal class MaterialTextures
+    {
+        private Material material;
+        public OnDemandTextureInfo mainTex;
+        public OnDemandTextureInfo bumpMap;
+        public OnDemandTextureInfo emissive;
+        public OnDemandTextureInfo specMap;
+
+        public MaterialTextures(Material material)
+        {
+            this.material = material;
+        }
+
+        public void LoadTextures()
+        {
+            if (mainTex != null)
+            {
+                mainTex.Load();
+                material.SetTexture("_MainTex", mainTex.texture);
+            }
+
+            if (bumpMap != null)
+            {
+                bumpMap.Load();
+                material.SetTexture("_BumpMap", bumpMap.texture);
+            }
+
+            if (emissive != null)
+            {
+                emissive.Load();
+                material.SetTexture("_Emissive", emissive.texture);
+            }
+
+            if (specMap != null)
+            {
+                specMap.Load();
+                material.SetTexture("_SpecMap", specMap.texture);
+            }
+        }
+    }
+
+    internal class OnDemandTextureInfo : GameDatabase.TextureInfo
+    {
+        public static Dictionary<string, OnDemandTextureInfo> texturesByUrl = new Dictionary<string, OnDemandTextureInfo>();
+
+        private Texture2D dummyTexture;
+
+        private bool isLoaded;
+        private RawAsset.AssetType textureType;
+
+        public OnDemandTextureInfo(UrlDir.UrlFile file, RawAsset.AssetType textureType, bool isNormalMap = false, bool isReadable = false, bool isCompressed = false, Texture2D texture = null) 
+            : base(file, texture, isNormalMap, isReadable, isCompressed)
+        {
+            name = file.url;
+            this.textureType = textureType;
+            dummyTexture = new Texture2D(1, 1, TextureFormat.ARGB32, false);
+            dummyTexture.Apply(false, true);
+            dummyTexture.name = name;
+            this.texture = dummyTexture;
+            texturesByUrl.Add(name, this);
+        }
+
+        public void Load()
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
This is exploratory work for implementing an on-demand loading mechanism for part textures.

The general idea would be identify which textures are used in parts prior to loading them, then to skip loading them during initial game load, to finally load them selectively and asynchronously when a part is effectively instantiated in game. Textures would then be unloaded when no instantiated part is using them anymore.

The potential benefits would be : 
- Reduced initial load time
- Reduced VRAM consumption

However, the caveats are numerous : 
- This require a lot of additional loading-time parsing that will at least partially offset the gains. The net result will still likely be positive, but I would temper expectations about this vastly reducing loading times. Even in a worst case scenario, texture loading hardly excess 50 % of the overall loading time (I'd say 30-40% is more typical), and any non-part texture would still be loaded as usual.
- While this can potentially save a lot of VRAM in heavily modded installs having a lot of additional parts, the savings will always be limited to the memory footprint of parts that aren't in use in the current scene.
- This is trading a single upfront time cost for additional work every time a scene is switched, and while the goal is to load textures asynchronously, there will be additional overhead that might end up delaying at which point the game starts to be useable and responsive after a scene switch. I'd say that scene switch delays is one of the worst problem of KSP, so depending on how bad this ends up, I'm not so sure the whole thing would be perceived as an improvement.
- The editor part picker thumbnails uses a rendered copy of the parts models, this wouldn't be possible anymore. A complete reimplementation would be needed. Two options are possible : either keep using rendered models but generate low res versions of the part textures, or use static images. Either way, this mean auto-generating and loading additional textures. The latter is likely the easiest to implement, and KSP already generate static thumbnails anyway for the inventory / cargo part system, so reusing / refactoring that system is likely the best option. The other option (keeping the 3D models but applying a low-res textures) might have been a simpler and better option if those thumbnails didn't exist, but since they do, this would be very wasteful as the scaled down textures will end up eating memory in addition to the memory used by the stock thumbnails[*].  No matter which solution is used, I would estimate this to be a very significant amount of work.
- This will be breaking a major assumption about how things work in stock and consequently is very likely to cause issues in the modding ecosystem. From preliminary research, I *think* the fallout would be relatively limited, but this is hard to assess. In particular, plugins doing some part rendering without actually instantiating parts are pretty certain to break, I can notably think of DistantObjectEnhancement, maybe KronalVesselViewer too.
- For this to be effective, the implementation needs to be able to know and keep track of every usage of every texture by every part. While this isn't too hard in stock, many mods are implementing various dynamic texture switching mechanisms, and things gets even more hairy with mods implementing non-stock shaders or custom rendering paths (for example, TextureUnlimited). In practice, supporting B9PartSwitch (the mainstream model/texture switchers) is likely doable, the rest will likely stay out of scope. To be clear, "not supporting" such mods would result in the textures they use being loaded as usual instead of on-demand, although there is a potential "missing texture" problem if such a plugin is *reusing* a texture not used (in a stock way) in the current part but otherwise used (in a stock way) by another part. This might for example be an issue for the "modular stock tanks" plugin the RO gang has put together.
- This being said, it should be possible to provide an API for this feature, allowing other plugins to leverage it. An assessment of potential usages would need to be made, because I would anticipate some complexities and compromises between the shape and usability of that API and our internal bookkeeping requirements. This should likely be assessed after a first minimally viable prototype is put together.

On a side note, I'm not sure I will have the time nor motivation to get this idea to completion. But at least whatever I do will be a base for anyone wanting to pursue this project.

[*] A stretch goal could be to replace the stock cargo/inventory static thumbnails by 3D models with downscaled textures. The stock static thumbnail system generate a 256x256 texture for every part and every variant of every part, which ends up being a significant waste of VRAM. At the very least, the resolution of those thumbs should be reduced, 128x128 would be more than enough given that at 100% UI scale, the viewport for a part is 64x64.