### PR TITLE
Add caching to LocalizerPerf

### DIFF
--- a/KSPCommunityFixes/Performance/LocalizerPerf.cs
+++ b/KSPCommunityFixes/Performance/LocalizerPerf.cs
@@ -19,6 +19,7 @@ namespace KSPCommunityFixes.Performance
     {
         private static Thread mainThread;
 
+        private static readonly Dictionary<(string, string),string> Cache = new Dictionary<(string, string), string>();
         protected override void ApplyPatches(List<PatchInfo> patches)
         {
             mainThread = Thread.CurrentThread;
@@ -51,7 +52,6 @@ namespace KSPCommunityFixes.Performance
                 __result = template;
                 return false;
             }
-
             Localizer localizer = Localizer.Instance;
             if (localizer == null || string.IsNullOrEmpty(template))
             {
@@ -85,6 +85,13 @@ namespace KSPCommunityFixes.Performance
                 return false;
             }
 
+            (string, string) cacheKey = (template, string.Join(".",list));
+            
+            if(Cache.TryGetValue(cacheKey, out __result))
+            {
+                return false;
+            }
+
             if (localizer.tagValues.TryGetValue(template, out string localizedTemplate))
                 template = localizedTemplate;
 
@@ -109,6 +116,7 @@ namespace KSPCommunityFixes.Performance
             if (Localizer.debugWriteMissingKeysToLog)
                 DebugWriteMissingKeysToLog(__result);
 
+            Cache.Add(cacheKey, __result);
             return false;
         }
 


### PR DESCRIPTION
When profiling time-warping in the Tracking Station, I noticed an unsual amount of time spent generating contracts, and a large part of that was spent in `KSPCommunityFixes.Performance.LocalizerPerf.Localizer_FormatStringParams_Prefix(string, string[], ref string)`

It appeared to be repeatedly looking up the same basic translations as it calculated contracts each update.

This patch adds a very basic cache.

There may be more appropriate caching structures to use, this assumes that the cache won't grow too big.

