### PR TITLE
New modding patch: KSPFieldEnumDesc

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -453,6 +453,10 @@ KSP_COMMUNITY_FIXES
   // upgrade scripts.
   ModUpgradePipeline = false
 
+  // Adds display name and localization support for enum KSPFields.
+  // To use add `Description` attribute to the field.
+  KSPFieldEnumDesc = false
+
   // ##########################
   // Localization tools
   // ##########################

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Library\Extensions.cs" />
     <Compile Include="Library\LocalizationUtils.cs" />
     <Compile Include="Library\ObjectPool.cs" />
+    <Compile Include="Modding\KSPFieldEnumDesc.cs" />
     <Compile Include="Modding\ModUpgradePipeline.cs" />
     <Compile Include="Performance\AsteroidAndCometDrillCache.cs" />
     <Compile Include="BugFixes\DoubleCurvePreserveTangents.cs" />

--- a/KSPCommunityFixes/Modding/KSPFieldEnumDesc.cs
+++ b/KSPCommunityFixes/Modding/KSPFieldEnumDesc.cs
@@ -1,0 +1,34 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+
+namespace KSPCommunityFixes.Modding
+{
+    public class KSPFieldEnumDesc : BasePatch
+    {
+        protected override Version VersionMin => new Version(1, 12, 3);
+
+        protected override void ApplyPatches(List<PatchInfo> patches)
+        {
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(BaseField), "GetStringValue"),
+                this));
+        }
+
+        internal static bool BaseField_GetStringValue_Prefix(BaseField __instance, object host, bool gui, ref string __result)
+        {
+            if (!gui) return true;
+
+            Type fieldType = __instance.FieldInfo.FieldType;
+            if (fieldType.IsEnum)
+            {
+                var val = (Enum)__instance.GetValue(host);
+                __result = val.displayDescription();
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ User options are available from the "ESC" in-game settings menu :<br/><img src="
   - `R16G16B16A16` : 4 channels (RGBA) uncompressed 64 bpp
   - `R16_FLOAT` / `R32_FLOAT` : single channel (R) uncompressed 16/32 bpp 
   - `R16G16_FLOAT` / `R32G32_FLOAT` : 2 channels (RG) uncompressed 32/64 bpp
-  - `R16G16B16A16_FLOAT` / `R32G32B32A32_FLOAT` : 4 channels (RGBA) uncompressed 64/128 bpp 
+  - `R16G16B16A16_FLOAT` / `R32G32B32A32_FLOAT` : 4 channels (RGBA) uncompressed 64/128 bpp
+- **KSPFieldEnumDesc** [KSP 1.12.2 - 1.12.5]<br/>Disabled by default, you can enable it with a MM patch. Adds display name and localization support for enum KSPFields. To use add `Description` attribute to the field.
 
 #### Stock configs tweaks
 - **[ManufacturerFixes](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/62)**<br/>Fix a bunch of stock parts not having manufacturers, add icons for the stock "Stratus Corporation" and "LightYear Tire Company" and two new agents, "FreeFall Parachutes" and "Clamp-O-Tron".


### PR DESCRIPTION
Add display name and localization support for enum KSPFields. This is done by slapping the `Description` attribute to the fields. Actually KSP itself already uses this pattern in some places but mysteriously it's missing on KSPFields.

(Note: no way in hell am I writing a transpiler for this)