### PR TITLE
Always run KSPCF first in `ModuleManagerPostLoad`

### DIFF
--- a/KSPCommunityFixes/KSPCommunityFixes.cs
+++ b/KSPCommunityFixes/KSPCommunityFixes.cs
@@ -63,7 +63,7 @@ namespace KSPCommunityFixes
                 Destroy(Instance);
                 Instance = null;
             }
-            
+
             if (Instance.IsNullOrDestroyed())
             {
                 Instance = this;
@@ -77,9 +77,17 @@ namespace KSPCommunityFixes
 #endif
             LocalizationUtils.GenerateLocTemplateIfRequested();
             LocalizationUtils.ParseLocalization();
+
+            // Insert KSPCF as the first entry in the explicit callback list.
+            // This guarantees that KSPCF will run before all other post load callbacks.
+            // Note that this is cumbersome to access via publicizer because it references
+            // assemblies via file name, and ModuleManager's dll is versioned.
+            AccessTools
+                .StaticFieldRefAccess<List<ModuleManager.ModuleManagerPostPatchCallback>>(typeof(ModuleManager.PostPatchLoader), "postPatchCallbacks")
+                .Insert(0, MMPostLoadCallback);
         }
 
-        public void ModuleManagerPostLoad()
+        public void MMPostLoadCallback()
         {
             if (Instance.IsNullOrDestroyed() || !Instance.RefEquals(this))
                 return;
@@ -106,7 +114,7 @@ namespace KSPCommunityFixes
                 if (!type.IsAbstract && type.IsSubclassOf(basePatchType))
                 {
                     patchesTypes.Add(type);
-                    
+
                 }
             }
 

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -84,6 +84,10 @@
       <Name>Harmony</Name>
       <Private>False</Private>
     </Reference>
+    <Reference Include="$(ReferencePath)\GameData\ModuleManager.*.dll">
+      <Name>ModuleManager</Name>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
   <!--Krafs.Publicizer items-->
   <ItemGroup>

--- a/KSPCommunityFixes/Properties/AssemblyInfo.cs
+++ b/KSPCommunityFixes/Properties/AssemblyInfo.cs
@@ -34,3 +34,4 @@ using System.Runtime.InteropServices;
 
 [assembly: KSPAssembly("KSPCommunityFixes", 1, 35, 2)]
 [assembly: KSPAssemblyDependency("MultipleModulePartAPI", 1, 0, 0)]
+[assembly: KSPAssemblyDependency("ModuleManager", 1, 0)]


### PR DESCRIPTION
As discussed with @JonnyOThan.

A `MonoBehaviour` gets called fairly late by MM (the ordering is explicit callbacks -> static methods -> `MonoBehaviour` methods). Furthermore, the calling order within each method signature is unspecified.

This PR inserts KSPCF as the first explicit callback, which allows other `ModuleManagerPostLoad` callbacks to rely on KSPCF fixes.