### PR TITLE
Improve SceneLoadSpeedBoost patch

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -302,6 +302,7 @@ KSP_COMMUNITY_FIXES
   // ##########################
 
   // Reduce scene loading time by caching the current save in memory instead of loading it from disk
+  // Additionally forces all scene transitions to happen synchronously.
   SceneLoadSpeedBoost = true
 
   // Prevent the buoyancy integrator from eating CPU cycles when the vessel isn't submerged

--- a/KSPCommunityFixes/Performance/SceneLoadSpeedBoost.cs
+++ b/KSPCommunityFixes/Performance/SceneLoadSpeedBoost.cs
@@ -32,6 +32,11 @@ namespace KSPCommunityFixes
                 AccessTools.Method(typeof(GamePersistence), "LoadGame", new Type[] { typeof(string), typeof(string), typeof(bool), typeof(bool) }),
                 this));
 
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(SceneTransitionMatrix), "GetTransitionValue", new Type[] { typeof(GameScenes), typeof(GameScenes) }),
+                this));
+
             //patches.Add(new PatchInfo(
             //    PatchMethodType.Prefix,
             //    AccessTools.Method(typeof(GamePersistence), "SaveGame", new Type[] {typeof(Game), typeof(string), typeof(string), typeof(SaveMode)}),
@@ -104,6 +109,12 @@ namespace KSPCommunityFixes
             }
 
             return code;
+        }
+
+        static bool SceneTransitionMatrix_GetTransitionValue_Prefix(out bool __result)
+        {
+            __result = false;
+            return false;
         }
 
         private static void CachePersistentSFS(string saveFileName, string saveFolder, ConfigNode configNode)

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ User options are available from the "ESC" in-game settings menu :<br/><img src="
 
 #### Performance tweaks 
 
-- **SceneLoadSpeedBoost** [KSP 1.8.0 - 1.12.5]<br/>Reduce scene switches loading time with large/modded saves by caching the current save in memory instead of loading it from disk.
+- **SceneLoadSpeedBoost** [KSP 1.8.0 - 1.12.5]<br/>Reduce scene switches loading time with large/modded saves by caching the current save in memory instead of loading it from disk. Additionally forces all scene transitions to happen synchronously.
 - **OnDemandPartBuoyancy** [KSP 1.8.0 - 1.12.5]<br/>Prevent the part buoyancy integrator from running when not needed. Improves performance for large part count vessels while in the SOI of a body that has an ocean (Kerbin, Eve, Laythe...)
 - [**FastLoader**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/108) [KSP 1.12.3 - 1.12.5]<br/>Complete rewrite of the KSP asset/part loader : prevent GPU framerate limits from affecting loading speed, implement multithreaded asset loading (20% to 40% speedup depending on CPU & storage specs), provides an opt-in mechanism for caching PNG textures in the DXT5 format, also implements loading of additional DDS formats (see **BetterDDSSupport** patch in the API/modding tools section).
 - **PQSUpdateNoMemoryAlloc** [KSP 1.11.0 - 1.12.5]<br/> Prevent huge memory allocations and resulting occasional stutter on PQS creation happening when moving around near a body surface.
@@ -189,6 +189,9 @@ The `Start` action of the IDE will trigger a build, update the `GameData` files 
 If doing so in the `Debug` configuration and if your KSP install is modified to be debuggable, you will be able to debug the code from within your IDE (if your IDE provides Unity debugging support).
 
 ### Changelog
+
+##### 1.36.0
+- **SceneLoadSpeedBoost** : Reduce scene switch times further by forcing them to happen synchronously.
 
 ##### 1.35.2
 - **FastLoader** : Fixed a regression introduced in 1.35.1, causing PNG normal maps to be generated with empty mipmaps.


### PR DESCRIPTION
Adds another change under the `SceneLoadSpeedBoost` umbrella. Forces all scene changes to happen synchronously which on some scenes can significantly lower load times. In my own testing with RP-1 I saw 4-4.5 seconds shaved off from SC -> VAB and VAB -> flight transitions. Others reported even 6-7s improvements.
The main speedup comes from asset cleanup running once instead of 3 times. However even if the async code path was forced to run cleanup only once, it was still close to 1s slower than the sync path.