### PR TITLE
Fix an IndexOutOfRangeException in DragCube.Load()

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -222,6 +222,9 @@ KSP_COMMUNITY_FIXES
   // cargo bays, wrong vessel size being reported, etc...
   PartBoundsIgnoreDisabledTransforms = true
 
+  // Fix loading of drag cubes without a name failing with an IndexOutOfRangeException
+  DragCubeLoadException = true
+
   // ##########################
   // Obsolete bugfixes
   // ##########################

--- a/KSPCommunityFixes/BugFixes/DragCubeLoadException.cs
+++ b/KSPCommunityFixes/BugFixes/DragCubeLoadException.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using HarmonyLib;
+
+namespace KSPCommunityFixes.BugFixes
+{
+class DragCubeLoadException : BasePatch
+{
+    // The name field in a DRAG_CUBE config node is supposed to be optional. However, when the name is not included in
+    // the list of values, an IndexOutOfRangeException is thrown.
+    //
+    // Even when not loaded from a config file, when the name field on a DragCube object is the empty string (for
+    // example, when it is default-constructed in code) it is not included in the string returned by
+    // DragCube.SaveToString(); this causes a problem when the FlightIntegrator.Setup() method uses this string to
+    // create a clone of a drag cube.
+
+    protected override Version VersionMin => new Version(1, 8, 0);
+
+    protected override void ApplyPatches(List<PatchInfo> patches)
+    {
+        patches.Add(
+            new PatchInfo(
+                PatchMethodType.Transpiler,
+                AccessTools.Method(typeof(DragCube), nameof(DragCube.Load)),
+                this));
+    }
+
+    static IEnumerable<CodeInstruction> DragCube_Load_Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        // The first instructions in DragCube.Load(string[] data) are:
+        //  - Check if it has the correct length (24 or 25), logging an error and returning if this is not the case
+        //  - Check if the length is 12; if it is not, take the first field as the name and skip it.
+        // That last check should have been against a length of 24 instead; this patch replaces the first occurrence of
+        // ldc.i4.s 12 in the code by ldc.i4.s 24.
+
+        bool found = false;
+        foreach (var instruction in instructions)
+        {
+            if (!found && instruction.Is(OpCodes.Ldc_I4_S, (sbyte)12))
+            {
+                found = true;
+                instruction.operand = (sbyte)24;
+            }
+            yield return instruction;
+        }
+    }
+}
+}

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -104,6 +104,7 @@
     <Compile Include="BugFixes\AsteroidInfiniteMining.cs" />
     <Compile Include="BugFixes\ChutePhantomSymmetry.cs" />
     <Compile Include="BugFixes\CorrectDragForFlags.cs" />
+    <Compile Include="BugFixes\DragCubeLoadException.cs" />
     <Compile Include="BugFixes\EVAConstructionMass.cs" />
     <Compile Include="BugFixes\InventoryPartMass.cs" />
     <Compile Include="BugFixes\ModulePartVariantsNodePersistence.cs" />

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ User options are available from the "ESC" in-game settings menu :<br/><img src="
 - [**ZeroCostTechNode**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/180) [KSP 1.12.3 - 1.12.5]<br/>Fixes a bug where parts in tech nodes that have 0 science cost would become unusable.
 - [**ModulePartVariantsNodePersistence**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/179) [KSP 1.12.3 - 1.12.5]<br/>Fixes an issue with ModulePartVariants where attachnodes would use their default state when resuming flight on a vessel from a saved game.  This would lead to different behavior in part joints and flexibility between initial launch and loading a save.
 - [**PartBoundsIgnoreDisabledTransforms**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/208) [KSP 1.12.3 - 1.12.5]<br/>Fix disabled renderers by mesh switchers (B9PartSwitch...) still being considered for part bounds evaluation, resulting in various issues like parts not being occluded from drag in cargo bays, wrong vessel size being reported, etc...
+- **DragCubeLoadException** [KSP 1.8.0 - 1.12.5]<br/>Fix loading of drag cubes without a name failing with an IndexOutOfRangeException
 
 #### Quality of Life tweaks 
 


### PR DESCRIPTION
The name field in a `DRAG_CUBE` config node is supposed to be optional. However, when the name is not included in the list of values, an `IndexOutOfRangeException` is thrown.

Even when not loaded from a config file, when the name field on a `DragCube` object is the empty string (for example, when it is default-constructed in code) it is not included in the string returned by `DragCube.SaveToString()`; this causes a problem when the `FlightIntegrator.Setup()` method uses this string to clone drag cubes.

The first instructions in `DragCube.Load(string[] data)` are:
 - Check if it has the correct length (24 or 25), logging an error and returning if this is not the case
 - Check if the length is 12; if it is not, take the first field as the name and skip it.

That last check should have been against a length of 24 instead; this patch replaces the first occurrence of `ldc.i4.s 12` in the code by `ldc.i4.s 24`.

I've checked KSP version 1.0.5 (the oldest version available via Steam), and the bug was already present in that version; the code seems to be unchanged between then and version 1.12.5.