### PR TITLE
FlightIntegrator and friends micro-optimization Round 2

### DIFF
--- a/GameData/KSPCommunityFixes/KSPCommunityFixes.version
+++ b/GameData/KSPCommunityFixes/KSPCommunityFixes.version
@@ -2,7 +2,7 @@
   "NAME": "KSPCommunityFixes",
   "URL": "https://raw.githubusercontent.com/KSPModdingLibs/KSPCommunityFixes/master/GameData/KSPCommunityFixes/KSPCommunityFixes.version",
   "DOWNLOAD": "https://github.com/KSPModdingLibs/KSPCommunityFixes/releases",
-  "VERSION": {"MAJOR": 1, "MINOR": 35, "PATCH": 0, "BUILD": 0},
+  "VERSION": {"MAJOR": 1, "MINOR": 35, "PATCH": 1, "BUILD": 0},
   "KSP_VERSION": {"MAJOR": 1, "MINOR": 12, "PATCH": 5},
   "KSP_VERSION_MIN": {"MAJOR": 1, "MINOR": 8, "PATCH": 0},
   "KSP_VERSION_MAX": {"MAJOR": 1, "MINOR": 12, "PATCH": 5}

--- a/GameData/KSPCommunityFixes/KSPCommunityFixes.version
+++ b/GameData/KSPCommunityFixes/KSPCommunityFixes.version
@@ -2,7 +2,7 @@
   "NAME": "KSPCommunityFixes",
   "URL": "https://raw.githubusercontent.com/KSPModdingLibs/KSPCommunityFixes/master/GameData/KSPCommunityFixes/KSPCommunityFixes.version",
   "DOWNLOAD": "https://github.com/KSPModdingLibs/KSPCommunityFixes/releases",
-  "VERSION": {"MAJOR": 1, "MINOR": 35, "PATCH": 1, "BUILD": 0},
+  "VERSION": {"MAJOR": 1, "MINOR": 35, "PATCH": 2, "BUILD": 0},
   "KSP_VERSION": {"MAJOR": 1, "MINOR": 12, "PATCH": 5},
   "KSP_VERSION_MIN": {"MAJOR": 1, "MINOR": 8, "PATCH": 0},
   "KSP_VERSION_MAX": {"MAJOR": 1, "MINOR": 12, "PATCH": 5}

--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -420,6 +420,10 @@ KSP_COMMUNITY_FIXES
   // state synchronization and caching solar panels scaled space raycasts results.
   OptimizedModuleRaycasts = true
 
+  // General micro-optimization of FlightIntegrator and VesselPrecalculate, significantely increase
+  // framerate in large part count situations.
+  FlightPerf = true
+
   // ##########################
   // Modding
   // ##########################

--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -420,14 +420,6 @@ KSP_COMMUNITY_FIXES
   // state synchronization and caching solar panels scaled space raycasts results.
   OptimizedModuleRaycasts = true
 
-  // General micro-optimization of FlightIntegrator and VesselPrecalculate. This has a significant impact in
-  // large part count situations, and especially in atmospheric situations.
-  FlightIntegratorPerf = true
-
-  // General micro-optimization of floating origin shifts. Main benefit is in large particle count situations
-  // but this helps a bit in other cases as well.
-  FloatingOriginPerf = true
-
   // Faster lookup of other docking nodes
   ModuleDockingNodeFindOtherNodesFaster = true
 
@@ -435,11 +427,19 @@ KSP_COMMUNITY_FIXES
   CollisionEnhancerFastUpdate = true
 
   // Micro-optimization of various flight scene auxiliary subsystems : temperature gauges, highlighter, 
-  // volume normalizer, strut position tracking...
+  // strut position tracking...
   PartSystemsFastUpdate = true
 
-  // Various small performance patches
+  // Various small performance patches (volume normalizer, eva module checks)
   MinorPerfTweaks = true
+
+  // General micro-optimization of FlightIntegrator and VesselPrecalculate. This has a significant impact in
+  // large part count situations, and especially in atmospheric situations.
+  FlightIntegratorPerf = false
+
+  // General micro-optimization of floating origin shifts. Main benefit is in large particle count situations
+  // but this helps a bit in other cases as well.
+  FloatingOriginPerf = false
 
   // ##########################
   // Modding

--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -420,9 +420,13 @@ KSP_COMMUNITY_FIXES
   // state synchronization and caching solar panels scaled space raycasts results.
   OptimizedModuleRaycasts = true
 
-  // General micro-optimization of FlightIntegrator, VesselPrecalculate and FloatingOrigin, significantely 
-  // increase framerate in large part count situations.
-  FlightCoreSystemsPerf = true
+  // General micro-optimization of FlightIntegrator and VesselPrecalculate. This has a significant impact in
+  // large part count situations, and especially in atmospheric situations.
+  FlightIntegratorPerf = true
+
+  // General micro-optimization of floating origin shifts. Main benefit is in large particle count situations
+  // but this helps a bit in other cases as well.
+  FloatingOriginPerf = true
 
   // Faster lookup of other docking nodes
   ModuleDockingNodeFindOtherNodesFaster = true
@@ -434,7 +438,7 @@ KSP_COMMUNITY_FIXES
   // volume normalizer, strut position tracking...
   PartSystemsFastUpdate = true
 
-  // Various small patches on hot loop methods
+  // Various small performance patches
   MinorPerfTweaks = true
 
   // ##########################

--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -484,6 +484,4 @@ KSP_COMMUNITY_FIXES
   //   the generated template will reuse existing translated strings.
 
   // GenerateLocTemplate = en-us
-
-  OverrideTests = true
 }

--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -432,7 +432,7 @@ KSP_COMMUNITY_FIXES
 
   // Micro-optimization of various flight scene auxiliary subsystems : temperature gauges, highlighter, 
   // volume normalizer, strut position tracking...
-  AuxiliarySystemsFastUpdate = true
+  PartSystemsFastUpdate = true
 
   // Various small patches on hot loop methods
   MinorPerfTweaks = true
@@ -484,4 +484,6 @@ KSP_COMMUNITY_FIXES
   //   the generated template will reuse existing translated strings.
 
   // GenerateLocTemplate = en-us
+
+  OverrideTests = true
 }

--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -420,9 +420,22 @@ KSP_COMMUNITY_FIXES
   // state synchronization and caching solar panels scaled space raycasts results.
   OptimizedModuleRaycasts = true
 
-  // General micro-optimization of FlightIntegrator and VesselPrecalculate, significantely increase
-  // framerate in large part count situations.
-  FlightPerf = true
+  // General micro-optimization of FlightIntegrator, VesselPrecalculate and FloatingOrigin, significantely 
+  // increase framerate in large part count situations.
+  FlightCoreSystemsPerf = true
+
+  // Faster lookup of other docking nodes
+  ModuleDockingNodeFindOtherNodesFaster = true
+
+  // Micro-optimizations of the CollisionEnhancer component, significant impact in high part count situations
+  CollisionEnhancerFastUpdate = true
+
+  // Micro-optimization of various flight scene auxiliary subsystems : temperature gauges, highlighter, 
+  // volume normalizer, strut position tracking...
+  AuxiliarySystemsFastUpdate = true
+
+  // Various small patches on hot loop methods
+  MinorPerfTweaks = true
 
   // ##########################
   // Modding

--- a/KSPCommunityFixes/BasePatch.cs
+++ b/KSPCommunityFixes/BasePatch.cs
@@ -1,9 +1,15 @@
-﻿using System;
+﻿using HarmonyLib;
+using Mono.Cecil.Cil;
+using MonoMod.Utils;
+using MonoMod.Utils.Cil;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
-using HarmonyLib;
+using System.Reflection.Emit;
 using UnityEngine;
+using static MonoMod.Utils.Cil.CecilILGenerator;
+using MethodBody = Mono.Cecil.Cil.MethodBody;
 
 namespace KSPCommunityFixes
 {
@@ -22,6 +28,15 @@ namespace KSPCommunityFixes
         {
             order = 0;
         }
+    }
+
+    /// <summary>
+    /// When applied to an override patch method, the patch method body will be transpiled into patched method body,
+    /// even in a debug configuration.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    internal class TranspileInDebugAttribute : Attribute
+    {
     }
 
     public abstract class BasePatch
@@ -54,19 +69,31 @@ namespace KSPCommunityFixes
                 return;
             }
 
+            bool patchApplied;
             try
             {
-                patch.ApplyHarmonyPatch();
-                Debug.Log($"[KSPCommunityFixes] Patch {patchType.Name} applied.");
+                patchApplied = patch.ApplyHarmonyPatch();
+                
             }
             catch (Exception e)
             {
-                Debug.LogError($"[KSPCommunityFixes] Patch {patchType.Name} not applied : {e}");
+                patchApplied = false;
+                Debug.LogException(e);
+            }
+
+            if (!patchApplied)
+            {
+                Debug.LogError($"[KSPCommunityFixes] Patch {patchType.Name} applied, error applying patch");
                 KSPCommunityFixes.enabledPatches.Remove(patchType.Name);
                 return;
             }
+            else
+            {
+                Debug.Log($"[KSPCommunityFixes] Patch {patchType.Name} applied.");
+                KSPCommunityFixes.patchInstances.Add(patchType, patch);
+            }
 
-            KSPCommunityFixes.patchInstances.Add(patchType, patch);
+            
             patch.LoadData();
         }
 
@@ -76,15 +103,27 @@ namespace KSPCommunityFixes
             Postfix,
             Transpiler,
             Finalizer,
-            ReversePatch
+            ReversePatch,
+            /// <summary>
+            /// The patch method body will be directly transpiled into the patched method body. <para/>
+            /// This is functionally similar as a "return false" prefix, but avoid some call overhead with prefixes.<para/>
+            /// It also mean the patched method cannot be transpiled by another patch, and that prefixes for that method will work as usual (which isn't the case with "return false" prefixes).<para/>
+            /// The patch method must be static, it must have the same return type and the same arguments in the same order as the patched method.<para/>
+            /// When the patched method is an instance method, the patch method must have the instance as an extra first argument (the name the argument doesn't matter).<para/>
+            /// When building in a debug configuration, the patch method will be called from the transpiler, allowing to put breakpoints on it.<para/>
+            /// In a release configuration, or if the patch has the [TranspileInDebug] attribute, the patch method is not called and can't be debugged.<para/> 
+            /// </summary>
+            Override
         }
 
         protected class PatchInfo
         {
             public PatchMethodType patchType;
             public MethodBase patchedMethod;
+            public string patchMethodName;
             public MethodInfo patchMethod;
             public int patchPriority;
+            public bool debugOverride = false;
 
             /// <summary>
             /// Define a harmony patch
@@ -93,22 +132,14 @@ namespace KSPCommunityFixes
             /// <param name="patchedMethod">Method to be patched</param>
             /// <param name="patchClass">Class where the patch method is implemented. Usually "this"</param>
             /// <param name="patchMethodName">if null, will default to a method with the name "ClassToPatch_MethodToPatch_PatchType"</param>
-            public PatchInfo(PatchMethodType patchType, MethodBase patchedMethod, BasePatch patchClass, string patchMethodName = null, int patchPriority = Priority.Normal)
+            public PatchInfo(PatchMethodType patchType, MethodBase patchedMethod, string patchMethodName = null, int patchPriority = Priority.Normal)
             {
-                if (patchedMethod == null)
-                    throw new Exception($"{patchType} target method not found in {patchClass}");
-
                 this.patchType = patchType;
                 this.patchedMethod = patchedMethod;
+                this.patchMethodName = patchMethodName;
                 this.patchPriority = patchPriority;
 
-                if (patchMethodName == null)
-                    patchMethodName = this.patchedMethod.DeclaringType.Name + "_" + this.patchedMethod.Name + "_" + this.patchType;
 
-                patchMethod = AccessTools.Method(patchClass.GetType(), patchMethodName);
-
-                if (patchMethod == null)
-                    throw new Exception($"{patchMethodName} implementation method not found in {patchClass}");
             }
         }
 
@@ -131,22 +162,79 @@ namespace KSPCommunityFixes
 
         public bool IsVersionValid => KSPCommunityFixes.KspVersion >= VersionMin && KSPCommunityFixes.KspVersion <= VersionMax;
 
-        private void ApplyHarmonyPatch()
+        private bool ApplyHarmonyPatch()
         {
             List<PatchInfo> patches = new List<PatchInfo>();
             ApplyPatches(patches);
+
+            bool error = false;
+            for (int i = 0; i < patches.Count; i++)
+            {
+                PatchInfo patch = patches[i];
+
+                if (patch.patchedMethod == null)
+                {
+                    error = true;
+                    Debug.LogWarning($"[{GetType()}] Target method not for found for {patch.patchType} patch at index {i}");
+                    continue;
+                }
+
+                if (patch.patchMethodName == null)
+                    patch.patchMethodName = patch.patchedMethod.DeclaringType.Name + "_" + patch.patchedMethod.Name + "_" + patch.patchType;
+
+                patch.patchMethod = AccessTools.Method(GetType(), patch.patchMethodName);
+
+                if (patch.patchMethod == null)
+                {
+                    error = true;
+                    Debug.LogWarning($"[{GetType()}] Patch {patch.patchMethodName} implementation method not found for patched method {patch.patchedMethod.FullDescription()}");
+                    continue;
+                }
+
+                if (patch.patchType == PatchMethodType.Override)
+                {
+#if DEBUG
+                    patch.debugOverride = Attribute.GetCustomAttributes(patch.patchMethod, typeof(TranspileInDebugAttribute), false).Length == 0;
+#endif
+                    if (!overrides.TryAdd(patch.patchedMethod, patch))
+                    {
+                        error = true;
+                        MethodInfo existingPatch = overrides[patch.patchedMethod].patchMethod;
+                        Debug.LogWarning($"[{GetType()}] Override for method '{patch.patchedMethod.FullDescription()}' wasn't applied because it has already been overriden by patch '{existingPatch.DeclaringType.FullName}'");
+                        continue;
+                    }
+                }
+            }
+
+            if (error)
+                return false;
 
             foreach (PatchInfo patch in patches)
             {
                 switch (patch.patchType)
                 {
-                    case PatchMethodType.Prefix: KSPCommunityFixes.Harmony.Patch(patch.patchedMethod, new HarmonyMethod(patch.patchMethod, patch.patchPriority)); break;
-                    case PatchMethodType.Postfix: KSPCommunityFixes.Harmony.Patch(patch.patchedMethod, null, new HarmonyMethod(patch.patchMethod, patch.patchPriority)); break;
-                    case PatchMethodType.Transpiler: KSPCommunityFixes.Harmony.Patch(patch.patchedMethod, null, null, new HarmonyMethod(patch.patchMethod, patch.patchPriority)); break;
-                    case PatchMethodType.Finalizer: KSPCommunityFixes.Harmony.Patch(patch.patchedMethod, null, null, null, new HarmonyMethod(patch.patchMethod, patch.patchPriority)); break;
-                    case PatchMethodType.ReversePatch: KSPCommunityFixes.Harmony.CreateReversePatcher(patch.patchedMethod, new HarmonyMethod(patch.patchMethod, patch.patchPriority)); break;
+                    case PatchMethodType.Prefix:
+                        KSPCommunityFixes.Harmony.Patch(patch.patchedMethod, new HarmonyMethod(patch.patchMethod, patch.patchPriority));
+                        break;
+                    case PatchMethodType.Postfix:
+                        KSPCommunityFixes.Harmony.Patch(patch.patchedMethod, null, new HarmonyMethod(patch.patchMethod, patch.patchPriority));
+                        break;
+                    case PatchMethodType.Transpiler:
+                        KSPCommunityFixes.Harmony.Patch(patch.patchedMethod, null, null, new HarmonyMethod(patch.patchMethod, patch.patchPriority));
+                        break;
+                    case PatchMethodType.Finalizer:
+                        KSPCommunityFixes.Harmony.Patch(patch.patchedMethod, null, null, null, new HarmonyMethod(patch.patchMethod, patch.patchPriority));
+                        break;
+                    case PatchMethodType.ReversePatch:
+                        KSPCommunityFixes.Harmony.CreateReversePatcher(patch.patchedMethod, new HarmonyMethod(patch.patchMethod, patch.patchPriority));
+                        break;
+                    case PatchMethodType.Override:
+                        KSPCommunityFixes.Harmony.Patch(patch.patchedMethod, null, null, new HarmonyMethod(overrideTranspiler, patch.patchPriority));
+                        break;
                 }
             }
+
+            return true;
         }
 
         private void LoadData()
@@ -186,7 +274,9 @@ namespace KSPCommunityFixes
         /// Called after a the patch has been applied during loading
         /// Get custom data that was saved using SaveData()
         /// </summary>
-        protected virtual void OnLoadData(ConfigNode node) { }
+        protected virtual void OnLoadData(ConfigNode node)
+        {
+        }
 
         /// <summary>
         /// Call this to save custom patch-specific data that will be reloaded on the next KSP launch (see OnLoadData())
@@ -204,6 +294,118 @@ namespace KSPCommunityFixes
             ConfigNode topNode = new ConfigNode();
             topNode.AddNode(patchName, node);
             topNode.Save(Path.Combine(pluginDataPath, patchName + ".cfg"));
+        }
+
+        private static readonly MethodInfo overrideTranspiler = AccessTools.Method(typeof(BasePatch), nameof(OverrideTranspiler));
+
+        /// <summary> key : patched method, value : replacement method </summary>
+        private static Dictionary<MethodBase, PatchInfo> overrides = new Dictionary<MethodBase, PatchInfo>();
+
+        private static IEnumerable<CodeInstruction> OverrideTranspiler(IEnumerable<CodeInstruction> _, ILGenerator patchGen, MethodBase __originalMethod)
+        {
+            if (!overrides.TryGetValue(__originalMethod, out PatchInfo patch))
+                throw new Exception($"Could not find override method for patched method {__originalMethod.FullDescription()}");
+
+            if (patch.debugOverride)
+            {
+                int instanceArg = __originalMethod.IsStatic ? 0 : 1;
+                int paramCount = instanceArg + __originalMethod.GetParameters().Length;
+                CodeInstruction[] debugIl = new CodeInstruction[paramCount + 2];
+
+                int i;
+                for (i = 0; i < paramCount; i++)
+                {
+                    switch (i)
+                    {
+                        case 0: debugIl[0] = new CodeInstruction(OpCodes.Ldarg_0); break;
+                        case 1: debugIl[1] = new CodeInstruction(OpCodes.Ldarg_1); break;
+                        case 2: debugIl[2] = new CodeInstruction(OpCodes.Ldarg_2); break;
+                        case 3: debugIl[3] = new CodeInstruction(OpCodes.Ldarg_3); break;
+                        default: debugIl[i] = new CodeInstruction(OpCodes.Ldarg_S, (byte)i); break;
+                    }
+                }
+
+                debugIl[i++] = new CodeInstruction(OpCodes.Call, patch.patchMethod);
+                debugIl[i] = new CodeInstruction(OpCodes.Ret);
+                return debugIl;
+            }
+
+            List<CodeInstruction> il = PatchProcessor.GetOriginalInstructions(patch.patchMethod, out ILGenerator overrideGen);
+
+            CecilILGenerator patchCecilGen = patchGen.GetProxiedShim<CecilILGenerator>();
+            CecilILGenerator overrideCecilGen = overrideGen.GetProxiedShim<CecilILGenerator>();
+
+            patchCecilGen._LabelInfos.Clear();
+            foreach (KeyValuePair<Label, LabelInfo> item in overrideCecilGen._LabelInfos)
+                patchCecilGen._LabelInfos.Add(item.Key, item.Value);
+
+            patchCecilGen._Variables.Clear();
+            foreach (KeyValuePair<LocalBuilder, VariableDefinition> item in overrideCecilGen._Variables)
+                patchCecilGen._Variables.Add(item.Key, item.Value);
+
+            patchCecilGen._LabelsToMark.Clear();
+            patchCecilGen._LabelsToMark.AddRange(overrideCecilGen._LabelsToMark);
+
+            patchCecilGen._ExceptionHandlersToMark.Clear();
+            patchCecilGen._ExceptionHandlersToMark.AddRange(overrideCecilGen._ExceptionHandlersToMark);
+
+            patchCecilGen._ExceptionHandlers.Clear();
+            ExceptionHandlerChain[] exceptionHandlerChains = overrideCecilGen._ExceptionHandlers.ToArray();
+            for (int i = exceptionHandlerChains.Length; i-- > 0;)
+                patchCecilGen._ExceptionHandlers.Push(exceptionHandlerChains[i]);
+
+            patchCecilGen._ILOffset = overrideCecilGen._ILOffset;
+            patchCecilGen.labelCounter = overrideCecilGen.labelCounter;
+
+            MethodBody patchBody = patchCecilGen.IL.Body;
+            MethodBody overrideBody = overrideCecilGen.IL.Body;
+
+            patchBody.ExceptionHandlers.Clear();
+            patchBody.Variables.Clear();
+            patchBody.ExceptionHandlers.AddRange(overrideBody.ExceptionHandlers);
+            patchBody.Variables.AddRange(overrideBody.Variables);
+
+            return il;
+        }
+
+        public static void XValueArgTest6(double a, double test, double c, double d, double e, double f)
+        {
+            XValueArgTest6(a, test, c, d, e, f);
+        }
+
+        public static void XValueArgTestLong(double a, double test, double c, double d, double e, double f, double g, double k, double z, double t, double p, double et, double po, double ty, double pp, double ks)
+        {
+            XValueArgTestLong(a, test, c, d, e, f, g, k, z, t, p, et, po, ty, pp, ks);
+        }
+
+        public static void XRefArgTest(double a, double test)
+        {
+            XRefArgTest(a, test);
+        }
+
+        public static void XOutValueArgTest(double a, out double test)
+        {
+            XOutValueArgTest(a,out test);
+        }
+
+        public static void XRefValueArgTest(double a, ref double test)
+        {
+            XRefValueArgTest(a,ref test);
+        }
+
+        public static void XOutRefArgTest(double a, out string test)
+        {
+            XOutRefArgTest(a,out test);
+        }
+
+        public static void XRefRefArgTest(double a, ref string test)
+        {
+            XRefRefArgTest(a,ref test);
+        }
+
+        public static void XParamArgTest(params double[] args)
+        {
+            XParamArgTest(args);
         }
     }
 }

--- a/KSPCommunityFixes/BasePatch.cs
+++ b/KSPCommunityFixes/BasePatch.cs
@@ -1,6 +1,7 @@
-﻿using HarmonyLib;
+﻿// #define DEBUG_OVERRIDE
+
+using HarmonyLib;
 using Mono.Cecil.Cil;
-using MonoMod.Utils;
 using MonoMod.Utils.Cil;
 using System;
 using System.Collections.Generic;
@@ -9,7 +10,9 @@ using System.Reflection;
 using System.Reflection.Emit;
 using UnityEngine;
 using static MonoMod.Utils.Cil.CecilILGenerator;
-using MethodBody = Mono.Cecil.Cil.MethodBody;
+using Label = System.Reflection.Emit.Label;
+using OpCode = System.Reflection.Emit.OpCode;
+using Version = System.Version;
 
 namespace KSPCommunityFixes
 {
@@ -111,7 +114,7 @@ namespace KSPCommunityFixes
             /// This is functionally similar as a "return false" prefix, but avoid some call overhead with prefixes.<para/>
             /// It also mean the patched method cannot be transpiled by another patch, and that prefixes for that method will work as usual (which isn't the case with "return false" prefixes).<para/>
             /// The patch method must be static, it must have the same return type and the same arguments in the same order as the patched method.<para/>
-            /// When the patched method is an instance method, the patch method must have the instance as an extra first argument (the name the argument doesn't matter).<para/>
+            /// When the patched method is an instance method, the patch method must have the instance as an extra first argument (the name of the argument doesn't matter).<para/>
             /// When building in a debug configuration, the patch method will be called from the transpiler, allowing to put breakpoints on it.<para/>
             /// In a release configuration, or if the patch has the [TranspileInDebug] attribute, the patch method is not called and can't be debugged.<para/> 
             /// </summary>
@@ -321,6 +324,7 @@ namespace KSPCommunityFixes
                 throw new Exception($"Could not find override method for patched method {__originalMethod.FullDescription()}");
 
             // When we want to be able to debug the override method, we generate transpiler that is calling it
+#if !DEBUG_OVERRIDE
             if (patch.debugOverride)
             {
                 int instanceArg = __originalMethod.IsStatic ? 0 : 1;
@@ -344,6 +348,7 @@ namespace KSPCommunityFixes
                 debugIl[i] = new CodeInstruction(OpCodes.Ret);
                 return debugIl;
             }
+#endif
 
             // Otherwise, we want to return all instructions of the override method.
             // We call an Harmony library method (GetOriginalInstructions) that return the IL and a matching ILGenerator for
@@ -357,42 +362,337 @@ namespace KSPCommunityFixes
             // This however mean that this is very likely to break on updating MonoMod/Harmony, and as a matter of fact, will
             // definitely break if we start using Harmony 2.3+, which is based on a new major version of MonoMod where all this
             // stuff has been heavily refactored.
-            List<CodeInstruction> il = PatchProcessor.GetOriginalInstructions(patch.patchMethod, out ILGenerator overrideGen);
+            List<CodeInstruction> overrideIl = PatchProcessor.GetOriginalInstructions(patch.patchMethod, out ILGenerator overrideGen);
+            PatchProcessor.GetOriginalInstructions(__originalMethod, out ILGenerator originalGen);
 
             CecilILGenerator patchCecilGen = patchGen.GetProxiedShim<CecilILGenerator>();
             CecilILGenerator overrideCecilGen = overrideGen.GetProxiedShim<CecilILGenerator>();
+            CecilILGenerator originalCecilGen = originalGen.GetProxiedShim<CecilILGenerator>();
 
-            patchCecilGen._LabelInfos.Clear();
+            Dictionary<int, int> modifiedOverrideLabelIndices = new Dictionary<int, int>(overrideCecilGen.labelCounter);
             foreach (KeyValuePair<Label, LabelInfo> item in overrideCecilGen._LabelInfos)
-                patchCecilGen._LabelInfos.Add(item.Key, item.Value);
+            {
+                Label label = item.Key;
+                int currentIndex = label.label;
+                while (patchCecilGen._LabelInfos.ContainsKey(label) || overrideCecilGen._LabelInfos.ContainsKey(label))
+                    label.label++;
 
-            patchCecilGen._Variables.Clear();
-            foreach (KeyValuePair<LocalBuilder, VariableDefinition> item in overrideCecilGen._Variables)
-                patchCecilGen._Variables.Add(item.Key, item.Value);
+                if (currentIndex != label.label)
+                    modifiedOverrideLabelIndices.Add(currentIndex, label.label);
 
-            patchCecilGen._LabelsToMark.Clear();
-            patchCecilGen._LabelsToMark.AddRange(overrideCecilGen._LabelsToMark);
+                patchCecilGen._LabelInfos.Add(label, item.Value);
+            }
 
-            patchCecilGen._ExceptionHandlersToMark.Clear();
-            patchCecilGen._ExceptionHandlersToMark.AddRange(overrideCecilGen._ExceptionHandlersToMark);
+            patchCecilGen.labelCounter = patchCecilGen._LabelInfos.Count;
 
-            patchCecilGen._ExceptionHandlers.Clear();
-            ExceptionHandlerChain[] exceptionHandlerChains = overrideCecilGen._ExceptionHandlers.ToArray();
-            for (int i = exceptionHandlerChains.Length; i-- > 0;)
-                patchCecilGen._ExceptionHandlers.Push(exceptionHandlerChains[i]);
+            int originalVariableCount = originalCecilGen._Variables.Count;
+            int variableOffset = patchCecilGen._Variables.Count;
+            Dictionary<int, int> modifiedOverrideVariableIndexes = new Dictionary<int, int>(overrideCecilGen._Variables.Count);
 
-            patchCecilGen._ILOffset = overrideCecilGen._ILOffset;
-            patchCecilGen.labelCounter = overrideCecilGen.labelCounter;
+            LocalBuilder[] patchLocalBuildersByLocalIndex = new LocalBuilder[patchCecilGen._Variables.Count];
+            foreach (LocalBuilder key in patchCecilGen._Variables.Keys)
+                patchLocalBuildersByLocalIndex[key.position] = key;
 
-            MethodBody patchBody = patchCecilGen.IL.Body;
-            MethodBody overrideBody = overrideCecilGen.IL.Body;
+            foreach (KeyValuePair<LocalBuilder, VariableDefinition> variableDef in overrideCecilGen._Variables)
+            {
+                int currentIndex = variableDef.Value.index;
+                
+                if (currentIndex < originalVariableCount)
+                {
+                    // if override variable index is within the range of the original variables, keep the index
+                    // but update the variable in the patch generator.
+                    LocalBuilder patchVariableKey = patchLocalBuildersByLocalIndex[currentIndex];
+                    LocalBuilder overrideLocalBuilder = variableDef.Key;
+                    patchVariableKey.position = overrideLocalBuilder.position;
+                    patchVariableKey.type = overrideLocalBuilder.type;
+                    patchVariableKey.is_pinned = overrideLocalBuilder.is_pinned;
+                    patchCecilGen._Variables[patchVariableKey] = variableDef.Value;
+                    patchCecilGen.IL.Body.Variables[currentIndex] = variableDef.Value;
+                }
+                else
+                {
+                    // else, update the index to the next unused, and add the variable to the patch generator
+                    int newIndex = variableOffset + modifiedOverrideVariableIndexes.Count;
+                    LocalBuilder newBuilderRef = patchGen.DeclareLocal(variableDef.Key.LocalType, variableDef.Key.IsPinned);
+                    if (currentIndex != newBuilderRef.position)
+                        modifiedOverrideVariableIndexes.Add(currentIndex, newIndex);
+                }
+            }
 
-            patchBody.ExceptionHandlers.Clear();
-            patchBody.Variables.Clear();
-            patchBody.ExceptionHandlers.AddRange(overrideBody.ExceptionHandlers);
-            patchBody.Variables.AddRange(overrideBody.Variables);
+            for (int i = overrideIl.Count; i-- > 0;)
+            {
+                CodeInstruction instruction = overrideIl[i];
+                for (int j = instruction.labels.Count; j-- > 0;)
+                {
+                    Label jumpLocation = instruction.labels[j];
+                    if (modifiedOverrideLabelIndices.TryGetValue(jumpLocation.label, out int newIndex))
+                    {
+                        jumpLocation.label = newIndex;
+                        instruction.labels[j] = jumpLocation;
+                    }
+                }
 
-            return il;
+                if (instruction.operand is Label jumpTo)
+                {
+                    if (modifiedOverrideLabelIndices.TryGetValue(jumpTo.label, out int newIndex))
+                    {
+                        jumpTo.label = newIndex;
+                        instruction.operand = jumpTo;
+                    }
+                }
+
+                OpCode opCode = instruction.opcode;
+                if (opCode == OpCodes.Stloc || opCode == OpCodes.Stloc_S)
+                {
+                    int currentVariableIdx;
+                    if (instruction.operand is LocalBuilder localBuilder)
+                        currentVariableIdx = localBuilder.LocalIndex;
+                    else
+                        currentVariableIdx = (int)instruction.operand;
+
+                    int newIndex = modifiedOverrideVariableIndexes.GetValueOrDefault(currentVariableIdx, currentVariableIdx);
+
+                    if (newIndex > byte.MaxValue && opCode == OpCodes.Stloc_S)
+                        instruction.opcode = OpCodes.Stloc;
+
+                    if (opCode == OpCodes.Stloc_S)
+                        instruction.operand = (byte)newIndex;
+                    else
+                        instruction.operand = newIndex;
+                }
+                else if (opCode == OpCodes.Stloc_0)
+                {
+                    int newIndex = modifiedOverrideVariableIndexes.GetValueOrDefault(0, 0);
+                    SetStlocForIndex(instruction, newIndex);
+                }
+                else if (opCode == OpCodes.Stloc_1)
+                {
+                    int newIndex = modifiedOverrideVariableIndexes.GetValueOrDefault(1, 1);
+                    SetStlocForIndex(instruction, newIndex);
+                }
+                else if (opCode == OpCodes.Stloc_2)
+                {
+                    int newIndex = modifiedOverrideVariableIndexes.GetValueOrDefault(2, 2);
+                    SetStlocForIndex(instruction, newIndex);
+                }
+                else if (opCode == OpCodes.Stloc_3)
+                {
+                    int newIndex = modifiedOverrideVariableIndexes.GetValueOrDefault(3, 3);
+                    SetStlocForIndex(instruction, newIndex);
+                }
+                else if (opCode == OpCodes.Ldloca || opCode == OpCodes.Ldloca_S || opCode == OpCodes.Ldloc || opCode == OpCodes.Ldloc_S)
+                {
+                    int currentVariableIdx;
+                    if (instruction.operand is LocalBuilder localBuilder)
+                        currentVariableIdx = localBuilder.LocalIndex;
+                    else
+                        currentVariableIdx = (int)instruction.operand;
+
+                    if (!modifiedOverrideVariableIndexes.TryGetValue(currentVariableIdx, out int newIndex))
+                        newIndex = currentVariableIdx;
+
+                    if (newIndex > byte.MaxValue)
+                    {
+                        if (opCode == OpCodes.Ldloca_S)
+                            instruction.opcode = OpCodes.Ldloca;
+                        else if (opCode == OpCodes.Stloc_S)
+                            instruction.opcode = OpCodes.Stloc;
+                    }
+
+                    if (opCode == OpCodes.Stloc_S || opCode == OpCodes.Ldloca_S)
+                        instruction.operand = (byte)newIndex;
+                    else
+                        instruction.operand = newIndex;
+                }
+                else if (opCode == OpCodes.Ldloc_0)
+                {
+                    int newIndex = modifiedOverrideVariableIndexes.GetValueOrDefault(0, 0);
+                    SetLdlocForIndex(instruction, newIndex);
+                }
+                else if (opCode == OpCodes.Ldloc_1)
+                {
+                    int newIndex = modifiedOverrideVariableIndexes.GetValueOrDefault(1, 1);
+                    SetLdlocForIndex(instruction, newIndex);
+                }
+                else if (opCode == OpCodes.Ldloc_2)
+                {
+                    int newIndex = modifiedOverrideVariableIndexes.GetValueOrDefault(2, 2);
+                    SetLdlocForIndex(instruction, newIndex);
+                }
+                else if (opCode == OpCodes.Ldloc_3)
+                {
+                    int newIndex = modifiedOverrideVariableIndexes.GetValueOrDefault(3, 3);
+                    SetLdlocForIndex(instruction, newIndex);
+                }
+            }
+
+            return overrideIl;
+        }
+
+        private static void SetStlocForIndex(CodeInstruction instruction, int varIndex)
+        {
+            if (varIndex == 0)
+            {
+                instruction.opcode = OpCodes.Stloc_0;
+            }
+            else if (varIndex == 1)
+            {
+                instruction.opcode = OpCodes.Stloc_1;
+            }
+            else if (varIndex == 2)
+            {
+                instruction.opcode = OpCodes.Stloc_2;
+            }
+            else if (varIndex == 3)
+            {
+                instruction.opcode = OpCodes.Stloc_3;
+            }
+            else if (varIndex < byte.MaxValue)
+            {
+                instruction.opcode = OpCodes.Stloc_S;
+                instruction.operand = varIndex;
+            }
+            else
+            {
+                instruction.opcode = OpCodes.Stloc;
+                instruction.operand = varIndex;
+            }
+        }
+
+        private static void SetLdlocForIndex(CodeInstruction instruction, int varIndex)
+        {
+            if (varIndex == 0)
+            {
+                instruction.opcode = OpCodes.Ldloc_0;
+            }
+            else if (varIndex == 1)
+            {
+                instruction.opcode = OpCodes.Ldloc_1;
+            }
+            else if (varIndex == 2)
+            {
+                instruction.opcode = OpCodes.Ldloc_2;
+            }
+            else if (varIndex == 3)
+            {
+                instruction.opcode = OpCodes.Ldloc_3;
+            }
+            else if (varIndex < byte.MaxValue)
+            {
+                instruction.opcode = OpCodes.Ldloc_S;
+                instruction.operand = varIndex;
+            }
+            else
+            {
+                instruction.opcode = OpCodes.Ldloc;
+                instruction.operand = varIndex;
+            }
         }
     }
+
+#if DEBUG_OVERRIDE
+    public class TranspilerTest : BasePatch
+    {
+        protected override bool IgnoreConfig => true;
+
+        protected override void ApplyPatches()
+        {
+            AddPatch(PatchType.Prefix, typeof(TranspilerTest), nameof(Method1));
+            AddPatch(PatchType.Postfix, typeof(TranspilerTest), nameof(Method1));
+            AddPatch(PatchType.Override, typeof(TranspilerTest), nameof(Method1));
+        }
+
+        private InstanceField testVarInstance = new InstanceField() {result = "instanceFieldValue"};
+
+        public ResultVar Method1()
+        {
+            Debug.Log("Hello from original");
+
+            if (testVarInstance.result == string.Empty)
+                return null;
+
+            try
+            {
+                LocalVarOrig localVar = new LocalVarOrig();
+                throw new Exception();
+            }
+            catch (Exception e)
+            {
+                Debug.Log("Catched exception from original");
+            }
+
+            if (testVarInstance.result == string.Empty)
+                return null;
+
+            if (testVarInstance.result == string.Empty)
+                return null;
+
+            try
+            {
+                LocalVarOrig localVar = new LocalVarOrig();
+                throw new Exception();
+            }
+            catch (Exception e)
+            {
+                Debug.Log("Catched exception from original");
+            }
+
+            return new ResultVar() { result = "origResult" };
+        }
+
+        [TranspileInDebug]
+        public static ResultVar TranspilerTest_Method1_Override(TranspilerTest __instance)
+        {
+            if (__instance.testVarInstance != null)
+                Debug.Log("Hello from override 1");
+
+            try
+            {
+                LocalVarOverride localVar = new LocalVarOverride();
+                throw new Exception();
+            }
+            catch (Exception e)
+            {
+                Debug.Log("Catched exception from override");
+            }
+
+            return new ResultVar() { result = "overrideResult" };
+        }
+
+        public static bool TranspilerTest_Method1_Prefix(TranspilerTest __instance, out StateVar __state, ref ResultVar __result)
+        {
+            Debug.Log("Hello from prefix 1");
+            __result = new ResultVar() { result = "prefixResult" };
+            __state = new StateVar();
+            __state.state = "good state !";
+            return true;
+        }
+
+        public static void TranspilerTest_Method1_Postfix(TranspilerTest __instance, InstanceField ___testVarInstance, StateVar __state, ref ResultVar __result)
+        {
+            Debug.Log($"Hello from postfix 1 : {__state.state}");
+            __result.result += "modifiedByPostfix";
+        }
+
+        public static IEnumerable<CodeInstruction> TranspilerTest_Method1_Transpiler(IEnumerable<CodeInstruction> original, ILGenerator ilGen)
+        {
+            Label label = ilGen.DefineLabel();
+            yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(TranspilerTest), nameof(Throw))).WithBlocks(new ExceptionBlock(ExceptionBlockType.BeginExceptionBlock));
+            yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(TranspilerTest), nameof(Log))).WithBlocks(new ExceptionBlock(ExceptionBlockType.BeginCatchBlock));
+            yield return new CodeInstruction(OpCodes.Leave_S, label).WithBlocks(new ExceptionBlock(ExceptionBlockType.EndExceptionBlock));
+            yield return new CodeInstruction(OpCodes.Ret).WithLabels(label);
+        }
+
+        public static void Log() => Debug.Log("Exception catched !");
+        public static void Throw() => throw new Exception();
+
+        public class InstanceField { public string result; }
+        public class ResultVar { public string result; }
+        public class LocalVarOrig { }
+        public class LocalVarPrefix { }
+        public class LocalVarPostfix { }
+        public class LocalVarOverride { }
+        public class StateVar { public string state; }
+    }
+#endif
 }

--- a/KSPCommunityFixes/BugFixes/AsteroidInfiniteMining.cs
+++ b/KSPCommunityFixes/BugFixes/AsteroidInfiniteMining.cs
@@ -15,7 +15,7 @@ namespace KSPCommunityFixes.BugFixes
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
                 AccessTools.PropertySetter(typeof(ModuleSpaceObjectInfo), nameof(ModuleSpaceObjectInfo.currentMassVal)),
-                this, nameof(ModuleSpaceObjectInfo_currentMassVal_Setter_Prefix)));
+                nameof(ModuleSpaceObjectInfo_currentMassVal_Setter_Prefix)));
         }
 
         static bool ModuleSpaceObjectInfo_currentMassVal_Setter_Prefix(ModuleSpaceObjectInfo __instance, double value)

--- a/KSPCommunityFixes/BugFixes/AsteroidInfiniteMining.cs
+++ b/KSPCommunityFixes/BugFixes/AsteroidInfiniteMining.cs
@@ -10,12 +10,11 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 10, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.PropertySetter(typeof(ModuleSpaceObjectInfo), nameof(ModuleSpaceObjectInfo.currentMassVal)),
-                nameof(ModuleSpaceObjectInfo_currentMassVal_Setter_Prefix)));
+            AddPatch(PatchType.Prefix, 
+                AccessTools.PropertySetter(typeof(ModuleSpaceObjectInfo), nameof(ModuleSpaceObjectInfo.currentMassVal)), 
+                nameof(ModuleSpaceObjectInfo_currentMassVal_Setter_Prefix));
         }
 
         static bool ModuleSpaceObjectInfo_currentMassVal_Setter_Prefix(ModuleSpaceObjectInfo __instance, double value)

--- a/KSPCommunityFixes/BugFixes/AsteroidSpawnerUniqueFlightId.cs
+++ b/KSPCommunityFixes/BugFixes/AsteroidSpawnerUniqueFlightId.cs
@@ -19,11 +19,9 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ScenarioDiscoverableObjects), nameof(ScenarioDiscoverableObjects.SpawnAsteroid))));
+            AddPatch(PatchType.Prefix, typeof(ScenarioDiscoverableObjects), nameof(ScenarioDiscoverableObjects.SpawnAsteroid));
         }
 
         static bool ScenarioDiscoverableObjects_SpawnAsteroid_Prefix(ScenarioDiscoverableObjects __instance)
@@ -52,11 +50,9 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 10, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                    PatchMethodType.Prefix,
-                    AccessTools.Method(typeof(ScenarioDiscoverableObjects), nameof(ScenarioDiscoverableObjects.SpawnComet), new Type[] {typeof(CometOrbitType) })));
+            AddPatch(PatchType.Prefix, typeof(ScenarioDiscoverableObjects), nameof(ScenarioDiscoverableObjects.SpawnComet), new Type[] {typeof(CometOrbitType) });
         }
 
         static bool ScenarioDiscoverableObjects_SpawnComet_Prefix(ScenarioDiscoverableObjects __instance, CometOrbitType cometType)

--- a/KSPCommunityFixes/BugFixes/AsteroidSpawnerUniqueFlightId.cs
+++ b/KSPCommunityFixes/BugFixes/AsteroidSpawnerUniqueFlightId.cs
@@ -23,8 +23,7 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ScenarioDiscoverableObjects), nameof(ScenarioDiscoverableObjects.SpawnAsteroid)),
-                this));
+                AccessTools.Method(typeof(ScenarioDiscoverableObjects), nameof(ScenarioDiscoverableObjects.SpawnAsteroid))));
         }
 
         static bool ScenarioDiscoverableObjects_SpawnAsteroid_Prefix(ScenarioDiscoverableObjects __instance)
@@ -57,8 +56,7 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                     PatchMethodType.Prefix,
-                    AccessTools.Method(typeof(ScenarioDiscoverableObjects), nameof(ScenarioDiscoverableObjects.SpawnComet), new Type[] {typeof(CometOrbitType) }),
-                    this));
+                    AccessTools.Method(typeof(ScenarioDiscoverableObjects), nameof(ScenarioDiscoverableObjects.SpawnComet), new Type[] {typeof(CometOrbitType) })));
         }
 
         static bool ScenarioDiscoverableObjects_SpawnComet_Prefix(ScenarioDiscoverableObjects __instance, CometOrbitType cometType)

--- a/KSPCommunityFixes/BugFixes/AutoStrutDrift.cs
+++ b/KSPCommunityFixes/BugFixes/AutoStrutDrift.cs
@@ -15,8 +15,7 @@ namespace KSPCommunityFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Part), "SecureAutoStrut", new Type[]{typeof(Part), typeof(AttachNode), typeof(AttachNode), typeof(bool)}),
-                this));
+                AccessTools.Method(typeof(Part), "SecureAutoStrut", new Type[]{typeof(Part), typeof(AttachNode), typeof(AttachNode), typeof(bool)})));
         }
 
         static void Part_SecureAutoStrut_Postfix(Part __instance, Part anchor, ref PartJoint __result)

--- a/KSPCommunityFixes/BugFixes/AutoStrutDrift.cs
+++ b/KSPCommunityFixes/BugFixes/AutoStrutDrift.cs
@@ -11,11 +11,9 @@ namespace KSPCommunityFixes
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Part), "SecureAutoStrut", new Type[]{typeof(Part), typeof(AttachNode), typeof(AttachNode), typeof(bool)})));
+            AddPatch(PatchType.Postfix, typeof(Part), "SecureAutoStrut", new Type[]{typeof(Part), typeof(AttachNode), typeof(AttachNode), typeof(bool)});
         }
 
         static void Part_SecureAutoStrut_Postfix(Part __instance, Part anchor, ref PartJoint __result)

--- a/KSPCommunityFixes/BugFixes/ChutePhantomSymmetry.cs
+++ b/KSPCommunityFixes/BugFixes/ChutePhantomSymmetry.cs
@@ -9,15 +9,11 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 10, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleParachute), nameof(ModuleParachute.OnStart))));
+            AddPatch(PatchType.Postfix, typeof(ModuleParachute), nameof(ModuleParachute.OnStart));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleParachute), nameof(ModuleParachute.OnDestroy))));
+            AddPatch(PatchType.Postfix, typeof(ModuleParachute), nameof(ModuleParachute.OnDestroy));
         }
 
         private static void ModuleParachute_OnStart_Postfix(ModuleParachute __instance, StartState state)

--- a/KSPCommunityFixes/BugFixes/ChutePhantomSymmetry.cs
+++ b/KSPCommunityFixes/BugFixes/ChutePhantomSymmetry.cs
@@ -13,13 +13,11 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleParachute), nameof(ModuleParachute.OnStart)),
-                this));
+                AccessTools.Method(typeof(ModuleParachute), nameof(ModuleParachute.OnStart))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleParachute), nameof(ModuleParachute.OnDestroy)),
-                this));
+                AccessTools.Method(typeof(ModuleParachute), nameof(ModuleParachute.OnDestroy))));
         }
 
         private static void ModuleParachute_OnStart_Postfix(ModuleParachute __instance, StartState state)

--- a/KSPCommunityFixes/BugFixes/CometMiningNotRemovingMass.cs
+++ b/KSPCommunityFixes/BugFixes/CometMiningNotRemovingMass.cs
@@ -14,8 +14,7 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleComet), nameof(ModuleComet.GetModuleMass)),
-                this));
+                AccessTools.Method(typeof(ModuleComet), nameof(ModuleComet.GetModuleMass))));
         }
 
         static bool ModuleComet_GetModuleMass_Prefix(ModuleComet __instance, float defaultMass, out float __result)

--- a/KSPCommunityFixes/BugFixes/CometMiningNotRemovingMass.cs
+++ b/KSPCommunityFixes/BugFixes/CometMiningNotRemovingMass.cs
@@ -10,11 +10,9 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 12, 2);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleComet), nameof(ModuleComet.GetModuleMass))));
+            AddPatch(PatchType.Prefix, typeof(ModuleComet), nameof(ModuleComet.GetModuleMass));
         }
 
         static bool ModuleComet_GetModuleMass_Prefix(ModuleComet __instance, float defaultMass, out float __result)

--- a/KSPCommunityFixes/BugFixes/CorrectDragForFlags.cs
+++ b/KSPCommunityFixes/BugFixes/CorrectDragForFlags.cs
@@ -13,11 +13,9 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 12, 3);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(FlagDecalBackground), nameof(FlagDecalBackground.EnableCurrentFlagMesh))));
+            AddPatch(PatchType.Postfix, typeof(FlagDecalBackground), nameof(FlagDecalBackground.EnableCurrentFlagMesh));
         }
 
         static void FlagDecalBackground_EnableCurrentFlagMesh_Postfix(FlagDecalBackground __instance)

--- a/KSPCommunityFixes/BugFixes/CorrectDragForFlags.cs
+++ b/KSPCommunityFixes/BugFixes/CorrectDragForFlags.cs
@@ -17,8 +17,7 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(FlagDecalBackground), nameof(FlagDecalBackground.EnableCurrentFlagMesh)),
-                this));
+                AccessTools.Method(typeof(FlagDecalBackground), nameof(FlagDecalBackground.EnableCurrentFlagMesh))));
         }
 
         static void FlagDecalBackground_EnableCurrentFlagMesh_Postfix(FlagDecalBackground __instance)

--- a/KSPCommunityFixes/BugFixes/DeltaVHideWhenDisabled.cs
+++ b/KSPCommunityFixes/BugFixes/DeltaVHideWhenDisabled.cs
@@ -14,38 +14,31 @@ namespace KSPCommunityFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(StageGroup), "Awake"),
-                this));
+                AccessTools.Method(typeof(StageGroup), "Awake")));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(StageManager), "Awake"),
-                this));
+                AccessTools.Method(typeof(StageManager), "Awake")));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(StageGroup), "ToggleInfoPanel", new Type[] { typeof(bool) }),
-                this));
+                AccessTools.Method(typeof(StageGroup), "ToggleInfoPanel", new Type[] { typeof(bool) })));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(NavBallBurnVector), "onGameSettingsApplied"),
-                this));
+                AccessTools.Method(typeof(NavBallBurnVector), "onGameSettingsApplied")));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(NavBallBurnVector), "onGameSettingsApplied"),
-                this));
+                AccessTools.Method(typeof(NavBallBurnVector), "onGameSettingsApplied")));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(NavBallBurnVector), "LateUpdate"),
-                this));
+                AccessTools.Method(typeof(NavBallBurnVector), "LateUpdate")));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(NavBallBurnVector), "LateUpdate"),
-                this));
+                AccessTools.Method(typeof(NavBallBurnVector), "LateUpdate")));
         }
 
         static void StageGroup_Awake_Postfix(StageGroup __instance)

--- a/KSPCommunityFixes/BugFixes/DeltaVHideWhenDisabled.cs
+++ b/KSPCommunityFixes/BugFixes/DeltaVHideWhenDisabled.cs
@@ -10,35 +10,21 @@ namespace KSPCommunityFixes
     {
         protected override Version VersionMin => new Version(1, 12, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(StageGroup), "Awake")));
+            AddPatch(PatchType.Postfix, typeof(StageGroup), "Awake");
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(StageManager), "Awake")));
+            AddPatch(PatchType.Postfix, typeof(StageManager), "Awake");
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(StageGroup), "ToggleInfoPanel", new Type[] { typeof(bool) })));
+            AddPatch(PatchType.Prefix, typeof(StageGroup), "ToggleInfoPanel", new Type[] { typeof(bool) });
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(NavBallBurnVector), "onGameSettingsApplied")));
+            AddPatch(PatchType.Prefix, typeof(NavBallBurnVector), "onGameSettingsApplied");
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(NavBallBurnVector), "onGameSettingsApplied")));
+            AddPatch(PatchType.Postfix, typeof(NavBallBurnVector), "onGameSettingsApplied");
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(NavBallBurnVector), "LateUpdate")));
+            AddPatch(PatchType.Prefix, typeof(NavBallBurnVector), "LateUpdate");
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(NavBallBurnVector), "LateUpdate")));
+            AddPatch(PatchType.Postfix, typeof(NavBallBurnVector), "LateUpdate");
         }
 
         static void StageGroup_Awake_Postfix(StageGroup __instance)

--- a/KSPCommunityFixes/BugFixes/DockingPortConserveMomentum.cs
+++ b/KSPCommunityFixes/BugFixes/DockingPortConserveMomentum.cs
@@ -10,7 +10,7 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 12, 3);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
             // We need to patch a closure, which doesn't have a stable method name.
             // So we patch everything that *might* be the closure we are looking for,
@@ -22,10 +22,7 @@ namespace KSPCommunityFixes.BugFixes
             {
                 if (methodName.StartsWith("<SetupFSM>") && !methodName.Contains("_Patch"))
                 {
-                    patches.Add(new PatchInfo(
-                    PatchMethodType.Transpiler,
-                    AccessTools.Method(typeof(ModuleDockingNode), methodName),
-                    "ModuleDockingNode_SetupFSMClosure_Transpiler"));
+                    AddPatch(PatchType.Transpiler, typeof(ModuleDockingNode), methodName, "ModuleDockingNode_SetupFSMClosure_Transpiler");
                 }
             }
         }

--- a/KSPCommunityFixes/BugFixes/DockingPortConserveMomentum.cs
+++ b/KSPCommunityFixes/BugFixes/DockingPortConserveMomentum.cs
@@ -25,7 +25,6 @@ namespace KSPCommunityFixes.BugFixes
                     patches.Add(new PatchInfo(
                     PatchMethodType.Transpiler,
                     AccessTools.Method(typeof(ModuleDockingNode), methodName),
-                    this,
                     "ModuleDockingNode_SetupFSMClosure_Transpiler"));
                 }
             }

--- a/KSPCommunityFixes/BugFixes/DockingPortRotationDriftAndFixes.cs
+++ b/KSPCommunityFixes/BugFixes/DockingPortRotationDriftAndFixes.cs
@@ -15,73 +15,61 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnLoad)),
-                this));
+                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnLoad))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnSave)),
-                this));
+                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnSave))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnStart)),
-                this));
+                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnStart))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnStartFinished)),
-                this));
+                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnStartFinished))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnDestroy)),
-                this));
+                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnDestroy))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.PropertyGetter(typeof(ModuleDockingNode), nameof(ModuleDockingNode.RotationJoint)),
-                this, nameof(ModuleDockingNode_RotationJoint_Prefix)));
+                AccessTools.PropertyGetter(typeof(ModuleDockingNode), nameof(ModuleDockingNode.RotationJoint)), 
+                nameof(ModuleDockingNode_RotationJoint_Prefix)));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
                 AccessTools.PropertyGetter(typeof(ModuleDockingNode), nameof(ModuleDockingNode.VisualTargetAngle)),
-                this, nameof(ModuleDockingNode_VisualTargetAngle_Prefix)));
+                nameof(ModuleDockingNode_VisualTargetAngle_Prefix)));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnPartUnpack)),
-                this));
+                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnPartUnpack))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.UpdatePAWUI)),
-                this));
+                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.UpdatePAWUI))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.UpdateAlignmentRotation)),
-                this));
+                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.UpdateAlignmentRotation))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.ApplyCoordsUpdate)),
-                this));
+                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.ApplyCoordsUpdate))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.SetJointHighLowLimits)),
-                this));
+                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.SetJointHighLowLimits))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.ModifyLocked)),
-                this));
+                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.ModifyLocked))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.IsJointUnlocked)),
-                this));
+                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.IsJointUnlocked))));
 
             GameEvents.onGameSceneLoadRequested.Add(OnSceneSwitch);
         }

--- a/KSPCommunityFixes/BugFixes/DockingPortRotationDriftAndFixes.cs
+++ b/KSPCommunityFixes/BugFixes/DockingPortRotationDriftAndFixes.cs
@@ -11,65 +11,39 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 12, 3);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnLoad))));
+            AddPatch(PatchType.Transpiler, typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnLoad));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnSave))));
+            AddPatch(PatchType.Postfix, typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnSave));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnStart))));
+            AddPatch(PatchType.Postfix, typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnStart));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnStartFinished))));
+            AddPatch(PatchType.Prefix, typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnStartFinished));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnDestroy))));
+            AddPatch(PatchType.Postfix, typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnDestroy));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.PropertyGetter(typeof(ModuleDockingNode), nameof(ModuleDockingNode.RotationJoint)), 
-                nameof(ModuleDockingNode_RotationJoint_Prefix)));
+            AddPatch(PatchType.Prefix,
+                AccessTools.PropertyGetter(typeof(ModuleDockingNode), nameof(ModuleDockingNode.RotationJoint)),
+                nameof(ModuleDockingNode_RotationJoint_Prefix));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
+            AddPatch(PatchType.Prefix,
                 AccessTools.PropertyGetter(typeof(ModuleDockingNode), nameof(ModuleDockingNode.VisualTargetAngle)),
-                nameof(ModuleDockingNode_VisualTargetAngle_Prefix)));
+                nameof(ModuleDockingNode_VisualTargetAngle_Prefix));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnPartUnpack))));
+            AddPatch(PatchType.Prefix, typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnPartUnpack));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.UpdatePAWUI))));
+            AddPatch(PatchType.Prefix, typeof(ModuleDockingNode), nameof(ModuleDockingNode.UpdatePAWUI));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.UpdateAlignmentRotation))));
+            AddPatch(PatchType.Prefix, typeof(ModuleDockingNode), nameof(ModuleDockingNode.UpdateAlignmentRotation));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.ApplyCoordsUpdate))));
+            AddPatch(PatchType.Prefix, typeof(ModuleDockingNode), nameof(ModuleDockingNode.ApplyCoordsUpdate));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.SetJointHighLowLimits))));
+            AddPatch(PatchType.Prefix, typeof(ModuleDockingNode), nameof(ModuleDockingNode.SetJointHighLowLimits));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.ModifyLocked))));
+            AddPatch(PatchType.Prefix, typeof(ModuleDockingNode), nameof(ModuleDockingNode.ModifyLocked));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.IsJointUnlocked))));
+            AddPatch(PatchType.Prefix, typeof(ModuleDockingNode), nameof(ModuleDockingNode.IsJointUnlocked));
 
             GameEvents.onGameSceneLoadRequested.Add(OnSceneSwitch);
         }

--- a/KSPCommunityFixes/BugFixes/DoubleCurvePreserveTangents.cs
+++ b/KSPCommunityFixes/BugFixes/DoubleCurvePreserveTangents.cs
@@ -9,11 +9,9 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(DoubleCurve), nameof(DoubleCurve.RecomputeTangents))));
+            AddPatch(PatchType.Transpiler, typeof(DoubleCurve), nameof(DoubleCurve.RecomputeTangents));
         }
 
         static IEnumerable<CodeInstruction> DoubleCurve_RecomputeTangents_Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/KSPCommunityFixes/BugFixes/DoubleCurvePreserveTangents.cs
+++ b/KSPCommunityFixes/BugFixes/DoubleCurvePreserveTangents.cs
@@ -13,8 +13,7 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(DoubleCurve), nameof(DoubleCurve.RecomputeTangents)),
-                this));
+                AccessTools.Method(typeof(DoubleCurve), nameof(DoubleCurve.RecomputeTangents))));
         }
 
         static IEnumerable<CodeInstruction> DoubleCurve_RecomputeTangents_Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/KSPCommunityFixes/BugFixes/EVAConstructionMass.cs
+++ b/KSPCommunityFixes/BugFixes/EVAConstructionMass.cs
@@ -16,11 +16,9 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 12, 3);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(EVAConstructionModeEditor), nameof(EVAConstructionModeEditor.PickupPart))));
+            AddPatch(PatchType.Transpiler, typeof(EVAConstructionModeEditor), nameof(EVAConstructionModeEditor.PickupPart));
         }
 
         // the stock code sets selectedpart.mass to the prefab mass, which breaks terribly in cases where there are mass modifiers involved

--- a/KSPCommunityFixes/BugFixes/EVAConstructionMass.cs
+++ b/KSPCommunityFixes/BugFixes/EVAConstructionMass.cs
@@ -20,8 +20,7 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(EVAConstructionModeEditor), nameof(EVAConstructionModeEditor.PickupPart)),
-                this));
+                AccessTools.Method(typeof(EVAConstructionModeEditor), nameof(EVAConstructionModeEditor.PickupPart))));
         }
 
         // the stock code sets selectedpart.mass to the prefab mass, which breaks terribly in cases where there are mass modifiers involved

--- a/KSPCommunityFixes/BugFixes/EVAKerbalRecovery.cs
+++ b/KSPCommunityFixes/BugFixes/EVAKerbalRecovery.cs
@@ -10,11 +10,9 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 11, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ProtoVessel), nameof(ProtoVessel.GetAllProtoPartsIncludingCargo))));
+            AddPatch(PatchType.Prefix, typeof(ProtoVessel), nameof(ProtoVessel.GetAllProtoPartsIncludingCargo));
         }
 
         private static bool ProtoVessel_GetAllProtoPartsIncludingCargo_Prefix(ProtoVessel __instance, out List<ProtoPartSnapshot> __result)

--- a/KSPCommunityFixes/BugFixes/EVAKerbalRecovery.cs
+++ b/KSPCommunityFixes/BugFixes/EVAKerbalRecovery.cs
@@ -14,8 +14,7 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ProtoVessel), nameof(ProtoVessel.GetAllProtoPartsIncludingCargo)),
-                this));
+                AccessTools.Method(typeof(ProtoVessel), nameof(ProtoVessel.GetAllProtoPartsIncludingCargo))));
         }
 
         private static bool ProtoVessel_GetAllProtoPartsIncludingCargo_Prefix(ProtoVessel __instance, out List<ProtoPartSnapshot> __result)

--- a/KSPCommunityFixes/BugFixes/EnginePlateAirstreamShieldedTopPart.cs
+++ b/KSPCommunityFixes/BugFixes/EnginePlateAirstreamShieldedTopPart.cs
@@ -15,8 +15,7 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleDecouplerBase), nameof(ModuleDecouplerBase.SetAirstream)),
-                this));
+                AccessTools.Method(typeof(ModuleDecouplerBase), nameof(ModuleDecouplerBase.SetAirstream))));
         }
 
         static bool ModuleDecouplerBase_SetAirstream_Prefix(ModuleDecouplerBase __instance, bool enclosed)

--- a/KSPCommunityFixes/BugFixes/EnginePlateAirstreamShieldedTopPart.cs
+++ b/KSPCommunityFixes/BugFixes/EnginePlateAirstreamShieldedTopPart.cs
@@ -11,11 +11,9 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 11, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleDecouplerBase), nameof(ModuleDecouplerBase.SetAirstream))));
+            AddPatch(PatchType.Prefix, typeof(ModuleDecouplerBase), nameof(ModuleDecouplerBase.SetAirstream));
         }
 
         static bool ModuleDecouplerBase_SetAirstream_Prefix(ModuleDecouplerBase __instance, bool enclosed)

--- a/KSPCommunityFixes/BugFixes/ExtendedDeployableParts.cs
+++ b/KSPCommunityFixes/BugFixes/ExtendedDeployableParts.cs
@@ -19,15 +19,11 @@ namespace KSPCommunityFixes.BugFixes
 
         protected override Version VersionMin => new Version(1, 12, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(ModuleDeployablePart), nameof(ModuleDeployablePart.startFSM))));
+            AddPatch(PatchType.Transpiler, typeof(ModuleDeployablePart), nameof(ModuleDeployablePart.startFSM));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(ModuleDeployableSolarPanel), nameof(ModuleDeployablePart.OnStart))));
+            AddPatch(PatchType.Transpiler, typeof(ModuleDeployableSolarPanel), nameof(ModuleDeployablePart.OnStart));
         }
 
         static IEnumerable<CodeInstruction> ModuleDeployablePart_startFSM_Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/KSPCommunityFixes/BugFixes/ExtendedDeployableParts.cs
+++ b/KSPCommunityFixes/BugFixes/ExtendedDeployableParts.cs
@@ -23,13 +23,11 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(ModuleDeployablePart), nameof(ModuleDeployablePart.startFSM)),
-                this));
+                AccessTools.Method(typeof(ModuleDeployablePart), nameof(ModuleDeployablePart.startFSM))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(ModuleDeployableSolarPanel), nameof(ModuleDeployablePart.OnStart)),
-                this));
+                AccessTools.Method(typeof(ModuleDeployableSolarPanel), nameof(ModuleDeployablePart.OnStart))));
         }
 
         static IEnumerable<CodeInstruction> ModuleDeployablePart_startFSM_Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/KSPCommunityFixes/BugFixes/FixGetUnivseralTime.cs
+++ b/KSPCommunityFixes/BugFixes/FixGetUnivseralTime.cs
@@ -9,11 +9,9 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(Planetarium), nameof(Planetarium.GetUniversalTime))));
+            AddPatch(PatchType.Prefix, typeof(Planetarium), nameof(Planetarium.GetUniversalTime));
         }
 
         static bool Planetarium_GetUniversalTime_Prefix(ref double __result)

--- a/KSPCommunityFixes/BugFixes/FixGetUnivseralTime.cs
+++ b/KSPCommunityFixes/BugFixes/FixGetUnivseralTime.cs
@@ -13,8 +13,7 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(Planetarium), nameof(Planetarium.GetUniversalTime)),
-                this));
+                AccessTools.Method(typeof(Planetarium), nameof(Planetarium.GetUniversalTime))));
         }
 
         static bool Planetarium_GetUniversalTime_Prefix(ref double __result)

--- a/KSPCommunityFixes/BugFixes/FlightSceneLoadKraken.cs
+++ b/KSPCommunityFixes/BugFixes/FlightSceneLoadKraken.cs
@@ -14,13 +14,11 @@ namespace KSPCommunityFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(HighLogic), "LoadScene"),
-                this));
+                AccessTools.Method(typeof(HighLogic), nameof(HighLogic.LoadScene))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(FlightDriver), "Start"),
-                this));
+                AccessTools.Method(typeof(FlightDriver), nameof(FlightDriver.Start))));
         }
 
         private static void HighLogic_LoadScene_Postfix(GameScenes scene)

--- a/KSPCommunityFixes/BugFixes/FlightSceneLoadKraken.cs
+++ b/KSPCommunityFixes/BugFixes/FlightSceneLoadKraken.cs
@@ -10,15 +10,11 @@ namespace KSPCommunityFixes
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(HighLogic), nameof(HighLogic.LoadScene))));
+            AddPatch(PatchType.Postfix, typeof(HighLogic), nameof(HighLogic.LoadScene));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(FlightDriver), nameof(FlightDriver.Start))));
+            AddPatch(PatchType.Prefix, typeof(FlightDriver), nameof(FlightDriver.Start));
         }
 
         private static void HighLogic_LoadScene_Postfix(GameScenes scene)

--- a/KSPCommunityFixes/BugFixes/InventoryPartMass.cs
+++ b/KSPCommunityFixes/BugFixes/InventoryPartMass.cs
@@ -13,11 +13,9 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 12, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleInventoryPart), nameof(ModuleInventoryPart.UpdateCapacityValues))));
+            AddPatch(PatchType.Prefix, typeof(ModuleInventoryPart), nameof(ModuleInventoryPart.UpdateCapacityValues));
 
             var EditorPartIcon_Create_ArgTypes = new Type[]
             {
@@ -35,13 +33,9 @@ namespace KSPCommunityFixes.BugFixes
                 typeof(bool)
             };
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(KSP.UI.Screens.EditorPartIcon), nameof(KSP.UI.Screens.EditorPartIcon.Create), EditorPartIcon_Create_ArgTypes)));
+            AddPatch(PatchType.Postfix, typeof(KSP.UI.Screens.EditorPartIcon), nameof(KSP.UI.Screens.EditorPartIcon.Create), EditorPartIcon_Create_ArgTypes);
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(InventoryPartListTooltip), nameof(InventoryPartListTooltip.CreateInfoWidgets))));
+            AddPatch(PatchType.Postfix, typeof(InventoryPartListTooltip), nameof(InventoryPartListTooltip.CreateInfoWidgets));
 
             // Making packedVolume persistent helps track what cargo modules *should* be if they were changed from the prefab before being added to the inventory
             StaticHelpers.EditPartModuleKSPFieldAttributes(typeof(ModuleCargoPart), nameof(ModuleCargoPart.packedVolume), field => field.isPersistant = true);

--- a/KSPCommunityFixes/BugFixes/InventoryPartMass.cs
+++ b/KSPCommunityFixes/BugFixes/InventoryPartMass.cs
@@ -17,8 +17,7 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleInventoryPart), nameof(ModuleInventoryPart.UpdateCapacityValues)),
-                this));
+                AccessTools.Method(typeof(ModuleInventoryPart), nameof(ModuleInventoryPart.UpdateCapacityValues))));
 
             var EditorPartIcon_Create_ArgTypes = new Type[]
             {
@@ -38,13 +37,11 @@ namespace KSPCommunityFixes.BugFixes
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(KSP.UI.Screens.EditorPartIcon), nameof(KSP.UI.Screens.EditorPartIcon.Create), EditorPartIcon_Create_ArgTypes),
-                this));
+                AccessTools.Method(typeof(KSP.UI.Screens.EditorPartIcon), nameof(KSP.UI.Screens.EditorPartIcon.Create), EditorPartIcon_Create_ArgTypes)));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(InventoryPartListTooltip), nameof(InventoryPartListTooltip.CreateInfoWidgets)),
-                this));
+                AccessTools.Method(typeof(InventoryPartListTooltip), nameof(InventoryPartListTooltip.CreateInfoWidgets))));
 
             // Making packedVolume persistent helps track what cargo modules *should* be if they were changed from the prefab before being added to the inventory
             StaticHelpers.EditPartModuleKSPFieldAttributes(typeof(ModuleCargoPart), nameof(ModuleCargoPart.packedVolume), field => field.isPersistant = true);

--- a/KSPCommunityFixes/BugFixes/InventoryPartMass.cs
+++ b/KSPCommunityFixes/BugFixes/InventoryPartMass.cs
@@ -94,7 +94,7 @@ namespace KSPCommunityFixes.BugFixes
             }
 
             // otherwise we have to fall back to the prefab volume (this is stock behavior)
-            ModuleCargoPart moduleCargoPart = partSnapshot.partPrefab.FindModuleImplementing<ModuleCargoPart>();
+            ModuleCargoPart moduleCargoPart = partSnapshot.partPrefab.FindModuleImplementingFast<ModuleCargoPart>();
             if (moduleCargoPart != null)
             {
                 return moduleCargoPart.packedVolume;

--- a/KSPCommunityFixes/BugFixes/KerbalInventoryPersistence.cs
+++ b/KSPCommunityFixes/BugFixes/KerbalInventoryPersistence.cs
@@ -32,7 +32,7 @@ namespace KSPCommunityFixes
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
                 AccessTools.PropertyGetter(typeof(ProtoCrewMember), "kerbalModule"),
-                this, nameof(ProtoCrewMember_kerbalModule_Transpiler)));
+                nameof(ProtoCrewMember_kerbalModule_Transpiler)));
         }
 
         private static IEnumerable<CodeInstruction> ProtoCrewMember_kerbalModule_Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/KSPCommunityFixes/BugFixes/KerbalInventoryPersistence.cs
+++ b/KSPCommunityFixes/BugFixes/KerbalInventoryPersistence.cs
@@ -27,12 +27,11 @@ namespace KSPCommunityFixes
     {
         protected override Version VersionMin => new Version(1, 12, 2);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
+            AddPatch(PatchType.Transpiler,
                 AccessTools.PropertyGetter(typeof(ProtoCrewMember), "kerbalModule"),
-                nameof(ProtoCrewMember_kerbalModule_Transpiler)));
+                nameof(ProtoCrewMember_kerbalModule_Transpiler));
         }
 
         private static IEnumerable<CodeInstruction> ProtoCrewMember_kerbalModule_Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/KSPCommunityFixes/BugFixes/KerbalTooltipMaxSustainedG.cs
+++ b/KSPCommunityFixes/BugFixes/KerbalTooltipMaxSustainedG.cs
@@ -10,7 +10,7 @@ namespace KSPCommunityFixes
 
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
             // replace the orginial delegate, no need for harmony patching here
             ProtoCrewMember.MaxSustainedG = MaxSustainedG;

--- a/KSPCommunityFixes/BugFixes/LadderToggleableLight.cs
+++ b/KSPCommunityFixes/BugFixes/LadderToggleableLight.cs
@@ -19,8 +19,7 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(RetractableLadder), nameof(RetractableLadder.OnStart)),
-                this));
+                AccessTools.Method(typeof(RetractableLadder), nameof(RetractableLadder.OnStart))));
         }
 
         static IEnumerable<CodeInstruction> RetractableLadder_OnStart_Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/KSPCommunityFixes/BugFixes/LadderToggleableLight.cs
+++ b/KSPCommunityFixes/BugFixes/LadderToggleableLight.cs
@@ -15,11 +15,9 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(RetractableLadder), nameof(RetractableLadder.OnStart))));
+            AddPatch(PatchType.Transpiler, typeof(RetractableLadder), nameof(RetractableLadder.OnStart));
         }
 
         static IEnumerable<CodeInstruction> RetractableLadder_OnStart_Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/KSPCommunityFixes/BugFixes/LostSoundAfterSceneSwitch.cs
+++ b/KSPCommunityFixes/BugFixes/LostSoundAfterSceneSwitch.cs
@@ -11,15 +11,11 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 12, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(FlightCamera), nameof(FlightCamera.EnableCamera))));
+            AddPatch(PatchType.Transpiler, typeof(FlightCamera), nameof(FlightCamera.EnableCamera));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(FlightCamera), nameof(FlightCamera.DisableCamera), new[] {typeof(bool)})));
+            AddPatch(PatchType.Transpiler, typeof(FlightCamera), nameof(FlightCamera.DisableCamera), new[] {typeof(bool)});
         }
 
         static IEnumerable<CodeInstruction> FlightCamera_EnableCamera_Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/KSPCommunityFixes/BugFixes/LostSoundAfterSceneSwitch.cs
+++ b/KSPCommunityFixes/BugFixes/LostSoundAfterSceneSwitch.cs
@@ -15,13 +15,11 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(FlightCamera), nameof(FlightCamera.EnableCamera)),
-                this));
+                AccessTools.Method(typeof(FlightCamera), nameof(FlightCamera.EnableCamera))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(FlightCamera), nameof(FlightCamera.DisableCamera), new[] {typeof(bool)}),
-                this));
+                AccessTools.Method(typeof(FlightCamera), nameof(FlightCamera.DisableCamera), new[] {typeof(bool)})));
         }
 
         static IEnumerable<CodeInstruction> FlightCamera_EnableCamera_Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/KSPCommunityFixes/BugFixes/MapSOCorrectWrapping.cs
+++ b/KSPCommunityFixes/BugFixes/MapSOCorrectWrapping.cs
@@ -14,13 +14,11 @@ namespace KSPCommunityFixes
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
                 AccessTools.Method(typeof(MapSO), nameof(MapSO.ConstructBilinearCoords), new Type[] { typeof(float), typeof(float) }),
-                this,
                 "MapSO_ConstructBilinearCoords_Float"));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
                 AccessTools.Method(typeof(MapSO), nameof(MapSO.ConstructBilinearCoords), new Type[] { typeof(double), typeof(double) }),
-                this,
                 "MapSO_ConstructBilinearCoords_Double"));
 
             // see https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/121
@@ -41,8 +39,7 @@ namespace KSPCommunityFixes
             {
                 patches.Add(new PatchInfo(
                     PatchMethodType.Postfix,
-                    AccessTools.Method(typeof(PSystemSetup), nameof(PSystemSetup.Awake)),
-                    this));
+                    AccessTools.Method(typeof(PSystemSetup), nameof(PSystemSetup.Awake))));
             }
         }
 

--- a/KSPCommunityFixes/BugFixes/MapSOCorrectWrapping.cs
+++ b/KSPCommunityFixes/BugFixes/MapSOCorrectWrapping.cs
@@ -9,17 +9,11 @@ namespace KSPCommunityFixes
     {
         protected override Version VersionMin => new Version(1, 10, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(MapSO), nameof(MapSO.ConstructBilinearCoords), new Type[] { typeof(float), typeof(float) }),
-                "MapSO_ConstructBilinearCoords_Float"));
+            AddPatch(PatchType.Prefix, typeof(MapSO), nameof(MapSO.ConstructBilinearCoords), new Type[] { typeof(float), typeof(float) }, "MapSO_ConstructBilinearCoords_Float");
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(MapSO), nameof(MapSO.ConstructBilinearCoords), new Type[] { typeof(double), typeof(double) }),
-                "MapSO_ConstructBilinearCoords_Double"));
+            AddPatch(PatchType.Prefix, typeof(MapSO), nameof(MapSO.ConstructBilinearCoords), new Type[] { typeof(double), typeof(double) }, "MapSO_ConstructBilinearCoords_Double");
 
             // see https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/121
             // The patched ConstructBilinearCoords() methods will have the side effect of removing the Mohole because Squad
@@ -37,9 +31,7 @@ namespace KSPCommunityFixes
             bool ignoreMoho = false;
             if (KSPCommunityFixes.SettingsNode.TryGetValue("MapSOCorrectWrappingIgnoreMoho", ref ignoreMoho) && ignoreMoho)
             {
-                patches.Add(new PatchInfo(
-                    PatchMethodType.Postfix,
-                    AccessTools.Method(typeof(PSystemSetup), nameof(PSystemSetup.Awake))));
+                AddPatch(PatchType.Postfix, typeof(PSystemSetup), nameof(PSystemSetup.Awake));
             }
         }
 

--- a/KSPCommunityFixes/BugFixes/ModuleAnimateGenericCrewModSpawnIVA.cs
+++ b/KSPCommunityFixes/BugFixes/ModuleAnimateGenericCrewModSpawnIVA.cs
@@ -11,11 +11,9 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(ModuleAnimateGeneric), nameof(ModuleAnimateGeneric.CheckCrewState))));
+            AddPatch(PatchType.Transpiler, typeof(ModuleAnimateGeneric), nameof(ModuleAnimateGeneric.CheckCrewState));
         }
 
         // Insert a call to our static OnCrewCapacityChanged() method in the "if (crewCapacity != base.part.CrewCapacity)" condition

--- a/KSPCommunityFixes/BugFixes/ModuleAnimateGenericCrewModSpawnIVA.cs
+++ b/KSPCommunityFixes/BugFixes/ModuleAnimateGenericCrewModSpawnIVA.cs
@@ -15,8 +15,7 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(ModuleAnimateGeneric), nameof(ModuleAnimateGeneric.CheckCrewState)),
-                this));
+                AccessTools.Method(typeof(ModuleAnimateGeneric), nameof(ModuleAnimateGeneric.CheckCrewState))));
         }
 
         // Insert a call to our static OnCrewCapacityChanged() method in the "if (crewCapacity != base.part.CrewCapacity)" condition

--- a/KSPCommunityFixes/BugFixes/ModuleIndexingMismatch.cs
+++ b/KSPCommunityFixes/BugFixes/ModuleIndexingMismatch.cs
@@ -31,26 +31,20 @@ namespace KSPCommunityFixes
 
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
             // ConfigurePart() was added in 1.11, by stripping a portion of the 1.10 ProtoPartSnapshot.Load()
             // method in a separate method.
             if (KSPCommunityFixes.KspVersion < new Version(1, 11, 0))
             {
-                patches.Add(new PatchInfo(
-                    PatchMethodType.Transpiler,
-                    AccessTools.Method(typeof(ProtoPartSnapshot), nameof(ProtoPartSnapshot.Load))));
+                AddPatch(PatchType.Transpiler, typeof(ProtoPartSnapshot), nameof(ProtoPartSnapshot.Load));
             }
             else
             {
-                patches.Add(new PatchInfo(
-                    PatchMethodType.Transpiler,
-                    AccessTools.Method(typeof(ProtoPartSnapshot), "ConfigurePart")));
+                AddPatch(PatchType.Transpiler, typeof(ProtoPartSnapshot), "ConfigurePart");
             }
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(ShipConstruct), "LoadShip", new Type[] { typeof(ConfigNode), typeof(uint), typeof(bool), typeof(string).MakeByRefType() })));
+            AddPatch(PatchType.Transpiler, typeof(ShipConstruct), "LoadShip", new Type[] { typeof(ConfigNode), typeof(uint), typeof(bool), typeof(string).MakeByRefType() });
 
             Type partModuleType = typeof(PartModule);
             Type multiModuleType = typeof(IMultipleModuleInPart);

--- a/KSPCommunityFixes/BugFixes/ModuleIndexingMismatch.cs
+++ b/KSPCommunityFixes/BugFixes/ModuleIndexingMismatch.cs
@@ -39,21 +39,18 @@ namespace KSPCommunityFixes
             {
                 patches.Add(new PatchInfo(
                     PatchMethodType.Transpiler,
-                    AccessTools.Method(typeof(ProtoPartSnapshot), nameof(ProtoPartSnapshot.Load)),
-                    this));
+                    AccessTools.Method(typeof(ProtoPartSnapshot), nameof(ProtoPartSnapshot.Load))));
             }
             else
             {
                 patches.Add(new PatchInfo(
                     PatchMethodType.Transpiler,
-                    AccessTools.Method(typeof(ProtoPartSnapshot), "ConfigurePart"),
-                    this));
+                    AccessTools.Method(typeof(ProtoPartSnapshot), "ConfigurePart")));
             }
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(ShipConstruct), "LoadShip", new Type[] { typeof(ConfigNode), typeof(uint), typeof(bool), typeof(string).MakeByRefType() }),
-                this));
+                AccessTools.Method(typeof(ShipConstruct), "LoadShip", new Type[] { typeof(ConfigNode), typeof(uint), typeof(bool), typeof(string).MakeByRefType() })));
 
             Type partModuleType = typeof(PartModule);
             Type multiModuleType = typeof(IMultipleModuleInPart);

--- a/KSPCommunityFixes/BugFixes/ModulePartVariantsNodePersistence.cs
+++ b/KSPCommunityFixes/BugFixes/ModulePartVariantsNodePersistence.cs
@@ -37,13 +37,11 @@ namespace KSPCommunityFixes.BugFixes
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(ModulePartVariants), nameof(ModulePartVariants.ApplyVariant), ApplyVariant_parameterTypes),
-                this));
+                AccessTools.Method(typeof(ModulePartVariants), nameof(ModulePartVariants.ApplyVariant), ApplyVariant_parameterTypes)));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModulePartVariants), nameof(ModulePartVariants.UpdatePartPosition)),
-                this));
+                AccessTools.Method(typeof(ModulePartVariants), nameof(ModulePartVariants.UpdatePartPosition))));
         }
 
         static IEnumerable<CodeInstruction> ModulePartVariants_ApplyVariant_Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/KSPCommunityFixes/BugFixes/ModulePartVariantsNodePersistence.cs
+++ b/KSPCommunityFixes/BugFixes/ModulePartVariantsNodePersistence.cs
@@ -23,7 +23,7 @@ namespace KSPCommunityFixes.BugFixes
 
     internal class ModulePartVariantsNodePersistence : BasePatch
     {
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
             Type[] ApplyVariant_parameterTypes = new Type[]
             {
@@ -35,13 +35,9 @@ namespace KSPCommunityFixes.BugFixes
                 typeof(int)
             };
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(ModulePartVariants), nameof(ModulePartVariants.ApplyVariant), ApplyVariant_parameterTypes)));
+            AddPatch(PatchType.Transpiler, typeof(ModulePartVariants), nameof(ModulePartVariants.ApplyVariant), ApplyVariant_parameterTypes);
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModulePartVariants), nameof(ModulePartVariants.UpdatePartPosition))));
+            AddPatch(PatchType.Prefix, typeof(ModulePartVariants), nameof(ModulePartVariants.UpdatePartPosition));
         }
 
         static IEnumerable<CodeInstruction> ModulePartVariants_ApplyVariant_Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/KSPCommunityFixes/BugFixes/PAWGroupMemory.cs
+++ b/KSPCommunityFixes/BugFixes/PAWGroupMemory.cs
@@ -16,18 +16,15 @@ namespace KSPCommunityFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(UIPartActionGroup), nameof(UIPartActionGroup.Initialize)),
-                this));
+                AccessTools.Method(typeof(UIPartActionGroup), nameof(UIPartActionGroup.Initialize))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(UIPartActionGroup), nameof(UIPartActionGroup.Collapse)),
-                this));
+                AccessTools.Method(typeof(UIPartActionGroup), nameof(UIPartActionGroup.Collapse))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(UIPartActionGroup), nameof(UIPartActionGroup.Expand)),
-                this));
+                AccessTools.Method(typeof(UIPartActionGroup), nameof(UIPartActionGroup.Expand))));
 
             collapseState = new Dictionary<string, bool>();
 

--- a/KSPCommunityFixes/BugFixes/PAWGroupMemory.cs
+++ b/KSPCommunityFixes/BugFixes/PAWGroupMemory.cs
@@ -12,19 +12,13 @@ namespace KSPCommunityFixes
 
         private static Dictionary<string, bool> collapseState;
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(UIPartActionGroup), nameof(UIPartActionGroup.Initialize))));
+            AddPatch(PatchType.Transpiler, typeof(UIPartActionGroup), nameof(UIPartActionGroup.Initialize));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(UIPartActionGroup), nameof(UIPartActionGroup.Collapse))));
+            AddPatch(PatchType.Postfix, typeof(UIPartActionGroup), nameof(UIPartActionGroup.Collapse));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(UIPartActionGroup), nameof(UIPartActionGroup.Expand))));
+            AddPatch(PatchType.Postfix, typeof(UIPartActionGroup), nameof(UIPartActionGroup.Expand));
 
             collapseState = new Dictionary<string, bool>();
 

--- a/KSPCommunityFixes/BugFixes/PAWItemOrder.cs
+++ b/KSPCommunityFixes/BugFixes/PAWItemOrder.cs
@@ -17,27 +17,19 @@ namespace KSPCommunityFixes
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(UIPartActionWindow), "AddGroup", new Type[] {typeof(Transform), typeof(BasePAWGroup)}),
-                nameof(UIPartActionWindow_AddGroup_1_Prefix)));
+            AddPatch(PatchType.Prefix, typeof(UIPartActionWindow), "AddGroup", new Type[] {typeof(Transform), typeof(BasePAWGroup)}, nameof(UIPartActionWindow_AddGroup_1_Prefix));
 
             if (KSPCommunityFixes.KspVersion >= new Version(1, 11, 0))
             {
-                patches.Add(new PatchInfo(
-                    PatchMethodType.Prefix,
-                    AccessTools.Method(typeof(UIPartActionWindow), "AddGroup", new Type[] { typeof(Transform), typeof(string), typeof(bool) }),
-                    nameof(UIPartActionWindow_AddGroup_2_Prefix)));
+                AddPatch(PatchType.Prefix, typeof(UIPartActionWindow), "AddGroup", new Type[] { typeof(Transform), typeof(string), typeof(bool) }, nameof(UIPartActionWindow_AddGroup_2_Prefix));
             }
 
 #if DEBUG
             if (KSPCommunityFixes.KspVersion >= new Version(1, 12, 2))
             {
-                patches.Add(new PatchInfo(
-                    PatchMethodType.Prefix,
-                    AccessTools.Method(typeof(UIPartActionWindow), nameof(UIPartActionWindow.CreatePartList))));
+                AddPatch(PatchType.Prefix, typeof(UIPartActionWindow), nameof(UIPartActionWindow.CreatePartList));
             }
 #endif
         }

--- a/KSPCommunityFixes/BugFixes/PAWItemOrder.cs
+++ b/KSPCommunityFixes/BugFixes/PAWItemOrder.cs
@@ -22,14 +22,14 @@ namespace KSPCommunityFixes
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
                 AccessTools.Method(typeof(UIPartActionWindow), "AddGroup", new Type[] {typeof(Transform), typeof(BasePAWGroup)}),
-                this, nameof(UIPartActionWindow_AddGroup_1_Prefix)));
+                nameof(UIPartActionWindow_AddGroup_1_Prefix)));
 
             if (KSPCommunityFixes.KspVersion >= new Version(1, 11, 0))
             {
                 patches.Add(new PatchInfo(
                     PatchMethodType.Prefix,
                     AccessTools.Method(typeof(UIPartActionWindow), "AddGroup", new Type[] { typeof(Transform), typeof(string), typeof(bool) }),
-                    this, nameof(UIPartActionWindow_AddGroup_2_Prefix)));
+                    nameof(UIPartActionWindow_AddGroup_2_Prefix)));
             }
 
 #if DEBUG
@@ -37,8 +37,7 @@ namespace KSPCommunityFixes
             {
                 patches.Add(new PatchInfo(
                     PatchMethodType.Prefix,
-                    AccessTools.Method(typeof(UIPartActionWindow), nameof(UIPartActionWindow.CreatePartList)),
-                    this));
+                    AccessTools.Method(typeof(UIPartActionWindow), nameof(UIPartActionWindow.CreatePartList))));
             }
 #endif
         }

--- a/KSPCommunityFixes/BugFixes/PackedPartsRotation.cs
+++ b/KSPCommunityFixes/BugFixes/PackedPartsRotation.cs
@@ -35,8 +35,7 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Vessel), nameof(Vessel.GoOnRails)),
-                this));
+                AccessTools.Method(typeof(Vessel), nameof(Vessel.GoOnRails))));
         }
 
         static void Vessel_GoOnRails_Postfix(Vessel __instance)

--- a/KSPCommunityFixes/BugFixes/PackedPartsRotation.cs
+++ b/KSPCommunityFixes/BugFixes/PackedPartsRotation.cs
@@ -31,11 +31,9 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Vessel), nameof(Vessel.GoOnRails))));
+            AddPatch(PatchType.Postfix, typeof(Vessel), nameof(Vessel.GoOnRails));
         }
 
         static void Vessel_GoOnRails_Postfix(Vessel __instance)

--- a/KSPCommunityFixes/BugFixes/PartBoundsIgnoreDisabledTransforms.cs
+++ b/KSPCommunityFixes/BugFixes/PartBoundsIgnoreDisabledTransforms.cs
@@ -14,11 +14,9 @@ namespace KSPCommunityFixes
 
         protected override Version VersionMin => new Version(1, 12, 3);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(PartGeometryUtil), nameof(PartGeometryUtil.GetPartRendererBounds))));
+            AddPatch(PatchType.Prefix, typeof(PartGeometryUtil), nameof(PartGeometryUtil.GetPartRendererBounds));
         }
 
         static readonly List<Renderer> partRenderersBuffer = new List<Renderer>();

--- a/KSPCommunityFixes/BugFixes/PartBoundsIgnoreDisabledTransforms.cs
+++ b/KSPCommunityFixes/BugFixes/PartBoundsIgnoreDisabledTransforms.cs
@@ -18,8 +18,7 @@ namespace KSPCommunityFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(PartGeometryUtil), nameof(PartGeometryUtil.GetPartRendererBounds)),
-                this));
+                AccessTools.Method(typeof(PartGeometryUtil), nameof(PartGeometryUtil.GetPartRendererBounds))));
         }
 
         static readonly List<Renderer> partRenderersBuffer = new List<Renderer>();

--- a/KSPCommunityFixes/BugFixes/PartListTooltipIconSpin.cs
+++ b/KSPCommunityFixes/BugFixes/PartListTooltipIconSpin.cs
@@ -13,8 +13,7 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(PartListTooltipController), nameof(PartListTooltipController.CreateTooltip)),
-                this));
+                AccessTools.Method(typeof(PartListTooltipController), nameof(PartListTooltipController.CreateTooltip))));
         }
 
         static void PartListTooltipController_CreateTooltip_Postfix(PartListTooltipController __instance, PartListTooltip tooltip)

--- a/KSPCommunityFixes/BugFixes/PartListTooltipIconSpin.cs
+++ b/KSPCommunityFixes/BugFixes/PartListTooltipIconSpin.cs
@@ -9,11 +9,9 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(PartListTooltipController), nameof(PartListTooltipController.CreateTooltip))));
+            AddPatch(PatchType.Postfix, typeof(PartListTooltipController), nameof(PartListTooltipController.CreateTooltip));
         }
 
         static void PartListTooltipController_CreateTooltip_Postfix(PartListTooltipController __instance, PartListTooltip tooltip)

--- a/KSPCommunityFixes/BugFixes/PartStartStability.cs
+++ b/KSPCommunityFixes/BugFixes/PartStartStability.cs
@@ -87,13 +87,11 @@ namespace KSPCommunityFixes
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
                 AccessTools.Method(partStartEnumerator, "MoveNext"),
-                this,
                 nameof(Part_StartEnumerator_MoveNext_Transpiler)));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(FlightIntegrator), nameof(FlightIntegrator.Update)),
-                this));
+                AccessTools.Method(typeof(FlightIntegrator), nameof(FlightIntegrator.Update))));
         }
 
         static IEnumerable<CodeInstruction> Part_StartEnumerator_MoveNext_Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/KSPCommunityFixes/BugFixes/PartStartStability.cs
+++ b/KSPCommunityFixes/BugFixes/PartStartStability.cs
@@ -54,7 +54,7 @@ namespace KSPCommunityFixes
         private static FieldInfo current;
         private static MethodBase waitForFixedUpdateCtor;
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
             Type partType = typeof(Part);
 
@@ -84,14 +84,9 @@ namespace KSPCommunityFixes
 
             waitForFixedUpdateCtor = AccessTools.Constructor(typeof(WaitForFixedUpdate));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(partStartEnumerator, "MoveNext"),
-                nameof(Part_StartEnumerator_MoveNext_Transpiler)));
+            AddPatch(PatchType.Transpiler, partStartEnumerator, "MoveNext", nameof(Part_StartEnumerator_MoveNext_Transpiler));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(FlightIntegrator), nameof(FlightIntegrator.Update))));
+            AddPatch(PatchType.Prefix, typeof(FlightIntegrator), nameof(FlightIntegrator.Update));
         }
 
         static IEnumerable<CodeInstruction> Part_StartEnumerator_MoveNext_Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/KSPCommunityFixes/BugFixes/PartTooltipUpgradesApplyToSubstituteParts.cs
+++ b/KSPCommunityFixes/BugFixes/PartTooltipUpgradesApplyToSubstituteParts.cs
@@ -31,23 +31,19 @@ namespace KSPCommunityFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(PartListTooltip), nameof(PartListTooltip.Setup), new Type[] { typeof(AvailablePart), typeof(Callback<PartListTooltip>), typeof(RenderTexture) }),
-                this));
+                AccessTools.Method(typeof(PartListTooltip), nameof(PartListTooltip.Setup), new Type[] { typeof(AvailablePart), typeof(Callback<PartListTooltip>), typeof(RenderTexture) })));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(PartListTooltip), nameof(PartListTooltip.Setup), new Type[] { typeof(AvailablePart), typeof(Callback<PartListTooltip>), typeof(RenderTexture) }),
-                this));
+                AccessTools.Method(typeof(PartListTooltip), nameof(PartListTooltip.Setup), new Type[] { typeof(AvailablePart), typeof(Callback<PartListTooltip>), typeof(RenderTexture) })));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(PartListTooltip), nameof(PartListTooltip.UpdateVariantText)),
-                this));
+                AccessTools.Method(typeof(PartListTooltip), nameof(PartListTooltip.UpdateVariantText))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(PartListTooltip), nameof(PartListTooltip.GetUpgradedPrimaryInfo)),
-                this));
+                AccessTools.Method(typeof(PartListTooltip), nameof(PartListTooltip.GetUpgradedPrimaryInfo))));
         }
 
         // We're not using UpgradesAvailable / FindUpgrades

--- a/KSPCommunityFixes/BugFixes/PartTooltipUpgradesApplyToSubstituteParts.cs
+++ b/KSPCommunityFixes/BugFixes/PartTooltipUpgradesApplyToSubstituteParts.cs
@@ -27,23 +27,15 @@ namespace KSPCommunityFixes
             return base.CanApplyPatch(out reason);
         }
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(PartListTooltip), nameof(PartListTooltip.Setup), new Type[] { typeof(AvailablePart), typeof(Callback<PartListTooltip>), typeof(RenderTexture) })));
+            AddPatch(PatchType.Transpiler, typeof(PartListTooltip), nameof(PartListTooltip.Setup), new Type[] { typeof(AvailablePart), typeof(Callback<PartListTooltip>), typeof(RenderTexture) });
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(PartListTooltip), nameof(PartListTooltip.Setup), new Type[] { typeof(AvailablePart), typeof(Callback<PartListTooltip>), typeof(RenderTexture) })));
+            AddPatch(PatchType.Prefix, typeof(PartListTooltip), nameof(PartListTooltip.Setup), new Type[] { typeof(AvailablePart), typeof(Callback<PartListTooltip>), typeof(RenderTexture) });
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(PartListTooltip), nameof(PartListTooltip.UpdateVariantText))));
+            AddPatch(PatchType.Transpiler, typeof(PartListTooltip), nameof(PartListTooltip.UpdateVariantText));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(PartListTooltip), nameof(PartListTooltip.GetUpgradedPrimaryInfo))));
+            AddPatch(PatchType.Prefix, typeof(PartListTooltip), nameof(PartListTooltip.GetUpgradedPrimaryInfo));
         }
 
         // We're not using UpgradesAvailable / FindUpgrades

--- a/KSPCommunityFixes/BugFixes/PropellantFlowDescription.cs
+++ b/KSPCommunityFixes/BugFixes/PropellantFlowDescription.cs
@@ -8,15 +8,11 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(Propellant), nameof(Propellant.GetFlowModeDescription))));
+            AddPatch(PatchType.Prefix, typeof(Propellant), nameof(Propellant.GetFlowModeDescription));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Propellant), nameof(Propellant.GetFlowModeDescription))));
+            AddPatch(PatchType.Postfix, typeof(Propellant), nameof(Propellant.GetFlowModeDescription));
         }
 
         // doing this this way rather than via __state

--- a/KSPCommunityFixes/BugFixes/PropellantFlowDescription.cs
+++ b/KSPCommunityFixes/BugFixes/PropellantFlowDescription.cs
@@ -12,13 +12,11 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(Propellant), nameof(Propellant.GetFlowModeDescription)),
-                this));
+                AccessTools.Method(typeof(Propellant), nameof(Propellant.GetFlowModeDescription))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Propellant), nameof(Propellant.GetFlowModeDescription)),
-                this));
+                AccessTools.Method(typeof(Propellant), nameof(Propellant.GetFlowModeDescription))));
         }
 
         // doing this this way rather than via __state

--- a/KSPCommunityFixes/BugFixes/ROCValidationOOR.cs
+++ b/KSPCommunityFixes/BugFixes/ROCValidationOOR.cs
@@ -14,11 +14,9 @@ namespace KSPCommunityFixes
         private static Func<ROCManager, string, CelestialBody> ValidCelestialBody;
         private static Func<ROCManager, CelestialBody, string, bool> ValidCBBiome;
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ROCManager), "ValidateCBBiomeCombos")));
+            AddPatch(PatchType.Prefix, typeof(ROCManager), "ValidateCBBiomeCombos");
 
             ValidCelestialBody = AccessTools.MethodDelegate<Func<ROCManager, string, CelestialBody>>(AccessTools.Method(typeof(ROCManager), "ValidCelestialBody"));
             ValidCBBiome = AccessTools.MethodDelegate<Func<ROCManager, CelestialBody, string, bool>>(AccessTools.Method(typeof(ROCManager), "ValidCBBiome"));

--- a/KSPCommunityFixes/BugFixes/ROCValidationOOR.cs
+++ b/KSPCommunityFixes/BugFixes/ROCValidationOOR.cs
@@ -18,8 +18,7 @@ namespace KSPCommunityFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ROCManager), "ValidateCBBiomeCombos"),
-                this));
+                AccessTools.Method(typeof(ROCManager), "ValidateCBBiomeCombos")));
 
             ValidCelestialBody = AccessTools.MethodDelegate<Func<ROCManager, string, CelestialBody>>(AccessTools.Method(typeof(ROCManager), "ValidCelestialBody"));
             ValidCBBiome = AccessTools.MethodDelegate<Func<ROCManager, CelestialBody, string, bool>>(AccessTools.Method(typeof(ROCManager), "ValidCBBiome"));

--- a/KSPCommunityFixes/BugFixes/ReRootPreserveSurfaceAttach.cs
+++ b/KSPCommunityFixes/BugFixes/ReRootPreserveSurfaceAttach.cs
@@ -15,11 +15,9 @@ namespace KSPCommunityFixes.BugFixes
 {
     class ReRootPreserveSurfaceAttach : BasePatch
     {
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(Part), nameof(Part.SetHierarchyRoot))));
+            AddPatch(PatchType.Transpiler, typeof(Part), nameof(Part.SetHierarchyRoot));
         }
 
         // skip the portion of that method that alter surface nodes position/orientation on re-rooting, 

--- a/KSPCommunityFixes/BugFixes/ReRootPreserveSurfaceAttach.cs
+++ b/KSPCommunityFixes/BugFixes/ReRootPreserveSurfaceAttach.cs
@@ -19,8 +19,7 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(Part), nameof(Part.SetHierarchyRoot)),
-                this));
+                AccessTools.Method(typeof(Part), nameof(Part.SetHierarchyRoot))));
         }
 
         // skip the portion of that method that alter surface nodes position/orientation on re-rooting, 

--- a/KSPCommunityFixes/BugFixes/ReactionWheelsPotentialTorque.cs
+++ b/KSPCommunityFixes/BugFixes/ReactionWheelsPotentialTorque.cs
@@ -10,11 +10,9 @@ namespace KSPCommunityFixes
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleReactionWheel), nameof(ModuleReactionWheel.GetPotentialTorque))));
+            AddPatch(PatchType.Prefix, typeof(ModuleReactionWheel), nameof(ModuleReactionWheel.GetPotentialTorque));
         }
 
         static bool ModuleReactionWheel_GetPotentialTorque_Prefix(ModuleReactionWheel __instance, out Vector3 pos, out Vector3 neg)

--- a/KSPCommunityFixes/BugFixes/ReactionWheelsPotentialTorque.cs
+++ b/KSPCommunityFixes/BugFixes/ReactionWheelsPotentialTorque.cs
@@ -14,8 +14,7 @@ namespace KSPCommunityFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleReactionWheel), nameof(ModuleReactionWheel.GetPotentialTorque)),
-                this));
+                AccessTools.Method(typeof(ModuleReactionWheel), nameof(ModuleReactionWheel.GetPotentialTorque))));
         }
 
         static bool ModuleReactionWheel_GetPotentialTorque_Prefix(ModuleReactionWheel __instance, out Vector3 pos, out Vector3 neg)

--- a/KSPCommunityFixes/BugFixes/RefundingOnRecovery.cs
+++ b/KSPCommunityFixes/BugFixes/RefundingOnRecovery.cs
@@ -54,11 +54,9 @@ namespace KSPCommunityFixes.BugFixes
 
         protected override Version VersionMin => new Version(1, 11, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(Funding), "onVesselRecoveryProcessing")));
+            AddPatch(PatchType.Transpiler, typeof(Funding), "onVesselRecoveryProcessing");
 
             moduleInventoryPartDerivatives.Clear();
             moduleInventoryPartDerivatives.Add(nameof(ModuleInventoryPart));

--- a/KSPCommunityFixes/BugFixes/RefundingOnRecovery.cs
+++ b/KSPCommunityFixes/BugFixes/RefundingOnRecovery.cs
@@ -58,8 +58,7 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(Funding), "onVesselRecoveryProcessing"),
-                this));
+                AccessTools.Method(typeof(Funding), "onVesselRecoveryProcessing")));
 
             moduleInventoryPartDerivatives.Clear();
             moduleInventoryPartDerivatives.Add(nameof(ModuleInventoryPart));

--- a/KSPCommunityFixes/BugFixes/RescaledRoboticParts.cs
+++ b/KSPCommunityFixes/BugFixes/RescaledRoboticParts.cs
@@ -19,8 +19,7 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(BaseServo), nameof(BaseServo.SetChildParentTransform)),
-                this));
+                AccessTools.Method(typeof(BaseServo), nameof(BaseServo.SetChildParentTransform))));
         }
 
         private static IEnumerable<CodeInstruction> BaseServo_SetChildParentTransform_Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/KSPCommunityFixes/BugFixes/RescaledRoboticParts.cs
+++ b/KSPCommunityFixes/BugFixes/RescaledRoboticParts.cs
@@ -15,11 +15,9 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(BaseServo), nameof(BaseServo.SetChildParentTransform))));
+            AddPatch(PatchType.Transpiler, typeof(BaseServo), nameof(BaseServo.SetChildParentTransform));
         }
 
         private static IEnumerable<CodeInstruction> BaseServo_SetChildParentTransform_Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/KSPCommunityFixes/BugFixes/RespawnDeadKerbals.cs
+++ b/KSPCommunityFixes/BugFixes/RespawnDeadKerbals.cs
@@ -10,12 +10,11 @@ namespace KSPCommunityFixes.BugFixes
     class RespawnDeadKerbals : BasePatch
     {
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
+            AddPatch(PatchType.Postfix,
                 AccessTools.Constructor(typeof(Game), new Type[] { typeof(ConfigNode) }),
-                nameof(Game_Constructor_Postfix)));
+                nameof(Game_Constructor_Postfix));
         }
 
         static void Game_Constructor_Postfix(Game __instance)

--- a/KSPCommunityFixes/BugFixes/RespawnDeadKerbals.cs
+++ b/KSPCommunityFixes/BugFixes/RespawnDeadKerbals.cs
@@ -15,7 +15,6 @@ namespace KSPCommunityFixes.BugFixes
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
                 AccessTools.Constructor(typeof(Game), new Type[] { typeof(ConfigNode) }),
-                this,
                 nameof(Game_Constructor_Postfix)));
         }
 

--- a/KSPCommunityFixes/BugFixes/RestoreMaxPhysicsDT.cs
+++ b/KSPCommunityFixes/BugFixes/RestoreMaxPhysicsDT.cs
@@ -12,11 +12,9 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(TimeWarp), "updateRate")));
+            AddPatch(PatchType.Prefix, typeof(TimeWarp), "updateRate");
         }
 
         static void TimeWarp_updateRate_Prefix()

--- a/KSPCommunityFixes/BugFixes/RestoreMaxPhysicsDT.cs
+++ b/KSPCommunityFixes/BugFixes/RestoreMaxPhysicsDT.cs
@@ -16,8 +16,7 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(TimeWarp), "updateRate"),
-                this));
+                AccessTools.Method(typeof(TimeWarp), "updateRate")));
         }
 
         static void TimeWarp_updateRate_Prefix()

--- a/KSPCommunityFixes/BugFixes/RoboticsDrift.cs
+++ b/KSPCommunityFixes/BugFixes/RoboticsDrift.cs
@@ -27,33 +27,27 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(BaseServo), nameof(BaseServo.OnStart)),
-                this));
+                AccessTools.Method(typeof(BaseServo), nameof(BaseServo.OnStart))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(BaseServo), nameof(BaseServo.OnDestroy)),
-                this));
+                AccessTools.Method(typeof(BaseServo), nameof(BaseServo.OnDestroy))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(BaseServo), nameof(BaseServo.RecurseCoordUpdate)),
-                this));
+                AccessTools.Method(typeof(BaseServo), nameof(BaseServo.RecurseCoordUpdate))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(BaseServo), nameof(BaseServo.OnSave)),
-                this));
+                AccessTools.Method(typeof(BaseServo), nameof(BaseServo.OnSave))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(BaseServo), nameof(BaseServo.ModifyLocked)),
-                this));
+                AccessTools.Method(typeof(BaseServo), nameof(BaseServo.ModifyLocked))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(BaseServo), nameof(BaseServo.OnPartPack)),
-                this));
+                AccessTools.Method(typeof(BaseServo), nameof(BaseServo.OnPartPack))));
 
             GameEvents.onGameSceneLoadRequested.Add(OnSceneSwitch);
         }

--- a/KSPCommunityFixes/BugFixes/RoboticsDrift.cs
+++ b/KSPCommunityFixes/BugFixes/RoboticsDrift.cs
@@ -23,31 +23,19 @@ namespace KSPCommunityFixes.BugFixes
             return base.CanApplyPatch(out reason);
         }
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(BaseServo), nameof(BaseServo.OnStart))));
+            AddPatch(PatchType.Postfix, typeof(BaseServo), nameof(BaseServo.OnStart));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(BaseServo), nameof(BaseServo.OnDestroy))));
+            AddPatch(PatchType.Postfix, typeof(BaseServo), nameof(BaseServo.OnDestroy));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(BaseServo), nameof(BaseServo.RecurseCoordUpdate))));
+            AddPatch(PatchType.Prefix, typeof(BaseServo), nameof(BaseServo.RecurseCoordUpdate));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(BaseServo), nameof(BaseServo.OnSave))));
+            AddPatch(PatchType.Prefix, typeof(BaseServo), nameof(BaseServo.OnSave));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(BaseServo), nameof(BaseServo.ModifyLocked))));
+            AddPatch(PatchType.Prefix, typeof(BaseServo), nameof(BaseServo.ModifyLocked));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(BaseServo), nameof(BaseServo.OnPartPack))));
+            AddPatch(PatchType.Prefix, typeof(BaseServo), nameof(BaseServo.OnPartPack));
 
             GameEvents.onGameSceneLoadRequested.Add(OnSceneSwitch);
         }

--- a/KSPCommunityFixes/BugFixes/ScatterDistribution.cs
+++ b/KSPCommunityFixes/BugFixes/ScatterDistribution.cs
@@ -10,11 +10,9 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(PQSLandControl), nameof(PQSLandControl.OnVertexBuildHeight))));
+            AddPatch(PatchType.Transpiler, typeof(PQSLandControl), nameof(PQSLandControl.OnVertexBuildHeight));
         }
 
         static IEnumerable<CodeInstruction> PQSLandControl_OnVertexBuildHeight_Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/KSPCommunityFixes/BugFixes/ScatterDistribution.cs
+++ b/KSPCommunityFixes/BugFixes/ScatterDistribution.cs
@@ -14,8 +14,7 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(PQSLandControl), nameof(PQSLandControl.OnVertexBuildHeight)),
-                this));
+                AccessTools.Method(typeof(PQSLandControl), nameof(PQSLandControl.OnVertexBuildHeight))));
         }
 
         static IEnumerable<CodeInstruction> PQSLandControl_OnVertexBuildHeight_Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/KSPCommunityFixes/BugFixes/StickySplashedFixer.cs
+++ b/KSPCommunityFixes/BugFixes/StickySplashedFixer.cs
@@ -12,28 +12,23 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(Vessel), nameof(Vessel.updateSituation)),
-                this));
+                AccessTools.Method(typeof(Vessel), nameof(Vessel.updateSituation))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(Part), nameof(Part.Die)),
-                this));
+                AccessTools.Method(typeof(Part), nameof(Part.Die))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Part), nameof(Part.Die)),
-                this));
+                AccessTools.Method(typeof(Part), nameof(Part.Die))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(Part), nameof(Part.decouple)),
-                this));
+                AccessTools.Method(typeof(Part), nameof(Part.decouple))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Part), nameof(Part.decouple)),
-                this));
+                AccessTools.Method(typeof(Part), nameof(Part.decouple))));
         }
 
         static bool Vessel_updateSituation_Prefix(Vessel __instance)

--- a/KSPCommunityFixes/BugFixes/StickySplashedFixer.cs
+++ b/KSPCommunityFixes/BugFixes/StickySplashedFixer.cs
@@ -8,27 +8,17 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(Vessel), nameof(Vessel.updateSituation))));
+            AddPatch(PatchType.Prefix, typeof(Vessel), nameof(Vessel.updateSituation));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(Part), nameof(Part.Die))));
+            AddPatch(PatchType.Prefix, typeof(Part), nameof(Part.Die));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Part), nameof(Part.Die))));
+            AddPatch(PatchType.Postfix, typeof(Part), nameof(Part.Die));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(Part), nameof(Part.decouple))));
+            AddPatch(PatchType.Prefix, typeof(Part), nameof(Part.decouple));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Part), nameof(Part.decouple))));
+            AddPatch(PatchType.Postfix, typeof(Part), nameof(Part.decouple));
         }
 
         static bool Vessel_updateSituation_Prefix(Vessel __instance)

--- a/KSPCommunityFixes/BugFixes/StockAlarmCustomFormatterDate.cs
+++ b/KSPCommunityFixes/BugFixes/StockAlarmCustomFormatterDate.cs
@@ -14,7 +14,7 @@ namespace KSPCommunityFixes
         protected override Version VersionMin => new Version(1, 12, 0);
         protected override Version VersionMax => new Version(1, 12, 3); // bug fixed in KSP 1.12.4
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
             foreach (MethodInfo methodInfo in AccessTools.GetDeclaredMethods(typeof(AppUIMember)))
             {
@@ -35,13 +35,9 @@ namespace KSPCommunityFixes
             if (AppUIMember_SetValue == null)
                 throw new Exception("AppUIMember.SetValue() : method not found");
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(AppUIMemberDateTime), "OnRefreshUI")));
+            AddPatch(PatchType.Prefix, typeof(AppUIMemberDateTime), "OnRefreshUI");
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(AppUIMemberDateTime), "InputEdited")));
+            AddPatch(PatchType.Prefix, typeof(AppUIMemberDateTime), "InputEdited");
         }
 
         static bool AppUIMemberDateTime_OnRefreshUI_Prefix(

--- a/KSPCommunityFixes/BugFixes/StockAlarmCustomFormatterDate.cs
+++ b/KSPCommunityFixes/BugFixes/StockAlarmCustomFormatterDate.cs
@@ -37,13 +37,11 @@ namespace KSPCommunityFixes
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(AppUIMemberDateTime), "OnRefreshUI"),
-                this));
+                AccessTools.Method(typeof(AppUIMemberDateTime), "OnRefreshUI")));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(AppUIMemberDateTime), "InputEdited"),
-                this));
+                AccessTools.Method(typeof(AppUIMemberDateTime), "InputEdited")));
         }
 
         static bool AppUIMemberDateTime_OnRefreshUI_Prefix(

--- a/KSPCommunityFixes/BugFixes/StockAlarmDescPreserveLineBreak.cs
+++ b/KSPCommunityFixes/BugFixes/StockAlarmDescPreserveLineBreak.cs
@@ -8,11 +8,9 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 12, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(AlarmTypeBase), nameof(AlarmTypeBase.OnSave))));
+            AddPatch(PatchType.Prefix, typeof(AlarmTypeBase), nameof(AlarmTypeBase.OnSave));
         }
 
         static void AlarmTypeBase_OnSave_Prefix(AlarmTypeBase __instance)

--- a/KSPCommunityFixes/BugFixes/StockAlarmDescPreserveLineBreak.cs
+++ b/KSPCommunityFixes/BugFixes/StockAlarmDescPreserveLineBreak.cs
@@ -12,8 +12,7 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(AlarmTypeBase), nameof(AlarmTypeBase.OnSave)),
-                this));
+                AccessTools.Method(typeof(AlarmTypeBase), nameof(AlarmTypeBase.OnSave))));
         }
 
         static void AlarmTypeBase_OnSave_Prefix(AlarmTypeBase __instance)

--- a/KSPCommunityFixes/BugFixes/StrategyDuration.cs
+++ b/KSPCommunityFixes/BugFixes/StrategyDuration.cs
@@ -10,25 +10,19 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
+            AddPatch(PatchType.Prefix,
                 AccessTools.PropertyGetter(typeof(Strategy), nameof(Strategy.LongestDuration)),
-                nameof(Strategy_LongestDuration)));
+                nameof(Strategy_LongestDuration));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
+            AddPatch(PatchType.Prefix,
                 AccessTools.PropertyGetter(typeof(Strategy), nameof(Strategy.LeastDuration)),
-                nameof(Strategy_LeastDuration)));
+                nameof(Strategy_LeastDuration));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(Strategy), nameof(Strategy.CanBeDeactivated))));
+            AddPatch(PatchType.Transpiler, typeof(Strategy), nameof(Strategy.CanBeDeactivated));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(Strategy), nameof(Strategy.SendStateMessage))));
+            AddPatch(PatchType.Transpiler, typeof(Strategy), nameof(Strategy.SendStateMessage));
         }
 
         static bool Strategy_LongestDuration(Strategy __instance, ref double __result)

--- a/KSPCommunityFixes/BugFixes/StrategyDuration.cs
+++ b/KSPCommunityFixes/BugFixes/StrategyDuration.cs
@@ -15,22 +15,20 @@ namespace KSPCommunityFixes.BugFixes
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
                 AccessTools.PropertyGetter(typeof(Strategy), nameof(Strategy.LongestDuration)),
-                this, nameof(Strategy_LongestDuration)));
+                nameof(Strategy_LongestDuration)));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
                 AccessTools.PropertyGetter(typeof(Strategy), nameof(Strategy.LeastDuration)),
-                this, nameof(Strategy_LeastDuration)));
+                nameof(Strategy_LeastDuration)));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(Strategy), nameof(Strategy.CanBeDeactivated)),
-                this));
+                AccessTools.Method(typeof(Strategy), nameof(Strategy.CanBeDeactivated))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(Strategy), nameof(Strategy.SendStateMessage)),
-                this));
+                AccessTools.Method(typeof(Strategy), nameof(Strategy.SendStateMessage))));
         }
 
         static bool Strategy_LongestDuration(Strategy __instance, ref double __result)

--- a/KSPCommunityFixes/BugFixes/ThumbnailSpotlight.cs
+++ b/KSPCommunityFixes/BugFixes/ThumbnailSpotlight.cs
@@ -8,11 +8,9 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 12, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(CraftThumbnail), nameof(CraftThumbnail.TakePartSnapshot))));
+            AddPatch(PatchType.Postfix, typeof(CraftThumbnail), nameof(CraftThumbnail.TakePartSnapshot));
         }
 
         private static void CraftThumbnail_TakePartSnapshot_Postfix()

--- a/KSPCommunityFixes/BugFixes/ThumbnailSpotlight.cs
+++ b/KSPCommunityFixes/BugFixes/ThumbnailSpotlight.cs
@@ -12,8 +12,7 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(CraftThumbnail), nameof(CraftThumbnail.TakePartSnapshot)),
-                this));
+                AccessTools.Method(typeof(CraftThumbnail), nameof(CraftThumbnail.TakePartSnapshot))));
         }
 
         private static void CraftThumbnail_TakePartSnapshot_Postfix()

--- a/KSPCommunityFixes/BugFixes/TimeWarpOrbitShift.cs
+++ b/KSPCommunityFixes/BugFixes/TimeWarpOrbitShift.cs
@@ -23,11 +23,9 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(TimeWarp), nameof(TimeWarp.setRate))));
+            AddPatch(PatchType.Prefix, typeof(TimeWarp), nameof(TimeWarp.setRate));
         }
 
         static void TimeWarp_setRate_Prefix(TimeWarp __instance, int rateIdx)

--- a/KSPCommunityFixes/BugFixes/TimeWarpOrbitShift.cs
+++ b/KSPCommunityFixes/BugFixes/TimeWarpOrbitShift.cs
@@ -27,8 +27,7 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(TimeWarp), nameof(TimeWarp.setRate)),
-                this));
+                AccessTools.Method(typeof(TimeWarp), nameof(TimeWarp.setRate))));
         }
 
         static void TimeWarp_setRate_Prefix(TimeWarp __instance, int rateIdx)

--- a/KSPCommunityFixes/BugFixes/UpgradeBugs.cs
+++ b/KSPCommunityFixes/BugFixes/UpgradeBugs.cs
@@ -18,63 +18,52 @@ namespace KSPCommunityFixes
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
                 AccessTools.Constructor(typeof(PartModule)),
-                this, "PartModule_ctor_Postfix"));
+                nameof(PartModule_ctor_Postfix)));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(PartListTooltip), nameof(PartListTooltip.SetupUpgradeInfo)),
-                this));
+                AccessTools.Method(typeof(PartListTooltip), nameof(PartListTooltip.SetupUpgradeInfo))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(PartListTooltip), nameof(PartListTooltip.Setup), new Type[] { typeof(AvailablePart), typeof(Callback<PartListTooltip>), typeof(RenderTexture) }),
-                this));
+                AccessTools.Method(typeof(PartListTooltip), nameof(PartListTooltip.Setup), new Type[] { typeof(AvailablePart), typeof(Callback<PartListTooltip>), typeof(RenderTexture) })));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(PartListTooltip), nameof(PartListTooltip.DisplayExtendedInfo)),
-                this));
+                AccessTools.Method(typeof(PartListTooltip), nameof(PartListTooltip.DisplayExtendedInfo))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(PartListTooltip), nameof(PartListTooltip.CreateExtendedInfo)),
-                this));
+                AccessTools.Method(typeof(PartListTooltip), nameof(PartListTooltip.CreateExtendedInfo))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(PartModule), nameof(PartModule.UpgradesAvailable), new Type[] { typeof(Part), typeof(ConfigNode) }),
-                this));
+                AccessTools.Method(typeof(PartModule), nameof(PartModule.UpgradesAvailable), new Type[] { typeof(Part), typeof(ConfigNode) })));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(PartModule), nameof(PartModule.FindUpgrades)),
-                this));
+                AccessTools.Method(typeof(PartModule), nameof(PartModule.FindUpgrades))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(EditorLogic), nameof(EditorLogic.OnPodSpawn)),
-                this));
+                AccessTools.Method(typeof(EditorLogic), nameof(EditorLogic.OnPodSpawn))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(EditorLogic), nameof(EditorLogic.SpawnPart)),
-                this));
+                AccessTools.Method(typeof(EditorLogic), nameof(EditorLogic.SpawnPart))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(EditorLogic), nameof(EditorLogic.SpawnPart)),
-                this));
+                AccessTools.Method(typeof(EditorLogic), nameof(EditorLogic.SpawnPart))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Part), nameof(Part.GetModuleCosts)),
-                this));
+                AccessTools.Method(typeof(Part), nameof(Part.GetModuleCosts))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
                 AccessTools.Method(typeof(PartUpgradeHandler.Upgrade), nameof(PartUpgradeHandler.Upgrade.GetUsedByStrings)),
-                this,
-                "GetUsedBy_Prefix"));
+                nameof(GetUsedBy_Prefix)));
         }
 
         static void PartModule_ctor_Postfix(PartModule __instance)

--- a/KSPCommunityFixes/BugFixes/UpgradeBugs.cs
+++ b/KSPCommunityFixes/BugFixes/UpgradeBugs.cs
@@ -209,7 +209,7 @@ namespace KSPCommunityFixes
             if (__instance.upgradeState == PartModule.PartUpgradeState.AVAILABLE)
             {
                 // Handle PartStatsUpgradeModule differently
-                var statsUpgradeModule = __instance.partRef.FindModuleImplementing<PartStatsUpgradeModule>();
+                var statsUpgradeModule = __instance.partRef.FindModuleImplementingFast<PartStatsUpgradeModule>();
                 if (statsUpgradeModule != null)
                 {
                     foreach (string upgradeName in statsUpgradeModule.upgradesApplied)
@@ -381,7 +381,7 @@ namespace KSPCommunityFixes
             __instance.rootPart.persistentId = FlightGlobals.CheckPartpersistentId(__instance.rootPart.persistentId, __instance.rootPart, false, true);
             if (__instance.rootPart.variants != null && pod.variant != null && pod.variant.Name != null)
                 __instance.rootPart.variants.SetVariant(pod.variant.Name);
-            ModuleInventoryPart moduleInventoryPart = __instance.rootPart.FindModuleImplementing<ModuleInventoryPart>();
+            ModuleInventoryPart moduleInventoryPart = __instance.rootPart.FindModuleImplementingFast<ModuleInventoryPart>();
             if (moduleInventoryPart != null)
                 moduleInventoryPart.SetInventoryDefaults();
 

--- a/KSPCommunityFixes/BugFixes/UpgradeBugs.cs
+++ b/KSPCommunityFixes/BugFixes/UpgradeBugs.cs
@@ -13,57 +13,31 @@ namespace KSPCommunityFixes
     {
         protected override Version VersionMin => new Version(1, 12, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Constructor(typeof(PartModule)),
-                nameof(PartModule_ctor_Postfix)));
+            AddPatch(PatchType.Postfix, AccessTools.Constructor(typeof(PartModule)), nameof(PartModule_ctor_Postfix));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(PartListTooltip), nameof(PartListTooltip.SetupUpgradeInfo))));
+            AddPatch(PatchType.Prefix, typeof(PartListTooltip), nameof(PartListTooltip.SetupUpgradeInfo));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(PartListTooltip), nameof(PartListTooltip.Setup), new Type[] { typeof(AvailablePart), typeof(Callback<PartListTooltip>), typeof(RenderTexture) })));
+            AddPatch(PatchType.Postfix, typeof(PartListTooltip), nameof(PartListTooltip.Setup), new Type[] { typeof(AvailablePart), typeof(Callback<PartListTooltip>), typeof(RenderTexture) });
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(PartListTooltip), nameof(PartListTooltip.DisplayExtendedInfo))));
+            AddPatch(PatchType.Prefix, typeof(PartListTooltip), nameof(PartListTooltip.DisplayExtendedInfo));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(PartListTooltip), nameof(PartListTooltip.CreateExtendedInfo))));
+            AddPatch(PatchType.Prefix, typeof(PartListTooltip), nameof(PartListTooltip.CreateExtendedInfo));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(PartModule), nameof(PartModule.UpgradesAvailable), new Type[] { typeof(Part), typeof(ConfigNode) })));
+            AddPatch(PatchType.Prefix, typeof(PartModule), nameof(PartModule.UpgradesAvailable), new Type[] { typeof(Part), typeof(ConfigNode) });
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(PartModule), nameof(PartModule.FindUpgrades))));
+            AddPatch(PatchType.Transpiler, typeof(PartModule), nameof(PartModule.FindUpgrades));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(EditorLogic), nameof(EditorLogic.OnPodSpawn))));
+            AddPatch(PatchType.Prefix, typeof(EditorLogic), nameof(EditorLogic.OnPodSpawn));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(EditorLogic), nameof(EditorLogic.SpawnPart))));
+            AddPatch(PatchType.Prefix, typeof(EditorLogic), nameof(EditorLogic.SpawnPart));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(EditorLogic), nameof(EditorLogic.SpawnPart))));
+            AddPatch(PatchType.Postfix, typeof(EditorLogic), nameof(EditorLogic.SpawnPart));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Part), nameof(Part.GetModuleCosts))));
+            AddPatch(PatchType.Postfix, typeof(Part), nameof(Part.GetModuleCosts));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(PartUpgradeHandler.Upgrade), nameof(PartUpgradeHandler.Upgrade.GetUsedByStrings)),
-                nameof(GetUsedBy_Prefix)));
+            AddPatch(PatchType.Prefix, typeof(PartUpgradeHandler.Upgrade), nameof(PartUpgradeHandler.Upgrade.GetUsedByStrings), nameof(GetUsedBy_Prefix));
         }
 
         static void PartModule_ctor_Postfix(PartModule __instance)

--- a/KSPCommunityFixes/BugFixes/ZeroCostTechNodes.cs
+++ b/KSPCommunityFixes/BugFixes/ZeroCostTechNodes.cs
@@ -13,15 +13,11 @@ namespace KSPCommunityFixes.BugFixes
 
     internal class ZeroCostTechNodes : BasePatch
     {
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(RDTech), nameof(RDTech.Start))));
+            AddPatch(PatchType.Postfix, typeof(RDTech), nameof(RDTech.Start));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(RDTech), nameof(RDTech.Load))));
+            AddPatch(PatchType.Transpiler, typeof(RDTech), nameof(RDTech.Load));
         }
 
         static void RDTech_Start_Postfix(RDTech __instance)

--- a/KSPCommunityFixes/BugFixes/ZeroCostTechNodes.cs
+++ b/KSPCommunityFixes/BugFixes/ZeroCostTechNodes.cs
@@ -17,13 +17,11 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(RDTech), nameof(RDTech.Start)),
-                this));
+                AccessTools.Method(typeof(RDTech), nameof(RDTech.Start))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(RDTech), nameof(RDTech.Load)),
-                this));
+                AccessTools.Method(typeof(RDTech), nameof(RDTech.Load))));
         }
 
         static void RDTech_Start_Postfix(RDTech __instance)

--- a/KSPCommunityFixes/Internal/PatchSettings.cs
+++ b/KSPCommunityFixes/Internal/PatchSettings.cs
@@ -24,13 +24,11 @@ namespace KSPCommunityFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(GameplaySettingsScreen), "DrawMiniSettings"),
-                this));
+                AccessTools.Method(typeof(GameplaySettingsScreen), "DrawMiniSettings")));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(GameplaySettingsScreen), "ApplySettings"),
-                this));
+                AccessTools.Method(typeof(GameplaySettingsScreen), "ApplySettings")));
 
             altimeterPatch = KSPCommunityFixes.GetPatchInstance<AltimeterHorizontalPosition>();
             if (altimeterPatch != null)

--- a/KSPCommunityFixes/Internal/PatchSettings.cs
+++ b/KSPCommunityFixes/Internal/PatchSettings.cs
@@ -20,15 +20,11 @@ namespace KSPCommunityFixes
         private static DisableManeuverTool maneuverToolPatch;
         private static OptionalMakingHistoryDLCFeatures disableMHPatch;
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(GameplaySettingsScreen), "DrawMiniSettings")));
+            AddPatch(PatchType.Postfix, typeof(GameplaySettingsScreen), "DrawMiniSettings");
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(GameplaySettingsScreen), "ApplySettings")));
+            AddPatch(PatchType.Postfix, typeof(GameplaySettingsScreen), "ApplySettings");
 
             altimeterPatch = KSPCommunityFixes.GetPatchInstance<AltimeterHorizontalPosition>();
             if (altimeterPatch != null)

--- a/KSPCommunityFixes/KSPCommunityFixes.cs
+++ b/KSPCommunityFixes/KSPCommunityFixes.cs
@@ -24,6 +24,8 @@ namespace KSPCommunityFixes
 
         public static KSPCommunityFixes Instance { get; private set; }
 
+        public static long FixedUpdateCount { get; private set; }
+
         private static string modPath;
         public static string ModPath
         {
@@ -116,6 +118,11 @@ namespace KSPCommunityFixes
             {
                 BasePatch.Patch(patchesType);
             }
+        }
+
+        void FixedUpdate()
+        {
+            FixedUpdateCount++;
         }
     }
 }

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Library\Collections\Deque.cs" />
     <Compile Include="Library\Extensions.cs" />
     <Compile Include="Library\LocalizationUtils.cs" />
+    <Compile Include="Library\Numerics.cs" />
     <Compile Include="Library\ObjectPool.cs" />
     <Compile Include="Modding\ModUpgradePipeline.cs" />
     <Compile Include="Performance\AsteroidAndCometDrillCache.cs" />
@@ -138,6 +139,7 @@
     <Compile Include="Performance\DisableMapUpdateInFlight.cs" />
     <Compile Include="Performance\DragCubeGeneration.cs" />
     <Compile Include="Performance\FastLoader.cs" />
+    <Compile Include="Performance\FlightPerf.cs" />
     <Compile Include="Performance\IMGUIOptimization.cs" />
     <Compile Include="Performance\LocalizerPerf.cs" />
     <Compile Include="Performance\LowerMinPhysicsDTPerFrame.cs" />

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -93,6 +93,7 @@
     <DoNotPublicize Include="Assembly-CSharp:SaveUpgradePipeline.SaveUpgradePipeline.OnSetCfgNodeVersion" />
     <Publicize Include="UnityEngine.CoreModule:UnityEngine.Object.m_CachedPtr" />
     <Publicize Include="UnityEngine.IMGUIModule" />
+    <Publicize Include="UnityEngine.CoreModule:Unity.Collections.NativeArray`1.m_Buffer" />
     <Publicize Include="mscorlib:System.IO.MonoIO" />
     <Publicize Include="mscorlib:System.IO.MonoIOError" />
     <Publicize Include="mscorlib:System.IO.MonoIOStat" />
@@ -124,6 +125,7 @@
     <Compile Include="BugFixes\StrategyDuration.cs" />
     <Compile Include="BugFixes\ZeroCostTechNodes.cs" />
     <Compile Include="Library\Collections\Deque.cs" />
+    <Compile Include="Library\Collections\FastStack.cs" />
     <Compile Include="Library\Extensions.cs" />
     <Compile Include="Library\LocalizationUtils.cs" />
     <Compile Include="Library\Numerics.cs" />

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -100,6 +100,17 @@
     <Publicize Include="mscorlib:System.IO.MonoIOStat" />
     <Publicize Include="mscorlib:System.Reflection.Assembly.GetTypes" />
     <Publicize Include="mscorlib:System.String.m_firstChar" />
+    <Publicize Include="0Harmony:MonoMod.Utils.Cil.ILGeneratorShimExt" />
+    <Publicize Include="0Harmony:MonoMod.Utils.Cil.CecilILGenerator+LabelInfo" />
+    <Publicize Include="0Harmony:MonoMod.Utils.Cil.CecilILGenerator+LabelledExceptionHandler" />
+    <Publicize Include="0Harmony:MonoMod.Utils.Cil.CecilILGenerator+ExceptionHandlerChain" />
+    <Publicize Include="0Harmony:MonoMod.Utils.Cil.CecilILGenerator._LabelInfos" />
+    <Publicize Include="0Harmony:MonoMod.Utils.Cil.CecilILGenerator._LabelsToMark" />
+    <Publicize Include="0Harmony:MonoMod.Utils.Cil.CecilILGenerator._ExceptionHandlersToMark" />
+    <Publicize Include="0Harmony:MonoMod.Utils.Cil.CecilILGenerator._Variables" />
+    <Publicize Include="0Harmony:MonoMod.Utils.Cil.CecilILGenerator._ExceptionHandlers" />
+    <Publicize Include="0Harmony:MonoMod.Utils.Cil.CecilILGenerator.labelCounter" />
+    <Publicize Include="0Harmony:MonoMod.Utils.Cil.CecilILGenerator._ILOffset" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BasePatch.cs" />
@@ -136,7 +147,7 @@
     <Compile Include="Performance\AsteroidAndCometDrillCache.cs" />
     <Compile Include="BugFixes\DoubleCurvePreserveTangents.cs" />
     <Compile Include="BugFixes\RestoreMaxPhysicsDT.cs" />
-    <Compile Include="Performance\AuxiliarySystemsFastUpdate.cs" />
+    <Compile Include="Performance\PartSystemsFastUpdate.cs" />
     <Compile Include="Performance\CollisionEnhancerFastUpdate.cs" />
     <Compile Include="Performance\CollisionManagerFastUpdate.cs" />
     <Compile Include="Performance\CommNetThrottling.cs" />

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -111,6 +111,11 @@
     <Publicize Include="0Harmony:MonoMod.Utils.Cil.CecilILGenerator._ExceptionHandlers" />
     <Publicize Include="0Harmony:MonoMod.Utils.Cil.CecilILGenerator.labelCounter" />
     <Publicize Include="0Harmony:MonoMod.Utils.Cil.CecilILGenerator._ILOffset" />
+    <Publicize Include="mscorlib:System.Reflection.Emit.Label.label" />
+    <Publicize Include="mscorlib:System.Reflection.LocalVariableInfo.position" />
+    <Publicize Include="mscorlib:System.Reflection.LocalVariableInfo.is_pinned" />
+    <Publicize Include="mscorlib:System.Reflection.LocalVariableInfo.type" />
+    <Publicize Include="0Harmony:Mono.Cecil.Cil.VariableReference.index" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BasePatch.cs" />

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -152,6 +152,7 @@
     <Compile Include="Performance\AsteroidAndCometDrillCache.cs" />
     <Compile Include="BugFixes\DoubleCurvePreserveTangents.cs" />
     <Compile Include="BugFixes\RestoreMaxPhysicsDT.cs" />
+    <Compile Include="Performance\FloatingOriginPerf.cs" />
     <Compile Include="Performance\PartSystemsFastUpdate.cs" />
     <Compile Include="Performance\CollisionEnhancerFastUpdate.cs" />
     <Compile Include="Performance\CollisionManagerFastUpdate.cs" />
@@ -161,7 +162,7 @@
     <Compile Include="Performance\DisableMapUpdateInFlight.cs" />
     <Compile Include="Performance\DragCubeGeneration.cs" />
     <Compile Include="Performance\FastLoader.cs" />
-    <Compile Include="Performance\FlightCoreSystemsPerf.cs" />
+    <Compile Include="Performance\FlightIntegratorPerf.cs" />
     <Compile Include="Performance\IMGUIOptimization.cs" />
     <Compile Include="Performance\LocalizerPerf.cs" />
     <Compile Include="Performance\LowerMinPhysicsDTPerFrame.cs" />

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -128,6 +128,7 @@
     <Compile Include="Library\Collections\Deque.cs" />
     <Compile Include="Library\Collections\FastStack.cs" />
     <Compile Include="Library\Extensions.cs" />
+    <Compile Include="Library\KSPObjectsExtensions.cs" />
     <Compile Include="Library\LocalizationUtils.cs" />
     <Compile Include="Library\Numerics.cs" />
     <Compile Include="Library\ObjectPool.cs" />
@@ -135,6 +136,8 @@
     <Compile Include="Performance\AsteroidAndCometDrillCache.cs" />
     <Compile Include="BugFixes\DoubleCurvePreserveTangents.cs" />
     <Compile Include="BugFixes\RestoreMaxPhysicsDT.cs" />
+    <Compile Include="Performance\AuxiliarySystemsFastUpdate.cs" />
+    <Compile Include="Performance\CollisionEnhancerFastUpdate.cs" />
     <Compile Include="Performance\CollisionManagerFastUpdate.cs" />
     <Compile Include="Performance\CommNetThrottling.cs" />
     <Compile Include="Performance\ContractProgressEnumCache.cs" />
@@ -142,7 +145,7 @@
     <Compile Include="Performance\DisableMapUpdateInFlight.cs" />
     <Compile Include="Performance\DragCubeGeneration.cs" />
     <Compile Include="Performance\FastLoader.cs" />
-    <Compile Include="Performance\FlightPerf.cs" />
+    <Compile Include="Performance\FlightCoreSystemsPerf.cs" />
     <Compile Include="Performance\IMGUIOptimization.cs" />
     <Compile Include="Performance\LocalizerPerf.cs" />
     <Compile Include="Performance\LowerMinPhysicsDTPerFrame.cs" />
@@ -175,6 +178,8 @@
     <Compile Include="Modding\ReflectionTypeLoadExceptionHandler.cs" />
     <Compile Include="Performance\FewerSaves.cs" />
     <Compile Include="Performance\ConfigNodePerf.cs" />
+    <Compile Include="Performance\MinorPerfTweaks.cs" />
+    <Compile Include="Performance\ModuleDockingNodeFindOtherNodesFaster.cs" />
     <Compile Include="Performance\OptimizedModuleRaycasts.cs" />
     <Compile Include="Performance\PQSCoroutineLeak.cs" />
     <Compile Include="Performance\PQSUpdateNoMemoryAlloc.cs" />

--- a/KSPCommunityFixes/Library/Collections/Deque.cs
+++ b/KSPCommunityFixes/Library/Collections/Deque.cs
@@ -808,25 +808,25 @@ namespace KSPCommunityFixes.Library.Collections
         }
 #pragma warning restore CA1812
 
-        private static IReadOnlyCollection<T> ReifyCollection<T>(IEnumerable<T> source)
+        private static IReadOnlyCollection<IT> ReifyCollection<IT>(IEnumerable<IT> source)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            var result = source as IReadOnlyCollection<T>;
+            var result = source as IReadOnlyCollection<IT>;
             if (result != null)
                 return result;
-            var collection = source as ICollection<T>;
+            var collection = source as ICollection<IT>;
             if (collection != null)
-                return new CollectionWrapper<T>(collection);
+                return new CollectionWrapper<IT>(collection);
             var nongenericCollection = source as ICollection;
             if (nongenericCollection != null)
-                return new NongenericCollectionWrapper<T>(nongenericCollection);
+                return new NongenericCollectionWrapper<IT>(nongenericCollection);
 
-            return new List<T>(source);
+            return new List<IT>(source);
         }
 
-        private sealed class NongenericCollectionWrapper<T> : IReadOnlyCollection<T>
+        private sealed class NongenericCollectionWrapper<IT> : IReadOnlyCollection<IT>
         {
             private readonly ICollection _collection;
 
@@ -845,9 +845,9 @@ namespace KSPCommunityFixes.Library.Collections
                 }
             }
 
-            public IEnumerator<T> GetEnumerator()
+            public IEnumerator<IT> GetEnumerator()
             {
-                foreach (T item in _collection)
+                foreach (IT item in _collection)
                     yield return item;
             }
 
@@ -857,11 +857,11 @@ namespace KSPCommunityFixes.Library.Collections
             }
         }
 
-        private sealed class CollectionWrapper<T> : IReadOnlyCollection<T>
+        private sealed class CollectionWrapper<IT> : IReadOnlyCollection<IT>
         {
-            private readonly ICollection<T> _collection;
+            private readonly ICollection<IT> _collection;
 
-            public CollectionWrapper(ICollection<T> collection)
+            public CollectionWrapper(ICollection<IT> collection)
             {
                 if (collection == null)
                     throw new ArgumentNullException(nameof(collection));
@@ -876,7 +876,7 @@ namespace KSPCommunityFixes.Library.Collections
                 }
             }
 
-            public IEnumerator<T> GetEnumerator()
+            public IEnumerator<IT> GetEnumerator()
             {
                 return _collection.GetEnumerator();
             }

--- a/KSPCommunityFixes/Library/Collections/FastStack.cs
+++ b/KSPCommunityFixes/Library/Collections/FastStack.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace KSPCommunityFixes.Library.Collections
+{
+    internal class FastStack<T> where T : class
+    {
+        private T[] _array = Array.Empty<T>();
+        private int _size;
+
+        public void EnsureCapacity(int capacity)
+        {
+            if (_array.Length < capacity)
+                _array = new T[capacity];
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Push(T item)
+        {
+            _array[_size++] = item;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryPop(out T result)
+        {
+            if (_size == 0)
+            {
+                result = null;
+                return false;
+            }
+
+            result = _array[--_size];
+            _array[_size] = null;
+            return true;
+        }
+
+        public void Clear()
+        {
+            Array.Clear(_array, 0, _size);
+            _size = 0;
+        }
+    }
+}

--- a/KSPCommunityFixes/Library/Extensions.cs
+++ b/KSPCommunityFixes/Library/Extensions.cs
@@ -1,8 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
 
 namespace KSPCommunityFixes
@@ -21,6 +20,48 @@ namespace KSPCommunityFixes
         public static bool IsPAWOpen(this Part part)
         {
             return part.PartActionWindow.IsNotNullOrDestroyed() && part.PartActionWindow.isActiveAndEnabled;
+        }
+    }
+
+    static class ParticleBuffer
+    {
+        private static NativeArray<ParticleSystem.Particle> particleBuffer = new NativeArray<ParticleSystem.Particle>(1000, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
+        private static long particleSize = UnsafeUtility.SizeOf<ParticleSystem.Particle>();
+
+        /// <summary>
+        /// Get a native array of active Particle in this ParticleSystem
+        /// </summary>
+        /// <param name="particleCount">The amount of particles in the system, usually ParticleSystem.particleCount. After returning, this will be the amount of active particles, which might be lower.</param>
+        /// <returns></returns>
+        public static NativeArray<ParticleSystem.Particle> GetParticlesNativeArray(this ParticleSystem particleSystem, ref int particleCount)
+        {
+            if (particleBuffer.Length < particleCount)
+            {
+                particleBuffer.Dispose();
+                particleBuffer = new NativeArray<ParticleSystem.Particle>(particleCount * 2, Allocator.Persistent, NativeArrayOptions.UninitializedMemory);
+            }
+            particleCount = particleSystem.GetParticles(particleBuffer);
+            return particleBuffer;
+        }
+
+        /// <summary>
+        /// Get the position of the particle at the specified index, avoiding to have to make copies of the (huge) particle struct
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe Vector3 GetParticlePosition(this NativeArray<ParticleSystem.Particle> buffer, int particleIndex)
+        {
+            // note : the position Vector3 is the first field of the struct
+            return *(Vector3*)((byte*)buffer.m_Buffer + particleIndex * particleSize);
+        }
+
+        /// <summary>
+        /// Set the position of the particle at the specified index, avoiding to have to make copies of the (huge) particle struct
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe void SetParticlePosition(this NativeArray<ParticleSystem.Particle> buffer, int particleIndex, Vector3 position)
+        {
+            // note : the position Vector3 is the first field of the struct
+            *(Vector3*)((byte*)buffer.m_Buffer + particleIndex * particleSize) = position;
         }
     }
 }

--- a/KSPCommunityFixes/Library/Extensions.cs
+++ b/KSPCommunityFixes/Library/Extensions.cs
@@ -10,17 +10,6 @@ namespace KSPCommunityFixes
     static class Extensions
     {
         /// <summary>
-        /// Transforms a direction by this matrix.
-        /// </summary>
-        public static Vector3 MultiplyVector(this Matrix4x4 m, float x, float y, float z)
-        {
-            return new Vector3(
-                m.m00 * x + m.m01 * y + m.m02 * z,
-                m.m10 * x + m.m11 * y + m.m12 * z,
-                m.m20 * x + m.m21 * y + m.m22 * z);
-        }
-
-        /// <summary>
         /// Get an assembly qualified type name in the "assemblyName:typeName" format
         /// </summary>
         public static string AssemblyQualifiedName(this object obj)

--- a/KSPCommunityFixes/Library/KSPObjectsExtensions.cs
+++ b/KSPCommunityFixes/Library/KSPObjectsExtensions.cs
@@ -1,10 +1,9 @@
-﻿using System;
+﻿// #define PROFILE_KSPObjectsExtensions
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 using Debug = UnityEngine.Debug;
 
@@ -320,7 +319,12 @@ namespace KSPCommunityFixes
         {
             return FindModelSkinnedMeshRenderersReadOnly(part).ToArray();
         }
+    }
 
+#if PROFILE_KSPObjectsExtensions
+    [KSPAddon(KSPAddon.Startup.MainMenu, false)]
+    public class MainMenuTester : MonoBehaviour
+    {
         public static Stopwatch w1 = new Stopwatch();
         public static Stopwatch w2 = new Stopwatch();
         public static Stopwatch w3 = new Stopwatch();
@@ -328,6 +332,21 @@ namespace KSPCommunityFixes
         public static Stopwatch w5 = new Stopwatch();
         public static Stopwatch w6 = new Stopwatch();
         public static Stopwatch w7 = new Stopwatch();
+
+        public IEnumerator Start()
+        {
+            for (int i = 0; i < 50; i++)
+            {
+                yield return null;
+            }
+
+            for (int i = 0; i < 50; i++)
+            {
+                Benchmark();
+                yield return null;
+            }
+            
+        }
 
         public static void Benchmark()
         {
@@ -337,7 +356,7 @@ namespace KSPCommunityFixes
             // warmup
             foreach (AvailablePart availablePart in PartLoader.LoadedPartsList)
             {
-                FindModelRenderersFast(availablePart.partPrefab, renderers); 
+                availablePart.partPrefab.FindModelRenderersFast(renderers);
                 renderers = availablePart.partPrefab.FindModelComponents<Renderer>();
                 renderers = availablePart.partPrefab.FindModelRenderersCached();
                 renderersArray = availablePart.partPrefab.FindModelRenderersCachedFast();
@@ -346,7 +365,7 @@ namespace KSPCommunityFixes
             w1.Start();
             foreach (AvailablePart availablePart in PartLoader.LoadedPartsList)
             {
-                FindModelRenderersFast(availablePart.partPrefab, renderers);
+                availablePart.partPrefab.FindModelRenderersFast(renderers);
             }
             w1.Stop();
             Debug.Log($"FindModelRenderersFast : {w1.Elapsed.TotalMilliseconds:F3} ms");
@@ -374,26 +393,7 @@ namespace KSPCommunityFixes
             }
             w4.Stop();
             Debug.Log($"FindModelRenderersCachedFast : {w4.Elapsed.TotalMilliseconds:F3} ms");
-
         }
     }
-
-    [KSPAddon(KSPAddon.Startup.MainMenu, false)]
-    public class MainMenuTester : MonoBehaviour
-    {
-        public IEnumerator Start()
-        {
-            for (int i = 0; i < 50; i++)
-            {
-                yield return null;
-            }
-
-            for (int i = 0; i < 50; i++)
-            {
-                KSPObjectsExtensions.Benchmark();
-                yield return null;
-            }
-            
-        }
-    }
+#endif
 }

--- a/KSPCommunityFixes/Library/KSPObjectsExtensions.cs
+++ b/KSPCommunityFixes/Library/KSPObjectsExtensions.cs
@@ -1,0 +1,399 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using Debug = UnityEngine.Debug;
+
+namespace KSPCommunityFixes
+{
+    public static class KSPObjectsExtensions
+    {
+        /// <summary>
+        /// Faster version of <see cref="Part.FindModuleImplementing"/>
+        /// </summary>
+        /// <typeparam name="T">The type of the module to search. Can be an interface.</typeparam>
+        /// <returns>The first found instance of type <typeparamref name="T"/>, or <see langword="null"/> if not present on the <see cref="Part"/></returns>
+        public static T FindModuleImplementingFast<T>(this Part part) where T : class
+        {
+            part.cachedModules ??= new Dictionary<Type, PartModule>(10);
+
+            Type moduleType = typeof(T);
+            if (!part.cachedModules.TryGetValue(moduleType, out PartModule module))
+            {
+                if (part.modules == null)
+                    return null;
+
+                List<PartModule> modules = part.modules.modules;
+                int moduleCount = modules.Count;
+                for (int i = 0; i < moduleCount; i++)
+                {
+                    if (modules[i] is T)
+                    {
+                        module = modules[i];
+                        break;
+                    }
+                }
+
+                part.cachedModules[moduleType] = module;
+            }
+
+            return module as T;
+        }
+
+        /// <summary>
+        /// Faster version of <see cref="Part.HasModuleImplementing"/>
+        /// </summary>
+        /// <typeparam name="T">The type of the module to search. Can be an interface.</typeparam>
+        /// <returns><see langword="true"/> if a <see cref="PartModule"/> of type <typeparamref name="T"/> is present on the <see cref="Part"/></returns>
+        public static bool HasModuleImplementingFast<T>(this Part part) where T : class
+        {
+            part.cachedModules ??= new Dictionary<Type, PartModule>(10);
+
+            Type moduleType = typeof(T);
+            if (!part.cachedModules.TryGetValue(moduleType, out PartModule module))
+            {
+                if (part.modules == null)
+                    return false;
+
+                List<PartModule> modules = part.modules.modules;
+                int moduleCount = modules.Count;
+                for (int i = 0; i < moduleCount; i++)
+                {
+                    if (modules[i] is T)
+                    {
+                        module = modules[i];
+                        break;
+                    }
+                }
+
+                part.cachedModules[moduleType] = module;
+            }
+
+            return module.IsNotNullRef();
+        }
+
+        public static bool IsKerbalEVA(Part part)
+        {
+            part.cachedModules ??= new Dictionary<Type, PartModule>(10);
+
+            if (!part.cachedModules.TryGetValue(typeof(KerbalEVA), out PartModule module))
+            {
+                if (part.modules == null)
+                    return false;
+
+                List<PartModule> modules = part.modules.modules;
+                int moduleCount = modules.Count;
+                for (int i = 0; i < moduleCount; i++)
+                {
+                    if (modules[i] is KerbalEVA)
+                    {
+                        module = modules[i];
+                        break;
+                    }
+                }
+
+                part.cachedModules[typeof(KerbalEVA)] = module;
+            }
+
+            return module.IsNotNullRef();
+        }
+
+
+        /// <summary>
+        /// Return the cached list of <see cref="PartModule"/> instances of type <typeparamref name="T"/> present on the part.<para/>
+        /// Do NOT modify the returned list, it is a direct reference to the cache.
+        /// </summary>
+        public static List<PartModule> FindModulesImplementingReadOnly<T>(this Part part) where T : class
+        {
+            part.cachedModuleLists ??= new Dictionary<Type, List<PartModule>>(10);
+
+            Type moduleType = typeof(T);
+            if (!part.cachedModuleLists.TryGetValue(moduleType, out List<PartModule> modules))
+            {
+                if (part.modules == null)
+                    return new List<PartModule>(0);
+
+                modules = new List<PartModule>(4);
+
+                List<PartModule> partModules = part.modules.modules;
+                int moduleCount = partModules.Count;
+
+                for (int i = 0; i < moduleCount; i++)
+                    if (partModules[i] is T)
+                        modules.Add(partModules[i]);
+
+                part.cachedModuleLists[moduleType] = modules;
+            }
+
+            return modules;
+        }
+
+        /// <summary>
+        /// Return the top level <see cref="Transform"/> of the part model.
+        /// </summary>
+        public static Transform FindModelTransform(this Part part)
+        {
+            if (part.partTransform.IsNullOrDestroyed())
+                return null;
+
+            string modelName;
+            if (part.HasModuleImplementing<KerbalEVA>())
+                modelName = "model01";
+            else if (part.HasModuleImplementing<ModuleAsteroid>())
+                modelName = "Asteroid";
+            else if (part.HasModuleImplementing<ModuleComet>())
+                modelName = "Comet";
+            else
+                modelName = "model";
+
+            return part.partTransform.Find(modelName);
+        }
+
+        /// <summary>
+        /// Populate the provided <paramref name="renderers"/> list with all <see cref="MeshRenderer"/> and <see cref="SkinnedMeshRenderer"/> instances on the part model (including its childrens).
+        /// </summary>
+        /// <param name="renderers">The list to populate. Existing elements will be cleared.</param>
+        /// <param name="includeInactive">If <see langword="false"/>, only <see cref="Renderer"/> on currently active <see cref="GameObject"/> will be returned.</param>
+        public static void FindModelRenderersFast(this Part part, List<Renderer> renderers, bool includeInactive = true)
+        {
+            Transform modelTransform = FindModelTransform(part);
+            if (modelTransform.IsNullRef())
+            {
+                renderers.Clear();
+                return;
+            }
+
+            modelTransform.GetComponentsInChildren(includeInactive, renderers);
+            for (int i = renderers.Count; i-- > 0;)
+            {
+                Renderer renderer = renderers[i];
+                if (!(renderer is MeshRenderer || renderer is SkinnedMeshRenderer))
+                    renderers.RemoveAt(i);
+            }
+        }
+
+        /// <summary>
+        /// Get a cached list of all the <see cref="MeshRenderer"/> and <see cref="SkinnedMeshRenderer"/> instances on the part model (including its childrens).<para/>
+        /// Do NOT modify the returned list, it is a direct reference to the cache.
+        /// </summary>
+        public static List<Renderer> FindModelRenderersReadOnly(this Part part)
+        {
+            List<Renderer> cache = part.modelRenderersCache;
+            if (cache != null)
+            {
+                for (int i = cache.Count; i-- > 0;)
+                {
+                    if (cache[i].IsDestroyed())
+                    {
+                        part.FindModelRenderersFast(cache, true);
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                cache = new List<Renderer>(0);
+                part.FindModelRenderersFast(cache, true);
+                part.modelRenderersCache = cache;
+            }
+
+            return cache;
+        }
+
+        /// <summary>
+        /// Faster version of <see cref="Part.FindModelRenderersCached"/>
+        /// Get an array of all the <see cref="MeshRenderer"/> and <see cref="SkinnedMeshRenderer"/> instances on the part model (including its childrens).
+        /// </summary>
+        public static Renderer[] FindModelRenderersCachedFast(this Part part)
+        {
+            return FindModelRenderersReadOnly(part).ToArray();
+        }
+
+        /// <summary>
+        /// Populate the provided <paramref name="renderers"/> list with all <see cref="MeshRenderer"/> instances on the part model (including its childrens).
+        /// </summary>
+        /// <param name="renderers">The list to populate. Existing elements will be cleared.</param>
+        /// <param name="includeInactive">If <see langword="false"/>, only components on currently active <see cref="GameObject"/>s will be returned.</param>
+        public static void FindModelMeshRenderersFast(this Part part, List<MeshRenderer> renderers, bool includeInactive = true)
+        {
+            Transform modelTransform = FindModelTransform(part);
+            if (modelTransform.IsNullRef())
+            {
+                renderers.Clear();
+                return;
+            }
+
+            modelTransform.GetComponentsInChildren(includeInactive, renderers);
+        }
+
+        /// <summary>
+        /// Get a cached list of all the <see cref="MeshRenderer"/> instances on the part model (including its childrens).<para/>
+        /// Do NOT modify the returned list, it is a direct reference to the cache.
+        /// </summary>
+        public static List<MeshRenderer> FindModelMeshRenderersReadOnly(this Part part)
+        {
+            List<MeshRenderer> cache = part.modelMeshRenderersCache;
+            if (cache != null)
+            {
+                for (int i = cache.Count; i-- > 0;)
+                {
+                    if (cache[i].IsDestroyed())
+                    {
+                        part.FindModelMeshRenderersFast(cache, true);
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                cache = new List<MeshRenderer>(0);
+                part.FindModelMeshRenderersFast(cache, true);
+                part.modelMeshRenderersCache = cache;
+            }
+
+            return cache;
+        }
+
+        /// <summary>
+        /// Faster version of <see cref="Part.FindModelMeshRenderersCached"/>
+        /// Get an array of all the <see cref="MeshRenderer"/> instances on the part model (including its childrens).
+        /// </summary>
+        public static MeshRenderer[] FindModelMeshRenderersCachedFast(this Part part)
+        {
+            return FindModelMeshRenderersReadOnly(part).ToArray();
+        }
+
+        /// <summary>
+        /// Populate the provided <paramref name="renderers"/> list with all <see cref="SkinnedMeshRenderer"/> instances on the part model (including its childrens).
+        /// </summary>
+        /// <param name="renderers">The list to populate. Existing elements will be cleared.</param>
+        /// <param name="includeInactive">If <see langword="false"/>, only components on currently active <see cref="GameObject"/>s will be returned.</param>
+        public static void FindModelSkinnedMeshRenderersFast(this Part part, List<SkinnedMeshRenderer> renderers, bool includeInactive = true)
+        {
+            Transform modelTransform = FindModelTransform(part);
+            if (modelTransform.IsNullRef())
+            {
+                renderers.Clear();
+                return;
+            }
+
+            modelTransform.GetComponentsInChildren(includeInactive, renderers);
+        }
+
+        /// <summary>
+        /// Get a cached list of all the <see cref="SkinnedMeshRenderer"/> instances on the part model (including its childrens).<para/>
+        /// Do NOT modify the returned list, it is a direct reference to the cache.
+        /// </summary>
+        public static List<SkinnedMeshRenderer> FindModelSkinnedMeshRenderersReadOnly(this Part part)
+        {
+            List<SkinnedMeshRenderer> cache = part.modelSkinnedMeshRenderersCache;
+            if (cache != null)
+            {
+                for (int i = cache.Count; i-- > 0;)
+                {
+                    if (cache[i].IsDestroyed())
+                    {
+                        part.FindModelSkinnedMeshRenderersFast(cache, true);
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                cache = new List<SkinnedMeshRenderer>(0);
+                part.FindModelSkinnedMeshRenderersFast(cache, true);
+                part.modelSkinnedMeshRenderersCache = cache;
+            }
+
+            return cache;
+        }
+
+        /// <summary>
+        /// Faster version of <see cref="Part.FindModelSkinnedMeshRenderersCached"/>
+        /// Get an array of all the <see cref="SkinnedMeshRenderer"/> instances on the part model (including its childrens).
+        /// </summary>
+        public static SkinnedMeshRenderer[] FindModelSkinnedMeshRenderersCachedFast(this Part part)
+        {
+            return FindModelSkinnedMeshRenderersReadOnly(part).ToArray();
+        }
+
+        public static Stopwatch w1 = new Stopwatch();
+        public static Stopwatch w2 = new Stopwatch();
+        public static Stopwatch w3 = new Stopwatch();
+        public static Stopwatch w4 = new Stopwatch();
+        public static Stopwatch w5 = new Stopwatch();
+        public static Stopwatch w6 = new Stopwatch();
+        public static Stopwatch w7 = new Stopwatch();
+
+        public static void Benchmark()
+        {
+            List<Renderer> renderers = new List<Renderer>();
+            Renderer[] renderersArray;
+
+            // warmup
+            foreach (AvailablePart availablePart in PartLoader.LoadedPartsList)
+            {
+                FindModelRenderersFast(availablePart.partPrefab, renderers); 
+                renderers = availablePart.partPrefab.FindModelComponents<Renderer>();
+                renderers = availablePart.partPrefab.FindModelRenderersCached();
+                renderersArray = availablePart.partPrefab.FindModelRenderersCachedFast();
+            }
+
+            w1.Start();
+            foreach (AvailablePart availablePart in PartLoader.LoadedPartsList)
+            {
+                FindModelRenderersFast(availablePart.partPrefab, renderers);
+            }
+            w1.Stop();
+            Debug.Log($"FindModelRenderersFast : {w1.Elapsed.TotalMilliseconds:F3} ms");
+
+            w2.Start();
+            foreach (AvailablePart availablePart in PartLoader.LoadedPartsList)
+            {
+                renderers = availablePart.partPrefab.FindModelComponents<Renderer>();
+            }
+            w2.Stop();
+            Debug.Log($"FindModelRenderersStock : {w2.Elapsed.TotalMilliseconds:F3} ms");
+
+            w3.Start();
+            foreach (AvailablePart availablePart in PartLoader.LoadedPartsList)
+            {
+                renderers = availablePart.partPrefab.FindModelRenderersCached();
+            }
+            w3.Stop();
+            Debug.Log($"FindModelRenderersCached : {w3.Elapsed.TotalMilliseconds:F3} ms");
+
+            w4.Start();
+            foreach (AvailablePart availablePart in PartLoader.LoadedPartsList)
+            {
+                renderersArray = availablePart.partPrefab.FindModelRenderersCachedFast();
+            }
+            w4.Stop();
+            Debug.Log($"FindModelRenderersCachedFast : {w4.Elapsed.TotalMilliseconds:F3} ms");
+
+        }
+    }
+
+    [KSPAddon(KSPAddon.Startup.MainMenu, false)]
+    public class MainMenuTester : MonoBehaviour
+    {
+        public IEnumerator Start()
+        {
+            for (int i = 0; i < 50; i++)
+            {
+                yield return null;
+            }
+
+            for (int i = 0; i < 50; i++)
+            {
+                KSPObjectsExtensions.Benchmark();
+                yield return null;
+            }
+            
+        }
+    }
+}

--- a/KSPCommunityFixes/Library/Numerics.cs
+++ b/KSPCommunityFixes/Library/Numerics.cs
@@ -1,11 +1,21 @@
 ﻿using System;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using UnityEngine;
+using Random = System.Random;
 
 namespace KSPCommunityFixes.Library
 {
     internal static class Numerics
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Zero(ref this Vector3 v)
+        {
+            v.x = 0f; 
+            v.y = 0f; 
+            v.z = 0f;
+        }
+
         /// <summary>
         /// mutating add, ~10 times faster than using the + operator
         /// </summary>
@@ -15,6 +25,135 @@ namespace KSPCommunityFixes.Library
             v.x += other.x;
             v.y += other.y;
             v.z += other.z;
+        }
+
+        /// <summary>
+        /// mutating add, ~10 times faster than using the + operator
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Add(ref this Vector3d v, double x, double y, double z)
+        {
+            v.x += x;
+            v.y += y;
+            v.z += z;
+        }
+
+        /// <summary>
+        /// mutating add, ~10 times faster than using the + operator
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Add(ref this Vector3 v, Vector3 other)
+        {
+            v.x += other.x;
+            v.y += other.y;
+            v.z += other.z;
+        }
+
+        /// <summary>
+        /// mutating add, ~10 times faster than using the + operator
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Add(ref this Vector3 v, float x, float y, float z)
+        {
+            v.x += x;
+            v.y += y;
+            v.z += z;
+        }
+
+        /// <summary>
+        /// mutating substract, ~10 times faster than using the + operator
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Substract(ref this Vector3d v, Vector3d other)
+        {
+            v.x -= other.x;
+            v.y -= other.y;
+            v.z -= other.z;
+        }
+
+        /// <summary>
+        /// mutating substract, ~10 times faster than using the + operator
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Substract(ref this Vector3d v, double x, double y, double z)
+        {
+            v.x -= x;
+            v.y -= y;
+            v.z -= z;
+        }
+
+        /// <summary>
+        /// mutating substract, ~10 times faster than using the + operator
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Substract(ref this Vector3 v, Vector3 other)
+        {
+            v.x -= other.x;
+            v.y -= other.y;
+            v.z -= other.z;
+        }
+
+        /// <summary>
+        /// mutating substract, ~10 times faster than using the + operator
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Substract(ref this Vector3 v, float x, float y, float z)
+        {
+            v.x -= x;
+            v.y -= y;
+            v.z -= z;
+        }
+
+        /// <summary>
+        /// mutating multiply, ~10 times faster than using the + operator
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Multiply(ref this Vector3d v, double scalar)
+        {
+            v.x *= scalar;
+            v.y *= scalar;
+            v.z *= scalar;
+        }
+
+        /// <summary>
+        /// mutating multiply, ~10 times faster than using the + operator
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Multiply(ref this Vector3 v, float scalar)
+        {
+            v.x *= scalar;
+            v.y *= scalar;
+            v.z *= scalar;
+        }
+
+        /// <summary>
+        /// Clamp a value between 0.0 and 1.0
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Clamp01(double value)
+        {
+            if (value < 0.0)
+                return 0.0;
+
+            if (value > 1.0)
+                return 1.0;
+
+            return value;
+        }
+
+        /// <summary>
+        /// Double backed clamped lerp
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Lerp(double a, double b, double t)
+        {
+            if (t <= 0f)
+                return a;
+
+            if (t >= 1f)
+                return a + (b - a);
+
+            return a + (b - a) * t;
         }
 
         /// <summary>
@@ -111,5 +250,187 @@ namespace KSPCommunityFixes.Library
         /// Evaluate whether a given integral value is a power of 2.
         /// </summary>
         public static bool IsPowerOfTwo(uint value) => (value & (value - 1)) == 0 && value != 0;
+
+        /// <summary>
+        /// Faster approximate alternative to Math.Pow(), by a factor 5-6. Max error around 5%, average error around 1.7%
+        /// </summary>
+        public static unsafe double FastPow(double value, double exponent)
+        {
+            // exponentiation by squaring
+            double r = 1.0;
+            int exp = (int)exponent;
+            double _base = value;
+            while (exp != 0)
+            {
+                if ((exp & 1) != 0)
+                {
+                    r *= _base;
+                }
+                _base *= _base;
+                exp >>= 1;
+            }
+
+            // use the IEEE 754 trick for the fraction of the exponent
+            double b_faction = exponent - (int)exponent;
+            long tmp = *(long*)&value;
+            long tmp2 = (long)(b_faction * (tmp - 4606921280493453312L)) + 4606921280493453312L;
+            return r * *(double*)&tmp2;
+        }
+    }
+
+    /// <summary>
+    /// A readonly 4x3 double-backed matrix for transform operations
+    /// </summary>
+    public readonly struct TransformMatrix
+    {
+        public readonly double m00, m01, m02, m03;
+        public readonly double m10, m11, m12, m13;
+        public readonly double m20, m21, m22, m23;
+
+        public TransformMatrix(double m00, double m01, double m02, double m03, double m10, double m11, double m12, double m13, double m20, double m21, double m22, double m23)
+        {
+            this.m00 = m00;
+            this.m01 = m01;
+            this.m02 = m02;
+            this.m03 = m03;
+            this.m10 = m10;
+            this.m11 = m11;
+            this.m12 = m12;
+            this.m13 = m13;
+            this.m20 = m20;
+            this.m21 = m21;
+            this.m22 = m22;
+            this.m23 = m23;
+        }
+
+        public TransformMatrix(ref Matrix4x4 transformMatrix)
+        {
+            m00 = transformMatrix.m00;
+            m01 = transformMatrix.m01;
+            m02 = transformMatrix.m02;
+            m03 = transformMatrix.m03;
+
+            m10 = transformMatrix.m10;
+            m11 = transformMatrix.m11;
+            m12 = transformMatrix.m12;
+            m13 = transformMatrix.m13;
+
+            m20 = transformMatrix.m20;
+            m21 = transformMatrix.m21;
+            m22 = transformMatrix.m22;
+            m23 = transformMatrix.m23;
+        }
+
+        public TransformMatrix(ref Matrix4x4D transformMatrix)
+        {
+            m00 = transformMatrix.m00;
+            m01 = transformMatrix.m01;
+            m02 = transformMatrix.m02;
+            m03 = transformMatrix.m03;
+
+            m10 = transformMatrix.m10;
+            m11 = transformMatrix.m11;
+            m12 = transformMatrix.m12;
+            m13 = transformMatrix.m13;
+
+            m20 = transformMatrix.m20;
+            m21 = transformMatrix.m21;
+            m22 = transformMatrix.m22;
+            m23 = transformMatrix.m23;
+        }
+
+        /// <summary>
+        /// Local to world space transform matrix
+        /// </summary>
+        public static TransformMatrix LocalToWorld(Transform transform)
+        {
+            Matrix4x4 matrix = transform.localToWorldMatrix;
+            return new TransformMatrix(
+                matrix.m00, matrix.m01, matrix.m02, matrix.m03,
+                matrix.m10, matrix.m11, matrix.m12, matrix.m13,
+                matrix.m20, matrix.m21, matrix.m22, matrix.m23);
+        }
+
+        /// <summary>
+        /// World to local space (inverse) transform matrix
+        /// </summary>
+        public static TransformMatrix WorldToLocal(Transform transform)
+        {
+            Matrix4x4 matrix = transform.worldToLocalMatrix;
+            return new TransformMatrix(
+                matrix.m00, matrix.m01, matrix.m02, matrix.m03,
+                matrix.m10, matrix.m11, matrix.m12, matrix.m13,
+                matrix.m20, matrix.m21, matrix.m22, matrix.m23);
+        }
+
+        /// <summary>
+        /// Transform point
+        /// </summary>
+        public void MultiplyPoint3x4(ref Vector3d point)
+        {
+            double x = point.x;
+            double y = point.y;
+            double z = point.z;
+            point.x = m00 * x + m01 * y + m02 * z + m03;
+            point.y = m10 * x + m11 * y + m12 * z + m13;
+            point.z = m20 * x + m21 * y + m22 * z + m23;
+        }
+
+        /// <summary>
+        /// Transform point
+        /// </summary>
+        public Vector3d MultiplyPoint3x4(Vector3d point)
+        {
+            return new Vector3d(
+                m00 * point.x + m01 * point.y + m02 * point.z + m03,
+                m10 * point.x + m11 * point.y + m12 * point.z + m13,
+                m20 * point.x + m21 * point.y + m22 * point.z + m23);
+        }
+
+        /// <summary>
+        /// Transform point
+        /// </summary>
+        public Vector3d MultiplyPoint3x4(double x, double y, double z)
+        {
+            return new Vector3d(
+                m00 * x + m01 * y + m02 * z + m03,
+                m10 * x + m11 * y + m12 * z + m13,
+                m20 * x + m21 * y + m22 * z + m23);
+        }
+
+        /// <summary>
+        /// Transform vector
+        /// </summary>
+        public void MultiplyVector(ref Vector3d point)
+        {
+            double x = point.x;
+            double y = point.y;
+            double z = point.z;
+            point.x = m00 * x + m01 * y + m02 * z;
+            point.y = m10 * x + m11 * y + m12 * z;
+            point.z = m20 * x + m21 * y + m22 * z;
+        }
+
+        /// <summary>
+        /// Transform vector
+        /// </summary>
+        public Vector3d MultiplyVector(Vector3d point)
+        {
+            return new Vector3d(
+                m00 * point.x + m01 * point.y + m02 * point.z,
+                m10 * point.x + m11 * point.y + m12 * point.z,
+                m20 * point.x + m21 * point.y + m22 * point.z);
+        }
+
+        /// <summary>
+        /// Transform vector
+        /// </summary>
+        public Vector3d MultiplyVector(double x, double y, double z)
+        {
+            return new Vector3d(
+                m00 * x + m01 * y + m02 * z,
+                m10 * x + m11 * y + m12 * z,
+                m20 * x + m21 * y + m22 * z);
+        }
     }
 }

--- a/KSPCommunityFixes/Library/Numerics.cs
+++ b/KSPCommunityFixes/Library/Numerics.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using UnityEngine;
+
+namespace KSPCommunityFixes.Library
+{
+    internal static class Numerics
+    {
+        /// <summary>
+        /// mutating add, ~10 times faster than using the + operator
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Add(ref this Vector3d v, Vector3d other)
+        {
+            v.x += other.x;
+            v.y += other.y;
+            v.z += other.z;
+        }
+
+        /// <summary>
+        /// Return a QuaternionD representing a rotation from a Vector3d to another
+        /// </summary>
+        public static QuaternionD FromToRotation(Vector3d from, Vector3d to)
+        {
+            double d = Vector3d.Dot(from, to);
+            double qw = Math.Sqrt(from.sqrMagnitude * to.sqrMagnitude) + d;
+            double x, y, z, sqrMag;
+            if (qw < 1e-12)
+            {
+                // vectors are 180 degrees apart
+                x = from.x;
+                y = from.y;
+                z = -from.z;
+                sqrMag = x * x + y * y + z * z;
+                if (sqrMag != 1.0)
+                {
+                    double invNorm = 1.0 / Math.Sqrt(sqrMag);
+                    x *= invNorm;
+                    y *= invNorm;
+                    z *= invNorm;
+                }
+                return new QuaternionD(x, y, z, 0.0);
+            }
+
+            Vector3d axis = Vector3d.Cross(from, to);
+            x = axis.x;
+            y = axis.y;
+            z = axis.z;
+            sqrMag = x * x + y * y + z * z + qw * qw;
+            if (sqrMag != 1.0)
+            {
+                double invNorm = 1.0 / Math.Sqrt(sqrMag);
+                x *= invNorm;
+                y *= invNorm;
+                z *= invNorm;
+                qw *= invNorm;
+            }
+
+            return new QuaternionD(x, y, z, qw);
+        }
+
+        /// <summary>
+        /// Cast a Matrix4x4 to a Matrix4x4D
+        /// </summary>
+        public static Matrix4x4D ToMatrix4x4D(ref this Matrix4x4 m)
+        {
+            return new Matrix4x4D(
+                m.m00, m.m01, m.m02, m.m03,
+                m.m10, m.m11, m.m12, m.m13,
+                m.m20, m.m21, m.m22, m.m23,
+                m.m30, m.m31, m.m32, m.m33);
+        }
+
+        /// <summary>
+        /// Transforms a direction by this matrix.
+        /// </summary>
+        public static Vector3 MultiplyVector(this Matrix4x4 m, float x, float y, float z)
+        {
+            return new Vector3(
+                m.m00 * x + m.m01 * y + m.m02 * z,
+                m.m10 * x + m.m11 * y + m.m12 * z,
+                m.m20 * x + m.m21 * y + m.m22 * z);
+        }
+
+        /// <summary>
+        /// Transforms a direction by this matrix.
+        /// </summary>
+        public static Vector3d MultiplyVector(ref this Matrix4x4D m, Vector3d vector)
+        {
+            return new Vector3d(
+                m.m00 * vector.x + m.m01 * vector.y + m.m02 * vector.z,
+                m.m10 * vector.x + m.m11 * vector.y + m.m12 * vector.z,
+                m.m20 * vector.x + m.m21 * vector.y + m.m22 * vector.z);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector3d MultiplyPoint3x4(ref this Matrix4x4D m, double x, double y, double z)
+        {
+            return new Vector3d(
+                m.m00 * x + m.m01 * y + m.m02 * z + m.m03,
+                m.m10 * x + m.m11 * y + m.m12 * z + m.m13,
+                m.m20 * x + m.m21 * y + m.m22 * z + m.m23);
+        }
+
+        /// <summary>
+        /// Evaluate whether a given integral value is a power of 2.
+        /// </summary>
+        public static bool IsPowerOfTwo(int value) => (value & (value - 1)) == 0 && value > 0;
+
+        /// <summary>
+        /// Evaluate whether a given integral value is a power of 2.
+        /// </summary>
+        public static bool IsPowerOfTwo(uint value) => (value & (value - 1)) == 0 && value != 0;
+    }
+}

--- a/KSPCommunityFixes/Library/Numerics.cs
+++ b/KSPCommunityFixes/Library/Numerics.cs
@@ -16,6 +16,54 @@ namespace KSPCommunityFixes.Library
             v.z = 0f;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CopyFrom(ref this Vector3d v, Vector3 other)
+        {
+            v.x = other.x;
+            v.y = other.y;
+            v.z = other.z;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CopyFrom(ref this Vector3d v, Vector3d other)
+        {
+            v.x = other.x;
+            v.y = other.y;
+            v.z = other.z;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CopyFrom(ref this Vector3d v, ref Vector3d other)
+        {
+            v.x = other.x;
+            v.y = other.y;
+            v.z = other.z;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CopyFrom(ref this Vector3 v, Vector3 other)
+        {
+            v.x = other.x;
+            v.y = other.y;
+            v.z = other.z;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CopyFrom(ref this Vector3 v, Vector3d other)
+        {
+            v.x = (float)other.x;
+            v.y = (float)other.y;
+            v.z = (float)other.z;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CopyFrom(ref this Vector3 v, ref Vector3d other)
+        {
+            v.x = (float)other.x;
+            v.y = (float)other.y;
+            v.z = (float)other.z;
+        }
+
         /// <summary>
         /// mutating add, ~10 times faster than using the + operator
         /// </summary>
@@ -61,6 +109,50 @@ namespace KSPCommunityFixes.Library
         }
 
         /// <summary>
+        /// mutate vector v with the result of a + b
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MutateAdd(ref Vector3d v, ref Vector3d a, ref Vector3d b)
+        {
+            v.x = a.x + b.x;
+            v.y = a.y + b.y;
+            v.z = a.z + b.z;
+        }
+
+        /// <summary>
+        /// mutate vector v with the result of a + b
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MutateAdd(ref Vector3d v, Vector3d a, ref Vector3d b)
+        {
+            v.x = a.x + b.x;
+            v.y = a.y + b.y;
+            v.z = a.z + b.z;
+        }
+
+        /// <summary>
+        /// mutate vector v with the result of a + b
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MutateAdd(ref Vector3d v, ref Vector3d a, Vector3d b)
+        {
+            v.x = a.x + b.x;
+            v.y = a.y + b.y;
+            v.z = a.z + b.z;
+        }
+
+        /// <summary>
+        /// mutate vector v with the result of a + b
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MutateAdd(ref Vector3d v, Vector3d a, Vector3d b)
+        {
+            v.x = a.x + b.x;
+            v.y = a.y + b.y;
+            v.z = a.z + b.z;
+        }
+
+        /// <summary>
         /// mutating substract, ~10 times faster than using the + operator
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -102,6 +194,50 @@ namespace KSPCommunityFixes.Library
             v.x -= x;
             v.y -= y;
             v.z -= z;
+        }
+
+        /// <summary>
+        /// mutate vector v with the result of a - b
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MutateSubstract(ref Vector3d v, ref Vector3d a, ref Vector3d b)
+        {
+            v.x = a.x - b.x;
+            v.y = a.y - b.y;
+            v.z = a.z - b.z;
+        }
+
+        /// <summary>
+        /// mutate vector v with the result of a - b
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MutateSubstract(ref Vector3d v, Vector3d a, ref Vector3d b)
+        {
+            v.x = a.x - b.x;
+            v.y = a.y - b.y;
+            v.z = a.z - b.z;
+        }
+
+        /// <summary>
+        /// mutate vector v with the result of a - b
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MutateSubstract(ref Vector3d v, ref Vector3d a, Vector3d b)
+        {
+            v.x = a.x - b.x;
+            v.y = a.y - b.y;
+            v.z = a.z - b.z;
+        }
+
+        /// <summary>
+        /// mutate vector v with the result of a - b
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void MutateSubstract(ref Vector3d v, Vector3d a, Vector3d b)
+        {
+            v.x = a.x - b.x;
+            v.y = a.y - b.y;
+            v.z = a.z - b.z;
         }
 
         /// <summary>
@@ -281,11 +417,13 @@ namespace KSPCommunityFixes.Library
     /// <summary>
     /// A readonly 4x3 double-backed matrix for transform operations
     /// </summary>
-    public readonly struct TransformMatrix
+    public struct TransformMatrix
     {
-        public readonly double m00, m01, m02, m03;
-        public readonly double m10, m11, m12, m13;
-        public readonly double m20, m21, m22, m23;
+        private static TransformMatrix current;
+
+        public double m00, m01, m02, m03;
+        public double m10, m11, m12, m13;
+        public double m20, m21, m22, m23;
 
         public TransformMatrix(double m00, double m01, double m02, double m03, double m10, double m11, double m12, double m13, double m20, double m21, double m22, double m23)
         {
@@ -340,6 +478,50 @@ namespace KSPCommunityFixes.Library
         }
 
         /// <summary>
+        /// Local to world space transform matrix, returning a ref to the singleton TransformMatrix.
+        /// A call to WorldToLocalCurrent or LocalToWorldCurrent will mutate the ref, so only one can be used at a time.
+        /// </summary>
+        public static ref TransformMatrix LocalToWorldCurrent(Transform transform)
+        {
+            Matrix4x4 matrix = transform.localToWorldMatrix;
+            current.m00 = matrix.m00;
+            current.m01 = matrix.m01;
+            current.m02 = matrix.m02;
+            current.m03 = matrix.m03;
+            current.m10 = matrix.m10;
+            current.m11 = matrix.m11;
+            current.m12 = matrix.m12;
+            current.m13 = matrix.m13;
+            current.m20 = matrix.m20;
+            current.m21 = matrix.m21;
+            current.m22 = matrix.m22;
+            current.m23 = matrix.m23;
+            return ref current;
+        }
+
+        /// <summary>
+        /// World to local space (inverse) transform matrix, returning a ref to the singleton TransformMatrix.
+        /// A call to WorldToLocalCurrent or LocalToWorldCurrent will mutate the ref, so only one can be used at a time.
+        /// </summary>
+        public static ref TransformMatrix WorldToLocalCurrent(Transform transform)
+        {
+            Matrix4x4 matrix = transform.worldToLocalMatrix;
+            current.m00 = matrix.m00;
+            current.m01 = matrix.m01;
+            current.m02 = matrix.m02;
+            current.m03 = matrix.m03;
+            current.m10 = matrix.m10;
+            current.m11 = matrix.m11;
+            current.m12 = matrix.m12;
+            current.m13 = matrix.m13;
+            current.m20 = matrix.m20;
+            current.m21 = matrix.m21;
+            current.m22 = matrix.m22;
+            current.m23 = matrix.m23;
+            return ref current;
+        }
+
+        /// <summary>
         /// Local to world space transform matrix
         /// </summary>
         public static TransformMatrix LocalToWorld(Transform transform)
@@ -366,7 +548,7 @@ namespace KSPCommunityFixes.Library
         /// <summary>
         /// Transform point
         /// </summary>
-        public void MultiplyPoint3x4(ref Vector3d point)
+        public void MutateMultiplyPoint3x4(ref Vector3d point)
         {
             double x = point.x;
             double y = point.y;
@@ -379,7 +561,7 @@ namespace KSPCommunityFixes.Library
         /// <summary>
         /// Transform point
         /// </summary>
-        public Vector3d MultiplyPoint3x4(Vector3d point)
+        public Vector3d MultiplyPoint3x4(ref Vector3d point)
         {
             return new Vector3d(
                 m00 * point.x + m01 * point.y + m02 * point.z + m03,
@@ -401,7 +583,7 @@ namespace KSPCommunityFixes.Library
         /// <summary>
         /// Transform vector
         /// </summary>
-        public void MultiplyVector(ref Vector3d point)
+        public void MutateMultiplyVector(ref Vector3d point)
         {
             double x = point.x;
             double y = point.y;
@@ -414,7 +596,7 @@ namespace KSPCommunityFixes.Library
         /// <summary>
         /// Transform vector
         /// </summary>
-        public Vector3d MultiplyVector(Vector3d point)
+        public Vector3d MultiplyVector(ref Vector3d point)
         {
             return new Vector3d(
                 m00 * point.x + m01 * point.y + m02 * point.z,

--- a/KSPCommunityFixes/Library/StaticHelpers.cs
+++ b/KSPCommunityFixes/Library/StaticHelpers.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using HarmonyLib;
 using KSP.UI.TooltipTypes;
 using UnityEngine;
@@ -78,5 +79,17 @@ namespace KSPCommunityFixes
 
             return false;
         }
+
+        /// <summary>
+        /// Evaluate whether a given integral value is a power of 2.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        public static bool IsPowerOfTwo(int value) => (value & (value - 1)) == 0 && value > 0;
+
+        /// <summary>
+        /// Evaluate whether a given integral value is a power of 2.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        public static bool IsPowerOfTwo(uint value) => (value & (value - 1)) == 0 && value != 0;
     }
 }

--- a/KSPCommunityFixes/Library/StaticHelpers.cs
+++ b/KSPCommunityFixes/Library/StaticHelpers.cs
@@ -79,17 +79,5 @@ namespace KSPCommunityFixes
 
             return false;
         }
-
-        /// <summary>
-        /// Evaluate whether a given integral value is a power of 2.
-        /// </summary>
-        /// <param name="value">The value.</param>
-        public static bool IsPowerOfTwo(int value) => (value & (value - 1)) == 0 && value > 0;
-
-        /// <summary>
-        /// Evaluate whether a given integral value is a power of 2.
-        /// </summary>
-        /// <param name="value">The value.</param>
-        public static bool IsPowerOfTwo(uint value) => (value & (value - 1)) == 0 && value != 0;
     }
 }

--- a/KSPCommunityFixes/Modding/DepartmentHeadImage.cs
+++ b/KSPCommunityFixes/Modding/DepartmentHeadImage.cs
@@ -13,8 +13,7 @@ namespace KSPCommunityFixes.Modding
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Administration), nameof(Administration.AddKerbalListItem)),
-                this));
+                AccessTools.Method(typeof(Administration), nameof(Administration.AddKerbalListItem))));
         }
 
         static void Administration_AddKerbalListItem_Postfix(Administration __instance, ref Strategies.DepartmentConfig dep)

--- a/KSPCommunityFixes/Modding/DepartmentHeadImage.cs
+++ b/KSPCommunityFixes/Modding/DepartmentHeadImage.cs
@@ -9,11 +9,9 @@ namespace KSPCommunityFixes.Modding
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Administration), nameof(Administration.AddKerbalListItem))));
+            AddPatch(PatchType.Postfix, typeof(Administration), nameof(Administration.AddKerbalListItem));
         }
 
         static void Administration_AddKerbalListItem_Postfix(Administration __instance, ref Strategies.DepartmentConfig dep)

--- a/KSPCommunityFixes/Modding/DockingPortLockedEvents.cs
+++ b/KSPCommunityFixes/Modding/DockingPortLockedEvents.cs
@@ -8,17 +8,12 @@ namespace KSPCommunityFixes.Modding
     {
         protected override Version VersionMin => new Version(1, 12, 2);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
             // Priority.First because we have an overriding prefix in the DockingPortRotationDriftAndFixes patch
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleDockingNode), "ModifyLocked"),
-                null, Priority.First));
+            AddPatch(PatchType.Prefix, typeof(ModuleDockingNode), "ModifyLocked", null, Priority.First);
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleDockingNode), "ModifyLocked")));
+            AddPatch(PatchType.Postfix, typeof(ModuleDockingNode), "ModifyLocked");
         }
 
         static void ModuleDockingNode_ModifyLocked_Prefix(ModuleDockingNode __instance)

--- a/KSPCommunityFixes/Modding/DockingPortLockedEvents.cs
+++ b/KSPCommunityFixes/Modding/DockingPortLockedEvents.cs
@@ -14,12 +14,11 @@ namespace KSPCommunityFixes.Modding
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
                 AccessTools.Method(typeof(ModuleDockingNode), "ModifyLocked"),
-                this, null, Priority.First));
+                null, Priority.First));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleDockingNode), "ModifyLocked"),
-                this));
+                AccessTools.Method(typeof(ModuleDockingNode), "ModifyLocked")));
         }
 
         static void ModuleDockingNode_ModifyLocked_Prefix(ModuleDockingNode __instance)

--- a/KSPCommunityFixes/Modding/ModUpgradePipeline.cs
+++ b/KSPCommunityFixes/Modding/ModUpgradePipeline.cs
@@ -29,33 +29,30 @@ namespace KSPCommunityFixes.Modding
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ShipConstruct), nameof(ShipConstruct.SaveShip)),
-                this));
+                AccessTools.Method(typeof(ShipConstruct), nameof(ShipConstruct.SaveShip))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Game), nameof(Game.Save)),
-                this));
+                AccessTools.Method(typeof(Game), nameof(Game.Save))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(KSPUpgradePipeline), nameof(KSPUpgradePipeline.Process)),
-                this));
+                AccessTools.Method(typeof(KSPUpgradePipeline), nameof(KSPUpgradePipeline.Process))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
                 AccessTools.Method(typeof(SaveUpgradePipeline.SaveUpgradePipeline), nameof(SaveUpgradePipeline.SaveUpgradePipeline.Init)),
-                this, "SaveUpgradePipeline_Init_Postfix"));
+                nameof(SaveUpgradePipeline_Init_Postfix)));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
                 AccessTools.Method(typeof(SaveUpgradePipeline.SaveUpgradePipeline), nameof(SaveUpgradePipeline.SaveUpgradePipeline.SanityCheck)),
-                this, "SaveUpgradePipeline_SanityCheck_Prefix"));
+                nameof(SaveUpgradePipeline_SanityCheck_Prefix)));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
                 AccessTools.Method(typeof(SaveUpgradePipeline.SaveUpgradePipeline), nameof(SaveUpgradePipeline.SaveUpgradePipeline.RunIteration)),
-                this, "SaveUpgradePipeline_RunIteration_Prefix"));
+                nameof(SaveUpgradePipeline_RunIteration_Prefix)));
 
             // For some reason this method is failing to be found normally.
             // So we'll find it manually.
@@ -71,12 +68,12 @@ namespace KSPCommunityFixes.Modding
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
                 runMethod,
-                this, "SaveUpgradePipeline_Run_Postfix"));
+                nameof(SaveUpgradePipeline_Run_Postfix)));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
                 AccessTools.Method(typeof(UpgradeScript), nameof(UpgradeScript.Test)),
-                this, "UpgradeScript_Test_Prefix"));
+                nameof(UpgradeScript_Test_Prefix)));
 
             SaveCurrentVersions();
 

--- a/KSPCommunityFixes/Modding/ModUpgradePipeline.cs
+++ b/KSPCommunityFixes/Modding/ModUpgradePipeline.cs
@@ -25,34 +25,19 @@ namespace KSPCommunityFixes.Modding
         // That means we can't get the callback directly, so we have to get it by reflection.
         private static FieldInfo OnSetCfgNodeVersionCallback = typeof(SaveUpgradePipeline.SaveUpgradePipeline).GetField(nameof(SaveUpgradePipeline.SaveUpgradePipeline.OnSetCfgNodeVersion), AccessTools.all);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ShipConstruct), nameof(ShipConstruct.SaveShip))));
+            AddPatch(PatchType.Postfix, typeof(ShipConstruct), nameof(ShipConstruct.SaveShip));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Game), nameof(Game.Save))));
+            AddPatch(PatchType.Postfix, typeof(Game), nameof(Game.Save));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(KSPUpgradePipeline), nameof(KSPUpgradePipeline.Process))));
+            AddPatch(PatchType.Prefix, typeof(KSPUpgradePipeline), nameof(KSPUpgradePipeline.Process));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(SaveUpgradePipeline.SaveUpgradePipeline), nameof(SaveUpgradePipeline.SaveUpgradePipeline.Init)),
-                nameof(SaveUpgradePipeline_Init_Postfix)));
+            AddPatch(PatchType.Postfix, typeof(SaveUpgradePipeline.SaveUpgradePipeline), nameof(SaveUpgradePipeline.SaveUpgradePipeline.Init), nameof(SaveUpgradePipeline_Init_Postfix));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(SaveUpgradePipeline.SaveUpgradePipeline), nameof(SaveUpgradePipeline.SaveUpgradePipeline.SanityCheck)),
-                nameof(SaveUpgradePipeline_SanityCheck_Prefix)));
+            AddPatch(PatchType.Prefix, typeof(SaveUpgradePipeline.SaveUpgradePipeline), nameof(SaveUpgradePipeline.SaveUpgradePipeline.SanityCheck), nameof(SaveUpgradePipeline_SanityCheck_Prefix));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(SaveUpgradePipeline.SaveUpgradePipeline), nameof(SaveUpgradePipeline.SaveUpgradePipeline.RunIteration)),
-                nameof(SaveUpgradePipeline_RunIteration_Prefix)));
+            AddPatch(PatchType.Prefix, typeof(SaveUpgradePipeline.SaveUpgradePipeline), nameof(SaveUpgradePipeline.SaveUpgradePipeline.RunIteration), nameof(SaveUpgradePipeline_RunIteration_Prefix));
 
             // For some reason this method is failing to be found normally.
             // So we'll find it manually.
@@ -65,15 +50,10 @@ namespace KSPCommunityFixes.Modding
                     break;
                 }
             }
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                runMethod,
-                nameof(SaveUpgradePipeline_Run_Postfix)));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(UpgradeScript), nameof(UpgradeScript.Test)),
-                nameof(UpgradeScript_Test_Prefix)));
+            AddPatch(PatchType.Postfix, runMethod, nameof(SaveUpgradePipeline_Run_Postfix));
+
+            AddPatch(PatchType.Prefix, typeof(UpgradeScript), nameof(UpgradeScript.Test), nameof(UpgradeScript_Test_Prefix));
 
             SaveCurrentVersions();
 

--- a/KSPCommunityFixes/Modding/OnSymmetryFieldChanged.cs
+++ b/KSPCommunityFixes/Modding/OnSymmetryFieldChanged.cs
@@ -12,8 +12,7 @@ namespace KSPCommunityFixes.Modding
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(UIPartActionFieldItem), nameof(UIPartActionFieldItem.SetSymCounterpartValue)),
-                this));
+                AccessTools.Method(typeof(UIPartActionFieldItem), nameof(UIPartActionFieldItem.SetSymCounterpartValue))));
         }
 
         static bool UIPartActionFieldItem_SetSymCounterpartValue_Prefix(UIPartActionFieldItem __instance, object value, out bool __result)

--- a/KSPCommunityFixes/Modding/OnSymmetryFieldChanged.cs
+++ b/KSPCommunityFixes/Modding/OnSymmetryFieldChanged.cs
@@ -8,11 +8,9 @@ namespace KSPCommunityFixes.Modding
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(UIPartActionFieldItem), nameof(UIPartActionFieldItem.SetSymCounterpartValue))));
+            AddPatch(PatchType.Prefix, typeof(UIPartActionFieldItem), nameof(UIPartActionFieldItem.SetSymCounterpartValue));
         }
 
         static bool UIPartActionFieldItem_SetSymCounterpartValue_Prefix(UIPartActionFieldItem __instance, object value, out bool __result)

--- a/KSPCommunityFixes/Modding/PersistentIConfigNode.cs
+++ b/KSPCommunityFixes/Modding/PersistentIConfigNode.cs
@@ -28,40 +28,19 @@ namespace KSPCommunityFixes.Modding
 
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            MethodInfo ConfigNode_ReadObject = AccessTools.Method(typeof(ConfigNode), nameof(ConfigNode.ReadObject), new Type[] { typeof(object), typeof(ConfigNode) });
-            MethodInfo ConfigNode_WriteObject = AccessTools.Method(typeof(ConfigNode), nameof(ConfigNode.WriteObject), new Type[] { typeof(object), typeof(ConfigNode), typeof(int) });
+            AddPatch(PatchType.Prefix, typeof(ConfigNode), nameof(ConfigNode.ReadObject), new Type[] { typeof(object), typeof(ConfigNode) });
 
-            if (ConfigNode_ReadObject == null)
-                throw new Exception("ConfigNode.ReadObject() : method not found");
+            AddPatch(PatchType.Prefix, typeof(ConfigNode), nameof(ConfigNode.WriteObject), new Type[] { typeof(object), typeof(ConfigNode), typeof(int) });
 
-            if (ConfigNode_WriteObject == null)
-                throw new Exception("ConfigNode.WriteObject() : method not found");
+            AddPatch(PatchType.Prefix, typeof(ConfigNode), nameof(CreateConfigFromObject), new Type[] { typeof(object), typeof(int), typeof(ConfigNode) });
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                ConfigNode_ReadObject));
+            AddPatch(PatchType.Postfix, typeof(ConfigNode), nameof(CreateConfigFromObject), new Type[] { typeof(object), typeof(int), typeof(ConfigNode) });
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                ConfigNode_WriteObject));
+            AddPatch(PatchType.Prefix, typeof(ConfigNode), nameof(LoadObjectFromConfig), new Type[] { typeof(object), typeof(ConfigNode), typeof(int), typeof(bool) });
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ConfigNode), nameof(CreateConfigFromObject), new Type[] { typeof(object), typeof(int), typeof(ConfigNode) })));
-
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ConfigNode), nameof(CreateConfigFromObject), new Type[] { typeof(object), typeof(int), typeof(ConfigNode) })));
-
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ConfigNode), nameof(LoadObjectFromConfig), new Type[] { typeof(object), typeof(ConfigNode), typeof(int), typeof(bool) })));
-
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ConfigNode), nameof(LoadObjectFromConfig), new Type[] { typeof(object), typeof(ConfigNode), typeof(int), typeof(bool) })));
+            AddPatch(PatchType.Postfix, typeof(ConfigNode), nameof(LoadObjectFromConfig), new Type[] { typeof(object), typeof(ConfigNode), typeof(int), typeof(bool) });
         }
 
         // This will fail if nested, so we cache off the old writeLinks.

--- a/KSPCommunityFixes/Modding/PersistentIConfigNode.cs
+++ b/KSPCommunityFixes/Modding/PersistentIConfigNode.cs
@@ -41,33 +41,27 @@ namespace KSPCommunityFixes.Modding
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                ConfigNode_ReadObject,
-                this));
+                ConfigNode_ReadObject));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                ConfigNode_WriteObject,
-                this));
+                ConfigNode_WriteObject));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ConfigNode), nameof(CreateConfigFromObject), new Type[] { typeof(object), typeof(int), typeof(ConfigNode) }),
-                this));
+                AccessTools.Method(typeof(ConfigNode), nameof(CreateConfigFromObject), new Type[] { typeof(object), typeof(int), typeof(ConfigNode) })));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ConfigNode), nameof(CreateConfigFromObject), new Type[] { typeof(object), typeof(int), typeof(ConfigNode) }),
-                this));
+                AccessTools.Method(typeof(ConfigNode), nameof(CreateConfigFromObject), new Type[] { typeof(object), typeof(int), typeof(ConfigNode) })));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ConfigNode), nameof(LoadObjectFromConfig), new Type[] { typeof(object), typeof(ConfigNode), typeof(int), typeof(bool) }),
-                this));
+                AccessTools.Method(typeof(ConfigNode), nameof(LoadObjectFromConfig), new Type[] { typeof(object), typeof(ConfigNode), typeof(int), typeof(bool) })));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ConfigNode), nameof(LoadObjectFromConfig), new Type[] { typeof(object), typeof(ConfigNode), typeof(int), typeof(bool) }),
-                this));
+                AccessTools.Method(typeof(ConfigNode), nameof(LoadObjectFromConfig), new Type[] { typeof(object), typeof(ConfigNode), typeof(int), typeof(bool) })));
         }
 
         // This will fail if nested, so we cache off the old writeLinks.

--- a/KSPCommunityFixes/Performance/AsteroidAndCometDrillCache.cs
+++ b/KSPCommunityFixes/Performance/AsteroidAndCometDrillCache.cs
@@ -21,23 +21,15 @@ namespace KSPCommunityFixes.Performance
     {
         protected override Version VersionMin => new Version(1, 12, 3);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(
-                new PatchInfo(PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleAsteroidDrill), nameof(ModuleAsteroidDrill.IsSituationValid))));
+            AddPatch(PatchType.Prefix, typeof(ModuleAsteroidDrill), nameof(ModuleAsteroidDrill.IsSituationValid));
 
-            patches.Add(
-                new PatchInfo(PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleAsteroidDrill), nameof(ModuleAsteroidDrill.GetAttachedPotato))));
+            AddPatch(PatchType.Prefix, typeof(ModuleAsteroidDrill), nameof(ModuleAsteroidDrill.GetAttachedPotato));
 
-            patches.Add(
-                new PatchInfo(PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleCometDrill), nameof(ModuleCometDrill.IsSituationValid))));
+            AddPatch(PatchType.Prefix, typeof(ModuleCometDrill), nameof(ModuleCometDrill.IsSituationValid));
 
-            patches.Add(
-                new PatchInfo(PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleCometDrill), nameof(ModuleCometDrill.GetAttachedPotato))));
+            AddPatch(PatchType.Prefix, typeof(ModuleCometDrill), nameof(ModuleCometDrill.GetAttachedPotato));
         }
 
         static bool ModuleAsteroidDrill_IsSituationValid_Prefix(ModuleAsteroidDrill __instance, ref bool __result)

--- a/KSPCommunityFixes/Performance/AsteroidAndCometDrillCache.cs
+++ b/KSPCommunityFixes/Performance/AsteroidAndCometDrillCache.cs
@@ -54,7 +54,7 @@ namespace KSPCommunityFixes.Performance
             }
 
             // the resource harvester module keeps a cache of whether the vessel has a comet or asteroid attached
-            var resourceHarvester = __instance.part.FindModuleImplementing<ModuleResourceHarvester>();
+            var resourceHarvester = __instance.part.FindModuleImplementingFast<ModuleResourceHarvester>();
             if (resourceHarvester.IsNotNullOrDestroyed() && resourceHarvester.partCountCache == __instance._part.vessel.parts.Count)
             {
                 __result = !resourceHarvester.cachedWasNotAsteroid;
@@ -75,7 +75,7 @@ namespace KSPCommunityFixes.Performance
             }
 
             // the resource harvester module keeps a cache of whether the vessel has a comet or asteroid attached
-            var resourceHarvester = __instance.part.FindModuleImplementing<ModuleResourceHarvester>();
+            var resourceHarvester = __instance.part.FindModuleImplementingFast<ModuleResourceHarvester>();
             if (resourceHarvester.IsNotNullOrDestroyed() && resourceHarvester.partCountCache == __instance._part.vessel.parts.Count)
             {
                 // if the cache says there's no asteroid on board, we're done
@@ -100,7 +100,7 @@ namespace KSPCommunityFixes.Performance
             }
 
             // the resource harvester module keeps a cache of whether the vessel has a comet or asteroid attached
-            var resourceHarvester = __instance.part.FindModuleImplementing<ModuleResourceHarvester>();
+            var resourceHarvester = __instance.part.FindModuleImplementingFast<ModuleResourceHarvester>();
             if (resourceHarvester.IsNotNullOrDestroyed() && resourceHarvester.partCountCache == __instance._part.vessel.parts.Count)
             {
                 __result = !resourceHarvester.cachedWasNotComet;
@@ -121,7 +121,7 @@ namespace KSPCommunityFixes.Performance
             }
 
             // the resource harvester module keeps a cache of whether the vessel has a comet or asteroid attached
-            var resourceHarvester = __instance.part.FindModuleImplementing<ModuleResourceHarvester>();
+            var resourceHarvester = __instance.part.FindModuleImplementingFast<ModuleResourceHarvester>();
             if (resourceHarvester.IsNotNullOrDestroyed() && resourceHarvester.partCountCache == __instance._part.vessel.parts.Count)
             {
                 // if the cache says there's no Comet on board, we're done

--- a/KSPCommunityFixes/Performance/AsteroidAndCometDrillCache.cs
+++ b/KSPCommunityFixes/Performance/AsteroidAndCometDrillCache.cs
@@ -25,23 +25,19 @@ namespace KSPCommunityFixes.Performance
         {
             patches.Add(
                 new PatchInfo(PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleAsteroidDrill), nameof(ModuleAsteroidDrill.IsSituationValid)),
-                this));
+                AccessTools.Method(typeof(ModuleAsteroidDrill), nameof(ModuleAsteroidDrill.IsSituationValid))));
 
             patches.Add(
                 new PatchInfo(PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleAsteroidDrill), nameof(ModuleAsteroidDrill.GetAttachedPotato)),
-                this));
+                AccessTools.Method(typeof(ModuleAsteroidDrill), nameof(ModuleAsteroidDrill.GetAttachedPotato))));
 
             patches.Add(
                 new PatchInfo(PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleCometDrill), nameof(ModuleCometDrill.IsSituationValid)),
-                this));
+                AccessTools.Method(typeof(ModuleCometDrill), nameof(ModuleCometDrill.IsSituationValid))));
 
             patches.Add(
                 new PatchInfo(PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleCometDrill), nameof(ModuleCometDrill.GetAttachedPotato)),
-                this));
+                AccessTools.Method(typeof(ModuleCometDrill), nameof(ModuleCometDrill.GetAttachedPotato))));
         }
 
         static bool ModuleAsteroidDrill_IsSituationValid_Prefix(ModuleAsteroidDrill __instance, ref bool __result)

--- a/KSPCommunityFixes/Performance/AuxiliarySystemsFastUpdate.cs
+++ b/KSPCommunityFixes/Performance/AuxiliarySystemsFastUpdate.cs
@@ -1,0 +1,240 @@
+﻿using System;
+using CompoundParts;
+using HarmonyLib;
+using Highlighting;
+using KSP.UI.Screens.Flight;
+using System.Collections.Generic;
+using UnityEngine;
+using static Highlighting.Highlighter;
+
+namespace KSPCommunityFixes.Performance
+{
+    internal class AuxiliarySystemsFastUpdate : BasePatch
+    {
+        protected override Version VersionMin => new Version(1, 12, 3);
+
+        protected override void ApplyPatches(List<PatchInfo> patches)
+        {
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(TemperatureGaugeSystem), nameof(TemperatureGaugeSystem.Update)),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(Highlighter), nameof(Highlighter.UpdateRenderers)),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(VolumeNormalizer), nameof(VolumeNormalizer.Update)),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(CModuleLinkedMesh), nameof(CModuleLinkedMesh.TrackAnchor)),
+                this));
+        }
+
+        private static bool TemperatureGaugeSystem_Update_Prefix(TemperatureGaugeSystem __instance)
+        {
+            if (!FlightGlobals.ready || !HighLogic.LoadedSceneIsFlight)
+                return false;
+
+            if (GameSettings.TEMPERATURE_GAUGES_MODE < 1 || CameraManager.Instance.currentCameraMode != CameraManager.CameraMode.Flight)
+            {
+                if (__instance.gaugeCount > 0)
+                    __instance.DestroyGauges();
+
+                return false;
+            }
+
+            if (__instance.TestRecreate())
+                __instance.CreateGauges();
+
+            if (__instance.TestRebuild())
+                __instance.RebuildGaugeList();
+
+            if (__instance.gaugeCount == 0)
+                return false;
+
+            __instance.visibleGauges.Clear();
+            for (int i = __instance.gaugeCount; i-- > 0;)
+            {
+                TemperatureGauge gauge = __instance.gauges[i];
+                gauge.GaugeUpdate();
+                if (gauge.gaugeActive)
+                    __instance.visibleGauges.Add(gauge);
+            }
+
+            __instance.visibleGaugeCount = __instance.visibleGauges.Count;
+
+            if (__instance.visibleGaugeCount > 0)
+            {
+                __instance.visibleGauges.Sort();
+
+                for (int i = 0; i < __instance.visibleGaugeCount; i++)
+                    __instance.visibleGauges[i].rTrf.SetSiblingIndex(i);
+            }
+            return false;
+        }
+
+        private static bool Highlighter_UpdateRenderers_Prefix(Highlighter __instance, out bool __result)
+        {
+            __result = __instance.renderersDirty;
+            if (__result)
+            {
+                Part part = __instance.tr.GetComponent<Part>();
+                if (part.IsNullRef())
+                    return true; // if highlighter is not on a part, fall back to stock logic
+
+                List<Renderer> partRenderers = part.FindModelRenderersReadOnly();
+                __instance.highlightableRenderers = new List<RendererCache>(partRenderers.Count);
+                for (int i = partRenderers.Count; i-- > 0;)
+                {
+                    Renderer renderer = partRenderers[i];
+                    if (renderer.gameObject.layer != 1 && !renderer.material.name.Contains("KSP/Alpha/Translucent Additive"))
+                    {
+                        RendererCache rendererCache = new RendererCache(renderer, __instance.opaqueMaterial, __instance.zTestFloat, __instance.stencilRefFloat);
+                        __instance.highlightableRenderers.Add(rendererCache);
+                    }
+                }
+                __instance.highlighted = false;
+                __instance.renderersDirty = false;
+                __instance.currentColor = Color.clear;
+                __result = true;
+                return false;
+            }
+
+            for (int i = __instance.highlightableRenderers.Count; i-- > 0;)
+            {
+                if (__instance.highlightableRenderers[i].renderer.IsDestroyed())
+                {
+                    __instance.highlightableRenderers[i].CleanUp();
+                    __instance.highlightableRenderers.RemoveAt(i);
+                    __instance.renderersDirty = true;
+                    __result = true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool VolumeNormalizer_Update_Prefix(VolumeNormalizer __instance)
+        {
+            float newVolume;
+            if (GameSettings.SOUND_NORMALIZER_ENABLED)
+            {
+                __instance.threshold = GameSettings.SOUND_NORMALIZER_THRESHOLD;
+                __instance.sharpness = GameSettings.SOUND_NORMALIZER_RESPONSIVENESS;
+                AudioListener.GetOutputData(__instance.samples, 0);
+                __instance.level = 0f;
+
+                for (int i = 0; i < __instance.sampleCount; i += 1 + GameSettings.SOUND_NORMALIZER_SKIPSAMPLES)
+                    __instance.level = Mathf.Max(__instance.level, Mathf.Abs(__instance.samples[i]));
+
+                if (__instance.level > __instance.threshold)
+                    newVolume = __instance.threshold / __instance.level;
+                else
+                    newVolume = 1f;
+
+                newVolume = Mathf.Lerp(AudioListener.volume, newVolume * GameSettings.MASTER_VOLUME, __instance.sharpness * Time.deltaTime);
+            }
+            else
+            {
+                newVolume = Mathf.Lerp(AudioListener.volume, GameSettings.MASTER_VOLUME, __instance.sharpness * Time.deltaTime);
+            }
+
+            if (newVolume != __instance.volume)
+                AudioListener.volume = newVolume;
+
+            __instance.volume = newVolume;
+
+            return false;
+
+        }
+
+        private static bool CModuleLinkedMesh_TrackAnchor_Prefix(CModuleLinkedMesh __instance, bool setTgtAnchor, Vector3 rDir, Vector3 rPos, Quaternion rRot)
+        {
+            CModuleLinkedMesh st = __instance;
+
+            if (st.targetAnchor.IsNotNullOrDestroyed())
+            {
+                if (!st.tweakingTarget && !st.part.PartTweakerSelected)
+                {
+                    if (setTgtAnchor && st.compoundPart.IsNotNullOrDestroyed() && st.compoundPart.transform.IsNotNullOrDestroyed())
+                    {
+                        st.targetAnchor.position = st.compoundPart.transform.TransformPoint(rPos);
+                        st.targetAnchor.rotation = st.compoundPart.transform.rotation * rRot;
+                    }
+                }
+                else
+                {
+                    st.compoundPart.targetPosition = st.transform.InverseTransformPoint(st.targetAnchor.position);
+                    st.compoundPart.targetRotation = st.targetAnchor.localRotation;
+                    st.compoundPart.UpdateWorldValues();
+                }
+            }
+
+            bool lineRotationComputed = false;
+            Quaternion lineRotation = default;
+            if (st.endCap.IsNotNullOrDestroyed())
+            {
+                Vector3 vector = st.line.position - st.endCap.position;
+                float magnitude = vector.magnitude;
+                if (magnitude != 0f)
+                {
+                    if (magnitude < st.lineMinimumLength)
+                    {
+                        st.line.gameObject.SetActive(false);
+                    }
+                    else
+                    {
+                        st.line.gameObject.SetActive(true);
+                        lineRotation = Quaternion.LookRotation(vector / magnitude, st.transform.forward);
+                        lineRotationComputed = true;
+                        st.line.rotation = lineRotation;
+                        Vector3 localScale = st.line.localScale;
+                        st.line.localScale = new Vector3(localScale.x, localScale.y, magnitude * st.part.scaleFactor);
+                        st.endCap.rotation = lineRotation;
+                    }
+                }
+            }
+            else if (st.transform.IsNotNullOrDestroyed() && st.targetAnchor.IsNotNullOrDestroyed())
+            {
+                Vector3 vector = st.transform.position - st.targetAnchor.position;
+                float magnitude = vector.magnitude;
+                if (magnitude != 0f)
+                {
+                    if (magnitude < st.lineMinimumLength)
+                    {
+                        st.line.gameObject.SetActive(false);
+                    }
+                    else
+                    {
+                        st.line.gameObject.SetActive(true);
+                        if (float.IsNaN(magnitude) || float.IsInfinity(magnitude))
+                        {
+                            Debug.LogError(string.Concat("[CModuleLinkedMesh]: Object ", st.name, ": Look vector magnitude invalid. Vector is (", vector.x, ", ", vector.y, ", ", vector.z, "). Transform ", st.transform.position.IsInvalid() ? "invalid" : "valid", " ", st.transform.position, ", target ", st.targetAnchor.position.IsInvalid() ? "invalid" : "valid", ", ", st.targetAnchor.position));
+                            return false;
+                        }
+                        lineRotation = Quaternion.LookRotation(vector / magnitude, st.transform.forward);
+                        lineRotationComputed = true;
+                        st.line.rotation = lineRotation;
+                        Vector3 localScale = st.line.localScale;
+                        st.line.localScale = new Vector3(localScale.x, localScale.y, magnitude * st.part.scaleFactor);
+                    }
+                }
+            }
+            if (st.startCap.IsNotNullOrDestroyed())
+            {
+                if (!lineRotationComputed)
+                    st.startCap.rotation = st.line.rotation;
+                else
+                    st.startCap.rotation = lineRotation;
+            }
+
+            return false;
+        }
+    }
+}

--- a/KSPCommunityFixes/Performance/CollisionEnhancerFastUpdate.cs
+++ b/KSPCommunityFixes/Performance/CollisionEnhancerFastUpdate.cs
@@ -14,8 +14,7 @@ namespace KSPCommunityFixes.Performance
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(CollisionEnhancer), nameof(CollisionEnhancer.FixedUpdate)),
-                this));
+                AccessTools.Method(typeof(CollisionEnhancer), nameof(CollisionEnhancer.FixedUpdate))));
         }
 
         private static bool CollisionEnhancer_FixedUpdate_Prefix(CollisionEnhancer __instance)

--- a/KSPCommunityFixes/Performance/CollisionEnhancerFastUpdate.cs
+++ b/KSPCommunityFixes/Performance/CollisionEnhancerFastUpdate.cs
@@ -10,11 +10,9 @@ namespace KSPCommunityFixes.Performance
     {
         protected override Version VersionMin => new Version(1, 12, 3);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(CollisionEnhancer), nameof(CollisionEnhancer.FixedUpdate))));
+            AddPatch(PatchType.Prefix, typeof(CollisionEnhancer), nameof(CollisionEnhancer.FixedUpdate));
         }
 
         private static bool CollisionEnhancer_FixedUpdate_Prefix(CollisionEnhancer __instance)

--- a/KSPCommunityFixes/Performance/CollisionEnhancerFastUpdate.cs
+++ b/KSPCommunityFixes/Performance/CollisionEnhancerFastUpdate.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using HarmonyLib;
+using KSP.Localization;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace KSPCommunityFixes.Performance
+{
+    internal class CollisionEnhancerFastUpdate : BasePatch
+    {
+        protected override Version VersionMin => new Version(1, 12, 3);
+
+        protected override void ApplyPatches(List<PatchInfo> patches)
+        {
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(CollisionEnhancer), nameof(CollisionEnhancer.FixedUpdate)),
+                this));
+        }
+
+        private static bool CollisionEnhancer_FixedUpdate_Prefix(CollisionEnhancer __instance)
+        {
+            Part part = __instance.part;
+            Vector3 position = part.partTransform.position;
+
+            if (part.packed)
+            {
+                __instance.lastPos = position;
+                __instance.wasPacked = true;
+                return false;
+            }
+
+            if (__instance.framesToSkip > 0)
+            {
+                __instance.lastPos = position;
+                __instance.framesToSkip--;
+                return false;
+            }
+
+            if (part.vessel.heightFromTerrain > 1000f)
+            {
+                __instance.lastPos = position;
+                return false;
+            }
+
+            if (!__instance.wasPacked)
+                __instance.lastPos -= FloatingOrigin.Offset;
+            else
+                __instance.wasPacked = false;
+
+            CollisionEnhancerBehaviour mode = __instance.OnTerrainPunchThrough;
+
+            if (mode < CollisionEnhancerBehaviour.COLLIDE // only handle EXPLODE, TRANSLATE and TRANSLATE_BACK_SPLAT
+                && !CollisionEnhancer.bypass
+                && part.State != PartStates.DEAD
+                && (__instance.lastPos - position).sqrMagnitude > CollisionEnhancer.minDistSqr
+                && Physics.Linecast(__instance.lastPos, position, out RaycastHit hit, 32768, QueryTriggerInteraction.Ignore)) // linecast against the "LocalScenery" layer
+            {
+                Vector3 rbVelocity = __instance.rb.velocity;
+                Debug.Log("[F: " + Time.frameCount + "]: [" + __instance.name + "] Collision Enhancer Punch Through - vel: " + rbVelocity.magnitude, __instance.gameObject);
+
+                if (mode == CollisionEnhancerBehaviour.EXPLODE
+                    && !CheatOptions.NoCrashDamage
+                    && rbVelocity.sqrMagnitude > part.crashTolerance * part.crashTolerance)
+                {
+                    GameEvents.onCollision.Fire(new EventReport(FlightEvents.COLLISION, part, part.partInfo.title, Localizer.Format("#autoLOC_204427")));
+                    part.explode();
+                }
+                else
+                {
+                    Vector3 upAxis = FlightGlobals.getUpAxis(FlightGlobals.currentMainBody, hit.point);
+
+                    if (!hit.point.IsInvalid())
+                        __instance.transform.position = hit.point + upAxis * CollisionEnhancer.upFactor;
+
+                    if (mode == CollisionEnhancerBehaviour.TRANSLATE_BACK_SPLAT)
+                    {
+                        __instance.rb.velocity = Vector3.zero;
+                    }
+                    else
+                    {
+                        Vector3 frameVelocity = Krakensbane.GetFrameVelocityV3f();
+                        Vector3 totalVelocity = rbVelocity + frameVelocity;
+                        float totalVelMagnitude = totalVelocity.magnitude;
+                        Vector3 totalVelNormalized = totalVelMagnitude > 1E-05f ? totalVelocity / totalVelMagnitude : Vector3.zero;
+                        Vector3 newVel = Vector3.Reflect(totalVelNormalized, hit.normal * Mathf.Sign(Vector3.Dot(hit.normal, upAxis))).normalized * totalVelMagnitude * __instance.translateBackVelocityFactor - frameVelocity;
+                        __instance.rb.velocity = newVel.IsInvalid() ? Vector3.zero : newVel;
+                    }
+                }
+                GameEvents.OnCollisionEnhancerHit.Fire(part, hit);
+                GameEvents.onPartExplodeGroundCollision.Fire(part);
+            }
+
+            __instance.lastPos = position;
+
+            return false;
+        }
+    }
+}

--- a/KSPCommunityFixes/Performance/CollisionManagerFastUpdate.cs
+++ b/KSPCommunityFixes/Performance/CollisionManagerFastUpdate.cs
@@ -26,8 +26,7 @@ namespace KSPCommunityFixes.Performance
         {
             patches.Add(
                 new PatchInfo(PatchMethodType.Prefix,
-                    AccessTools.Method(typeof(CollisionManager), nameof(CollisionManager.UpdatePartCollisionIgnores)),
-                    this));
+                    AccessTools.Method(typeof(CollisionManager), nameof(CollisionManager.UpdatePartCollisionIgnores))));
         }
 
         static bool CollisionManager_UpdatePartCollisionIgnores_Prefix(CollisionManager __instance)

--- a/KSPCommunityFixes/Performance/CollisionManagerFastUpdate.cs
+++ b/KSPCommunityFixes/Performance/CollisionManagerFastUpdate.cs
@@ -22,11 +22,9 @@ namespace KSPCommunityFixes.Performance
     {
         protected override Version VersionMin => new Version(1, 11, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(
-                new PatchInfo(PatchMethodType.Prefix,
-                    AccessTools.Method(typeof(CollisionManager), nameof(CollisionManager.UpdatePartCollisionIgnores))));
+            AddPatch(PatchType.Prefix, typeof(CollisionManager), nameof(CollisionManager.UpdatePartCollisionIgnores));
         }
 
         static bool CollisionManager_UpdatePartCollisionIgnores_Prefix(CollisionManager __instance)

--- a/KSPCommunityFixes/Performance/CommNetThrottling.cs
+++ b/KSPCommunityFixes/Performance/CommNetThrottling.cs
@@ -21,8 +21,7 @@ namespace KSPCommunityFixes.Performance
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(CommNet.CommNetNetwork), nameof(CommNet.CommNetNetwork.Update)),
-                this));
+                AccessTools.Method(typeof(CommNet.CommNetNetwork), nameof(CommNet.CommNetNetwork.Update))));
         }
 
         static bool CommNetNetwork_Update_Prefix(CommNet.CommNetNetwork __instance)

--- a/KSPCommunityFixes/Performance/CommNetThrottling.cs
+++ b/KSPCommunityFixes/Performance/CommNetThrottling.cs
@@ -9,7 +9,7 @@ namespace KSPCommunityFixes.Performance
         private static double packedInterval = 0.5;
         private static double unpackedInterval = 5.0;
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
             ConfigNode settingsNode = KSPCommunityFixes.SettingsNode.GetNode("COMMNET_THROTTLING_SETTINGS");
 
@@ -19,9 +19,7 @@ namespace KSPCommunityFixes.Performance
                 settingsNode.TryGetValue("unpackedInterval", ref unpackedInterval);
             }
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(CommNet.CommNetNetwork), nameof(CommNet.CommNetNetwork.Update))));
+            AddPatch(PatchType.Prefix, typeof(CommNet.CommNetNetwork), nameof(CommNet.CommNetNetwork.Update));
         }
 
         static bool CommNetNetwork_Update_Prefix(CommNet.CommNetNetwork __instance)

--- a/KSPCommunityFixes/Performance/ContractProgressEnumCache.cs
+++ b/KSPCommunityFixes/Performance/ContractProgressEnumCache.cs
@@ -22,19 +22,16 @@ namespace KSPCommunityFixes.Performance
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(ProgressUtilities), nameof(ProgressUtilities.GetAnyBodyProgress)),
-                this));
+                AccessTools.Method(typeof(ProgressUtilities), nameof(ProgressUtilities.GetAnyBodyProgress))));
 
 #if PROFILE_GETANYBODYPROGRESS
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ProgressUtilities), nameof(ProgressUtilities.GetAnyBodyProgress)),
-                this));
+                AccessTools.Method(typeof(ProgressUtilities), nameof(ProgressUtilities.GetAnyBodyProgress))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ProgressUtilities), nameof(ProgressUtilities.GetAnyBodyProgress)),
-                this));
+                AccessTools.Method(typeof(ProgressUtilities), nameof(ProgressUtilities.GetAnyBodyProgress))));
 #endif
         }
 

--- a/KSPCommunityFixes/Performance/ContractProgressEnumCache.cs
+++ b/KSPCommunityFixes/Performance/ContractProgressEnumCache.cs
@@ -18,11 +18,9 @@ namespace KSPCommunityFixes.Performance
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(ProgressUtilities), nameof(ProgressUtilities.GetAnyBodyProgress))));
+            AddPatch(PatchType.Transpiler, typeof(ProgressUtilities), nameof(ProgressUtilities.GetAnyBodyProgress));
 
 #if PROFILE_GETANYBODYPROGRESS
             patches.Add(new PatchInfo(

--- a/KSPCommunityFixes/Performance/DisableHiddenPortraits.cs
+++ b/KSPCommunityFixes/Performance/DisableHiddenPortraits.cs
@@ -21,11 +21,9 @@ namespace KSPCommunityFixes.Performance
 {
     internal class DisableHiddenPortraits : BasePatch
     {
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(KerbalPortrait), nameof(KerbalPortrait.OnEnable))));
+            AddPatch(PatchType.Prefix, typeof(KerbalPortrait), nameof(KerbalPortrait.OnEnable));
         }
 
         private static bool KerbalPortrait_OnEnable_Prefix(KerbalPortrait __instance)

--- a/KSPCommunityFixes/Performance/DisableHiddenPortraits.cs
+++ b/KSPCommunityFixes/Performance/DisableHiddenPortraits.cs
@@ -25,8 +25,7 @@ namespace KSPCommunityFixes.Performance
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(KerbalPortrait), nameof(KerbalPortrait.OnEnable)),
-                this));
+                AccessTools.Method(typeof(KerbalPortrait), nameof(KerbalPortrait.OnEnable))));
         }
 
         private static bool KerbalPortrait_OnEnable_Prefix(KerbalPortrait __instance)

--- a/KSPCommunityFixes/Performance/DisableMapUpdateInFlight.cs
+++ b/KSPCommunityFixes/Performance/DisableMapUpdateInFlight.cs
@@ -14,13 +14,11 @@ namespace KSPCommunityFixes.Performance
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(OrbitRendererBase), nameof(OrbitRendererBase.Start)),
-                this));
+                AccessTools.Method(typeof(OrbitRendererBase), nameof(OrbitRendererBase.Start))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(OrbitRendererBase), nameof(OrbitRendererBase.LateUpdate)),
-                this));
+                AccessTools.Method(typeof(OrbitRendererBase), nameof(OrbitRendererBase.LateUpdate))));
         }
 
         static void OrbitRendererBase_Start_Postfix(OrbitRendererBase __instance)

--- a/KSPCommunityFixes/Performance/DisableMapUpdateInFlight.cs
+++ b/KSPCommunityFixes/Performance/DisableMapUpdateInFlight.cs
@@ -10,15 +10,11 @@ namespace KSPCommunityFixes.Performance
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(OrbitRendererBase), nameof(OrbitRendererBase.Start))));
+            AddPatch(PatchType.Postfix, typeof(OrbitRendererBase), nameof(OrbitRendererBase.Start));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(OrbitRendererBase), nameof(OrbitRendererBase.LateUpdate))));
+            AddPatch(PatchType.Prefix, typeof(OrbitRendererBase), nameof(OrbitRendererBase.LateUpdate));
         }
 
         static void OrbitRendererBase_Start_Postfix(OrbitRendererBase __instance)

--- a/KSPCommunityFixes/Performance/DragCubeGeneration.cs
+++ b/KSPCommunityFixes/Performance/DragCubeGeneration.cs
@@ -52,7 +52,7 @@ namespace KSPCommunityFixes.Performance
 {
     public class DragCubeGeneration : BasePatch
     {
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
             dragMaterial = new Material(DragCubeSystem.Instance.dragShader);
             defaultCubeNameArray = new[] { defaultCubeName };
@@ -70,23 +70,13 @@ namespace KSPCommunityFixes.Performance
             FieldInfo f_Canvas_willRenderCanvases = AccessTools.Field(typeof(Canvas), "willRenderCanvases");
             fieldRef_Canvas_WillRenderCanvases = AccessTools.FieldRefAccess<object, Canvas.WillRenderCanvases>(f_Canvas_willRenderCanvases);
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix, 
-                AccessTools.Method(typeof(DragCubeSystem), nameof(DragCubeSystem.RenderProceduralDragCube))));
+            AddPatch(PatchType.Prefix, typeof(DragCubeSystem), nameof(DragCubeSystem.RenderProceduralDragCube));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.EnumeratorMoveNext(AccessTools.Method(typeof(DragCubeSystem), nameof(DragCubeSystem.SetupDragCubeCoroutine), new [] {typeof(Part)} )),
-                nameof(DragCubeSystem_SetupDragCubeCoroutine_MoveNextTranspiler)));
+            AddPatch(PatchType.Transpiler, typeof(DragCubeSystem), nameof(DragCubeSystem.SetupDragCubeCoroutine), new[] {typeof(Part)}, nameof(DragCubeSystem_SetupDragCubeCoroutine_MoveNextTranspiler));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.EnumeratorMoveNext(AccessTools.Method(typeof(DragCubeSystem), nameof(DragCubeSystem.SetupDragCubeCoroutine), new[] { typeof(Part), typeof(ConfigNode) })),
-                nameof(DragCubeSystem_SetupDragCubeCoroutine_MoveNextTranspiler)));
+            AddPatch(PatchType.Transpiler, typeof(DragCubeSystem), nameof(DragCubeSystem.SetupDragCubeCoroutine), new[] {typeof(Part), typeof(ConfigNode)}, nameof(DragCubeSystem_SetupDragCubeCoroutine_MoveNextTranspiler));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ScreenPhysics), nameof(ScreenPhysics.Start))));
+            AddPatch(PatchType.Prefix, typeof(ScreenPhysics), nameof(ScreenPhysics.Start));
         }
 
         private static bool DragCubeSystem_RenderProceduralDragCube_Prefix(Part p, out DragCube __result)

--- a/KSPCommunityFixes/Performance/DragCubeGeneration.cs
+++ b/KSPCommunityFixes/Performance/DragCubeGeneration.cs
@@ -634,7 +634,8 @@ namespace KSPCommunityFixes.Performance
                 DragCube.DragFace.YP => boundsSize.y,
                 DragCube.DragFace.YN => boundsSize.y,
                 DragCube.DragFace.ZP => boundsSize.z,
-                DragCube.DragFace.ZN => boundsSize.z
+                DragCube.DragFace.ZN => boundsSize.z,
+                _ => throw new NotImplementedException()
             } + cameraDoubleOffset;
         }
 
@@ -654,7 +655,8 @@ namespace KSPCommunityFixes.Performance
                 DragCube.DragFace.YP => partTransform.rotation * lookDown,
                 DragCube.DragFace.YN => partTransform.rotation * lookUp,
                 DragCube.DragFace.ZP => partTransform.rotation * lookBack,
-                DragCube.DragFace.ZN => partTransform.rotation * lookForward
+                DragCube.DragFace.ZN => partTransform.rotation * lookForward,
+                _ => throw new NotImplementedException()
             };
         }
 
@@ -667,7 +669,8 @@ namespace KSPCommunityFixes.Performance
                 DragCube.DragFace.YP => new Vector3(partBounds.center.x, partBounds.max.y + cameraOffset, partBounds.center.z),
                 DragCube.DragFace.YN => new Vector3(partBounds.center.x, partBounds.min.y - cameraOffset, partBounds.center.z),
                 DragCube.DragFace.ZP => new Vector3(partBounds.center.x, partBounds.center.y, partBounds.max.z + cameraOffset),
-                DragCube.DragFace.ZN => new Vector3(partBounds.center.x, partBounds.center.y, partBounds.min.z - cameraOffset)
+                DragCube.DragFace.ZN => new Vector3(partBounds.center.x, partBounds.center.y, partBounds.min.z - cameraOffset),
+                _ => throw new NotImplementedException()
             };
 
             return part.transform.rotation * pos + part.transform.position;
@@ -942,6 +945,7 @@ namespace KSPCommunityFixes.Performance
                 DragCube.DragFace.YN => instance.yn,
                 DragCube.DragFace.ZP => instance.zp,
                 DragCube.DragFace.ZN => instance.zn,
+                _ => throw new NotImplementedException()
             };
 
             if (currentTexture.IsNullOrDestroyed())

--- a/KSPCommunityFixes/Performance/DragCubeGeneration.cs
+++ b/KSPCommunityFixes/Performance/DragCubeGeneration.cs
@@ -72,23 +72,21 @@ namespace KSPCommunityFixes.Performance
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix, 
-                AccessTools.Method(typeof(DragCubeSystem), nameof(DragCubeSystem.RenderProceduralDragCube)),
-                this));
+                AccessTools.Method(typeof(DragCubeSystem), nameof(DragCubeSystem.RenderProceduralDragCube))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
                 AccessTools.EnumeratorMoveNext(AccessTools.Method(typeof(DragCubeSystem), nameof(DragCubeSystem.SetupDragCubeCoroutine), new [] {typeof(Part)} )),
-                this, nameof(DragCubeSystem_SetupDragCubeCoroutine_MoveNextTranspiler)));
+                nameof(DragCubeSystem_SetupDragCubeCoroutine_MoveNextTranspiler)));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
                 AccessTools.EnumeratorMoveNext(AccessTools.Method(typeof(DragCubeSystem), nameof(DragCubeSystem.SetupDragCubeCoroutine), new[] { typeof(Part), typeof(ConfigNode) })),
-                this, nameof(DragCubeSystem_SetupDragCubeCoroutine_MoveNextTranspiler)));
+                nameof(DragCubeSystem_SetupDragCubeCoroutine_MoveNextTranspiler)));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ScreenPhysics), nameof(ScreenPhysics.Start)),
-                this));
+                AccessTools.Method(typeof(ScreenPhysics), nameof(ScreenPhysics.Start))));
         }
 
         private static bool DragCubeSystem_RenderProceduralDragCube_Prefix(Part p, out DragCube __result)

--- a/KSPCommunityFixes/Performance/FastLoader.cs
+++ b/KSPCommunityFixes/Performance/FastLoader.cs
@@ -1659,6 +1659,7 @@ namespace KSPCommunityFixes.Performance
                 // Unity can't convert NPOT textures to DXT5 with mipmaps
                 if (StaticHelpers.IsPowerOfTwo(normalMap.width) && StaticHelpers.IsPowerOfTwo(normalMap.height))
                 {
+                    normalMap.Apply(true); // needed to generate mipmaps, must be done before compression
                     normalMap.Compress(false);
                     normalMap.Apply(true, makeNoLongerReadable);
                 }

--- a/KSPCommunityFixes/Performance/FastLoader.cs
+++ b/KSPCommunityFixes/Performance/FastLoader.cs
@@ -2348,7 +2348,6 @@ namespace KSPCommunityFixes.Performance
             private string stackTrace;
             private string loader;
             private string origin;
-            private IEnumerator rootEnumerator;
 
             public LoaderExceptionInfo(Exception e, IEnumerator rootEnumerator)
             {

--- a/KSPCommunityFixes/Performance/FastLoader.cs
+++ b/KSPCommunityFixes/Performance/FastLoader.cs
@@ -16,6 +16,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.InteropServices;
 using System.Threading;
+using KSPCommunityFixes.Library;
 using TMPro;
 using Unity.Collections;
 using UnityEngine;
@@ -1378,7 +1379,7 @@ namespace KSPCommunityFixes.Performance
                 bool isNormalMap = file.name.EndsWith("NRM");
                 bool nonReadable = file.fullPath.Contains("@thumbs"); // KSPCF optimization : don't keep cargo icons in memory
                 bool hasMipMaps = file.fullPath.Contains(mipMapsPNGTexturePath); // only generate mipmaps for flags (stock behavior)
-                bool canCompress = hasMipMaps ? StaticHelpers.IsPowerOfTwo(width) && StaticHelpers.IsPowerOfTwo(height) : width % 4 == 0 && height % 4 == 0;
+                bool canCompress = hasMipMaps ? Numerics.IsPowerOfTwo(width) && Numerics.IsPowerOfTwo(height) : width % 4 == 0 && height % 4 == 0;
 
                 // don't initially compress normal textures, as we need to swizzle the raw data first
                 TextureFormat textureFormat;
@@ -1657,7 +1658,7 @@ namespace KSPCommunityFixes.Performance
                 }
 
                 // Unity can't convert NPOT textures to DXT5 with mipmaps
-                if (StaticHelpers.IsPowerOfTwo(normalMap.width) && StaticHelpers.IsPowerOfTwo(normalMap.height))
+                if (Numerics.IsPowerOfTwo(normalMap.width) && Numerics.IsPowerOfTwo(normalMap.height))
                 {
                     normalMap.Apply(true); // needed to generate mipmaps, must be done before compression
                     normalMap.Compress(false);

--- a/KSPCommunityFixes/Performance/FewerSaves.cs
+++ b/KSPCommunityFixes/Performance/FewerSaves.cs
@@ -12,27 +12,17 @@ namespace KSPCommunityFixes
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ACSceneSpawner), nameof(ACSceneSpawner.onACDespawn))));
+            AddPatch(PatchType.Prefix, typeof(ACSceneSpawner), nameof(ACSceneSpawner.onACDespawn));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(AdministrationSceneSpawner), nameof(AdministrationSceneSpawner.onAdminDespawn))));
+            AddPatch(PatchType.Prefix, typeof(AdministrationSceneSpawner), nameof(AdministrationSceneSpawner.onAdminDespawn));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(MCSceneSpawner), nameof(MCSceneSpawner.OnMCDespawn))));
+            AddPatch(PatchType.Prefix, typeof(MCSceneSpawner), nameof(MCSceneSpawner.OnMCDespawn));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(RDSceneSpawner), nameof(RDSceneSpawner.onRDDespawn))));
+            AddPatch(PatchType.Prefix, typeof(RDSceneSpawner), nameof(RDSceneSpawner.onRDDespawn));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(SpaceTracking), "OnVesselDeleteConfirm")));
+            AddPatch(PatchType.Transpiler, typeof(SpaceTracking), "OnVesselDeleteConfirm");
         }
 
         static bool ACSceneSpawner_onACDespawn_Prefix(ACSceneSpawner __instance)

--- a/KSPCommunityFixes/Performance/FewerSaves.cs
+++ b/KSPCommunityFixes/Performance/FewerSaves.cs
@@ -16,28 +16,23 @@ namespace KSPCommunityFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ACSceneSpawner), nameof(ACSceneSpawner.onACDespawn)),
-                this));
+                AccessTools.Method(typeof(ACSceneSpawner), nameof(ACSceneSpawner.onACDespawn))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(AdministrationSceneSpawner), nameof(AdministrationSceneSpawner.onAdminDespawn)),
-                this));
+                AccessTools.Method(typeof(AdministrationSceneSpawner), nameof(AdministrationSceneSpawner.onAdminDespawn))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(MCSceneSpawner), nameof(MCSceneSpawner.OnMCDespawn)),
-                this));
+                AccessTools.Method(typeof(MCSceneSpawner), nameof(MCSceneSpawner.OnMCDespawn))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(RDSceneSpawner), nameof(RDSceneSpawner.onRDDespawn)),
-                this));
+                AccessTools.Method(typeof(RDSceneSpawner), nameof(RDSceneSpawner.onRDDespawn))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(SpaceTracking), "OnVesselDeleteConfirm"),
-                this));
+                AccessTools.Method(typeof(SpaceTracking), "OnVesselDeleteConfirm")));
         }
 
         static bool ACSceneSpawner_onACDespawn_Prefix(ACSceneSpawner __instance)

--- a/KSPCommunityFixes/Performance/FlightCoreSystemsPerf.cs
+++ b/KSPCommunityFixes/Performance/FlightCoreSystemsPerf.cs
@@ -33,47 +33,23 @@ namespace KSPCommunityFixes.Performance
     {
         protected override Version VersionMin => new Version(1, 12, 3);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(VesselPrecalculate), nameof(VesselPrecalculate.CalculatePhysicsStats))));
+            AddPatch(PatchType.Prefix, typeof(VesselPrecalculate), nameof(VesselPrecalculate.CalculatePhysicsStats));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(FlightIntegrator), nameof(FlightIntegrator.UpdateOcclusionSolar))));
+            AddPatch(PatchType.Prefix, typeof(FlightIntegrator), nameof(FlightIntegrator.UpdateOcclusionSolar));
+            AddPatch(PatchType.Prefix, typeof(FlightIntegrator), nameof(FlightIntegrator.UpdateOcclusionBody));
+            AddPatch(PatchType.Prefix, typeof(FlightIntegrator), nameof(FlightIntegrator.UpdateOcclusionConvection));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(FlightIntegrator), nameof(FlightIntegrator.UpdateOcclusionBody))));
+            AddPatch(PatchType.Prefix, typeof(FlightIntegrator), nameof(FlightIntegrator.UpdateMassStats));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(FlightIntegrator), nameof(FlightIntegrator.UpdateOcclusionConvection))));
+            AddPatch(PatchType.Prefix, typeof(FlightIntegrator), nameof(FlightIntegrator.Integrate));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(FlightIntegrator), nameof(FlightIntegrator.UpdateMassStats))));
+            AddPatch(PatchType.Override, typeof(FlightIntegrator), nameof(FlightIntegrator.PrecalcRadiation));
+            AddPatch(PatchType.Override, typeof(FlightIntegrator), nameof(FlightIntegrator.GetSunArea));
+            AddPatch(PatchType.Override, typeof(FlightIntegrator), nameof(FlightIntegrator.GetBodyArea));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(FlightIntegrator), nameof(FlightIntegrator.Integrate))));
-
-            patches.Add(new PatchInfo(
-                PatchMethodType.Override,
-                AccessTools.Method(typeof(FlightIntegrator), nameof(FlightIntegrator.PrecalcRadiation))));
-
-            patches.Add(new PatchInfo(
-                PatchMethodType.Override,
-                AccessTools.Method(typeof(FlightIntegrator), nameof(FlightIntegrator.GetSunArea))));
-
-            patches.Add(new PatchInfo(
-                PatchMethodType.Override,
-                AccessTools.Method(typeof(FlightIntegrator), nameof(FlightIntegrator.GetBodyArea))));
-
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(FloatingOrigin), nameof(FloatingOrigin.setOffset))));
+            AddPatch(PatchType.Prefix, typeof(FloatingOrigin), nameof(FloatingOrigin.setOffset));
         }
 
         private static HashSet<int> activePS = new HashSet<int>(200);

--- a/KSPCommunityFixes/Performance/FlightPerf.cs
+++ b/KSPCommunityFixes/Performance/FlightPerf.cs
@@ -2,12 +2,34 @@
 // Warning : very log-spammy and performance destroying, don't leave this enabled if you don't need to.
 // #define DEBUG_FLIGHTINTEGRATOR
 
+/* Perf comparison (patch disabled vs enabled)
+| FPS                                     | Mean  | Mean (P) | Diff | Worst 1% | Worst 1% (P) | Diff |
+| --------------------------------------- | ----- | -------- | ---- | -------- | ------------ | ---- |
+| Acapello (150 parts) - Launchpad        | 238,7 | 247,8    | 4%   | 162,1    | 175,6        | 8%   |
+| Acapello (150 parts) - Atmo flight      | 237,1 | 250      | 5%   | 140,7    | 153,5        | 9%   |
+| Acapello (150 parts) - Orbit            | 287,3 | 312,9    | 9%   | 129,5    | 181,5        | 40%  |
+| SSTO (500 parts) - Launchpad            | 98,7  | 116,2    | 18%  | 73,1     | 96,1         | 31%  |
+| SSTO (500 parts) - Atmo flight          | 85,1  | 100,4    | 18%  | 54,8     | 68,8         | 26%  |
+| SSTO (500 parts) - Orbit                | 118,4 | 153      | 29%  | 70       | 85,9         | 23%  |
+| Big launcher (1000 parts) - Launchpad   | 62,2  | 88,4     | 42%  | 39,2     | 70,5         | 80%  |
+| Big launcher (1000 parts) - Atmo flight | 28,2  | 59,4     | 111% | 18,9     | 35           | 85%  |
+| Big launcher (1000 parts) - Orbit       | 56,3  | 90,4     | 61%  | 27,9     | 39,9         | 43%  |
+*/
+
+using CompoundParts;
 using HarmonyLib;
+using Highlighting;
+using KSP.Localization;
+using KSP.UI.Screens.Flight;
 using KSPCommunityFixes.Library;
+using KSPCommunityFixes.Library.Collections;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
+using Unity.Collections;
 using UnityEngine;
+using static DragCubeList;
 using Debug = UnityEngine.Debug;
 
 namespace KSPCommunityFixes.Performance
@@ -28,6 +50,11 @@ namespace KSPCommunityFixes.Performance
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
+                AccessTools.Method(typeof(FlightIntegrator), nameof(FlightIntegrator.UpdateOcclusionConvection)),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
                 AccessTools.Method(typeof(FlightIntegrator), nameof(FlightIntegrator.UpdateMassStats)),
                 this));
 
@@ -36,19 +63,1141 @@ namespace KSPCommunityFixes.Performance
                 AccessTools.Method(typeof(VesselPrecalculate), nameof(VesselPrecalculate.CalculatePhysicsStats)),
                 this));
 
-            // other offenders, in aero situations :
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(FlightIntegrator), nameof(FlightIntegrator.Integrate)),
+                this));
 
-            // AddSurfaceDragDirection : 7%
-            // - could turn the curves (1.6%) into lookup tables
-            // - general float to double pass, not sure how practical due to working a lot with float-backed drag cubes, relevant at least for the Mathf.Pow() call
-            // - multiple InverseTransform calls, use the matrix instead
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(Part), nameof(Part.isKerbalEVA)),
+                this));
 
-            // general optimization pass on UpdateOcclusionConvection() : 4.4%
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.FindNodeApproaches)),
+                this));
 
-            // In general, Integrate() should benefit from being made a non recursive loop, and that might open a few optimizations
-            // by moving some expensive matrix / quaternion stuff outside that loop.
+            patches.Add(new PatchInfo(
+                PatchMethodType.Postfix,
+                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnLoad)),
+                this));
 
-            // In a similar vein, there are a few thing to be done about FloatingOrigin and more specifically Vessel.SetPosition (at least, pre-computing the quaternion rotation)
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(CModuleLinkedMesh), nameof(CModuleLinkedMesh.TrackAnchor)),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(FlightIntegrator), nameof(FlightIntegrator.PrecalcRadiation)),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Postfix,
+                AccessTools.Method(typeof(Part), nameof(Part.OnDestroy)),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(Highlighter), nameof(Highlighter.UpdateRenderers)),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(CollisionEnhancer), nameof(CollisionEnhancer.FixedUpdate)),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(VolumeNormalizer), nameof(VolumeNormalizer.Update)),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(TemperatureGaugeSystem), nameof(TemperatureGaugeSystem.Update)),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(FloatingOrigin), nameof(FloatingOrigin.setOffset)),
+                this));
+        }
+
+        private static HashSet<int> activePS = new HashSet<int>(200);
+
+        private static bool FloatingOrigin_setOffset_Prefix(FloatingOrigin __instance, Vector3d refPos, Vector3d nonFrame)
+        {
+            if (refPos.IsInvalid())
+                return false;
+
+            if (double.IsInfinity(refPos.sqrMagnitude))
+                return false;
+
+            __instance.SetOffsetThisFrame = true;
+            __instance.offset = refPos;
+            __instance.reverseoffset = new Vector3d(0.0 - refPos.x, 0.0 - refPos.y, 0.0 - refPos.z);
+            __instance.offsetNonKrakensbane = __instance.offset + nonFrame;
+
+            Vector3 offsetF = __instance.offset;
+            Vector3 offsetNonKrakensbaneF = __instance.offsetNonKrakensbane;
+            float deltaTime = Time.deltaTime;
+            Vector3 frameVelocity = Krakensbane.GetFrameVelocity();
+
+            activePS.Clear();
+
+            List<CelestialBody> bodies = FlightGlobals.Bodies;
+            for (int i = bodies.Count; i-- > 0;)
+                bodies[i].position -= __instance.offsetNonKrakensbane;
+
+            bool needCoMRecalc = __instance.offset.sqrMagnitude > __instance.CoMRecalcOffsetMaxSqr;
+            List<Vessel> vessels = FlightGlobals.Vessels;
+
+            for (int i = vessels.Count; i-- > 0;)
+            {
+                Vessel vessel = vessels[i];
+
+                if (vessel.state == Vessel.State.DEAD)
+                    continue;
+
+                Vector3d vesselOffset = (!vessel.loaded || vessel.packed || vessel.LandedOrSplashed) ? __instance.offsetNonKrakensbane : __instance.offset;
+                vessel.SetPosition((Vector3d)vessel.transform.position - vesselOffset);
+
+                if (needCoMRecalc && vessel.packed)
+                {
+                    vessel.precalc.CalculatePhysicsStats();
+                }
+                else
+                {
+                    vessel.CoMD -= vesselOffset;
+                    vessel.CoM = vessel.CoMD;
+                }
+
+                // Update legacy (?) particle system
+                for (int j = vessel.parts.Count; j-- > 0;)
+                {
+                    Part part = vessel.parts[j];
+
+                    if (part.fxGroups.Count == 0)
+                        continue;
+
+                    bool partDataComputed = false;
+                    bool hasRigidbody = false;
+                    Vector3 partVelocity = Vector3.zero;
+
+                    for (int k = part.fxGroups.Count; k-- > 0;)
+                    {
+                        FXGroup fXGroup = part.fxGroups[k];
+                        for (int l = fXGroup.fxEmittersNewSystem.Count; l-- > 0;)
+                        {
+                            ParticleSystem particleSystem = fXGroup.fxEmittersNewSystem[l];
+                            
+                            int particleCount = particleSystem.particleCount;
+                            if (particleCount == 0 || particleSystem.main.simulationSpace != ParticleSystemSimulationSpace.World)
+                                continue;
+
+                            activePS.Add(particleSystem.GetInstanceID());
+
+                            if (!partDataComputed)
+                            {
+                                partDataComputed = true;
+                                Rigidbody partRB = part.Rigidbody;
+                                if (partRB.IsNotNullOrDestroyed())
+                                {
+                                    hasRigidbody = true;
+                                    partVelocity = partRB.velocity + frameVelocity;
+                                }
+                            }
+
+                            NativeArray<ParticleSystem.Particle> particleBuffer = particleSystem.GetParticlesNativeArray(ref particleCount);
+                            for (int pIdx = particleCount; pIdx-- > 0;)
+                            {
+                                Vector3 particlePos = particleBuffer.GetParticlePosition(pIdx);
+
+                                if (hasRigidbody)
+                                {
+                                    float scalar = UnityEngine.Random.value * deltaTime;
+                                    particlePos.Substract(partVelocity.x * scalar, partVelocity.y * scalar, partVelocity.z * scalar);
+                                }
+
+                                particlePos.Substract(offsetNonKrakensbaneF);
+                                particleBuffer.SetParticlePosition(pIdx, particlePos);
+                            }
+                            particleSystem.SetParticles(particleBuffer, particleCount);
+                        }
+                    }
+                }
+            }
+
+            // update "new" (but just as shitty) particle system (this replicate a call to EffectBehaviour.OffsetParticles())
+            Vector3 systemVelocity = Vector3.zero;
+
+            List<ParticleSystem> pSystems = EffectBehaviour.emitters;
+            for (int i = pSystems.Count; i-- > 0;)
+            {
+                ParticleSystem particleSystem = pSystems[i];
+
+                if (particleSystem.IsNullOrDestroyed())
+                {
+                    pSystems.RemoveAt(i);
+                    continue;
+                }
+
+                int particleCount = particleSystem.particleCount;
+                if (particleCount == 0 || particleSystem.main.simulationSpace != ParticleSystemSimulationSpace.World)
+                    continue;
+
+                activePS.Add(particleSystem.GetInstanceID());
+
+                bool hasRigidbody = false;
+                Rigidbody rb = particleSystem.GetComponentInParent<Rigidbody>();
+                if (rb.IsNotNullRef())
+                {
+                    hasRigidbody = true;
+                    systemVelocity = rb.velocity + frameVelocity;
+                }
+
+                NativeArray<ParticleSystem.Particle> particleBuffer = particleSystem.GetParticlesNativeArray(ref particleCount);
+                for (int pIdx = particleCount; pIdx-- > 0;)
+                {
+                    Vector3 particlePos = particleBuffer.GetParticlePosition(pIdx);
+
+                    if (hasRigidbody)
+                    {
+                        float scalar = UnityEngine.Random.value * deltaTime;
+                        particlePos.Substract(systemVelocity.x * scalar, systemVelocity.y * scalar, systemVelocity.z * scalar);
+                    }
+
+                    particlePos.Substract(offsetNonKrakensbaneF);
+                    particleBuffer.SetParticlePosition(pIdx, particlePos);
+                }
+                particleSystem.SetParticles(particleBuffer, particleCount);
+            }
+
+            List<KSPParticleEmitter> pSystemsKSP = EffectBehaviour.kspEmitters;
+            for (int i = pSystemsKSP.Count; i-- > 0;)
+            {
+                KSPParticleEmitter particleSystemKSP = pSystemsKSP[i];
+
+                if (particleSystemKSP.IsNullOrDestroyed())
+                {
+                    pSystemsKSP.RemoveAt(i);
+                    continue;
+                }
+
+                int particleCount = particleSystemKSP.ps.particleCount;
+                if (particleCount == 0 || !particleSystemKSP.useWorldSpace)
+                    continue;
+
+                activePS.Add(particleSystemKSP.ps.GetInstanceID());
+
+                bool hasRigidbody = false;
+                Rigidbody rb = particleSystemKSP.GetComponentInParent<Rigidbody>();
+                if (rb.IsNotNullRef())
+                {
+                    hasRigidbody = true;
+                    systemVelocity = rb.velocity + frameVelocity;
+                }
+
+                NativeArray<ParticleSystem.Particle> particleBuffer = particleSystemKSP.ps.GetParticlesNativeArray(ref particleCount);
+                for (int pIdx = particleCount; pIdx-- > 0;)
+                {
+                    Vector3 particlePos = particleBuffer.GetParticlePosition(pIdx);
+
+                    if (hasRigidbody)
+                    {
+                        float scalar = UnityEngine.Random.value * deltaTime;
+                        particlePos.Substract(systemVelocity.x * scalar, systemVelocity.y * scalar, systemVelocity.z * scalar);
+                    }
+
+                    particlePos.Substract(offsetNonKrakensbaneF);
+                    particleBuffer.SetParticlePosition(pIdx, particlePos);
+                }
+                particleSystemKSP.ps.SetParticles(particleBuffer, particleCount);
+            }
+
+            // Just have another handling of the same stuff, sometimes overlapping, sometimes not, because why not ?
+            for (int i = __instance.particleSystems.Count; i-- > 0;)
+            {
+                ParticleSystem particleSystem = __instance.particleSystems[i];
+                if (particleSystem.IsNullOrDestroyed() || activePS.Contains(particleSystem.GetInstanceID()))
+                {
+                    __instance.particleSystems.RemoveAt(i);
+                    continue;
+                }
+
+                int particleCount = particleSystem.particleCount;
+                if (particleCount == 0)
+                    continue;
+
+                if (particleSystem.main.simulationSpace != ParticleSystemSimulationSpace.World)
+                    continue;
+
+                if (activePS.Contains(particleSystem.GetInstanceID()))
+                {
+                    __instance.particleSystems.RemoveAt(i);
+                    continue;
+                }
+
+                NativeArray<ParticleSystem.Particle> particleBuffer = particleSystem.GetParticlesNativeArray(ref particleCount);
+                for (int pIdx = particleCount; pIdx-- > 0;)
+                {
+                    Vector3 particlePos = particleBuffer.GetParticlePosition(pIdx);
+                    particlePos.Substract(offsetNonKrakensbaneF);
+                    particleBuffer.SetParticlePosition(pIdx, particlePos);
+                }
+
+                particleSystem.SetParticles(particleBuffer, particleCount);
+            }
+
+            // more particle system (explosions, fireworks...) moving in here, but this is getting silly, I don't care anymore...
+            if (FlightGlobals.ActiveVessel != null && FlightGlobals.ActiveVessel.radarAltitude < __instance.altToStopMovingExplosions)
+                FXMonger.OffsetPositions(-__instance.offsetNonKrakensbane);
+
+            for (int i = FlightGlobals.physicalObjects.Count; i-- > 0;)
+            {
+                physicalObject physicalObject = FlightGlobals.physicalObjects[i];
+                if (physicalObject.IsNotNullOrDestroyed())
+                {
+                    Transform obj = physicalObject.transform;
+                    obj.position -= offsetF;
+                }
+            }
+
+            FloatingOrigin.TerrainShaderOffset += __instance.offsetNonKrakensbane;
+            GameEvents.onFloatingOriginShift.Fire(__instance.offset, nonFrame);
+
+            return false;
+        }
+
+        private static bool TemperatureGaugeSystem_Update_Prefix(TemperatureGaugeSystem __instance)
+        {
+            if (!FlightGlobals.ready || !HighLogic.LoadedSceneIsFlight)
+                return false;
+
+            if (GameSettings.TEMPERATURE_GAUGES_MODE < 1 || CameraManager.Instance.currentCameraMode != CameraManager.CameraMode.Flight)
+            {
+                if (__instance.gaugeCount > 0)
+                    __instance.DestroyGauges();
+
+                return false;
+            }
+
+            if (__instance.TestRecreate())
+                __instance.CreateGauges();
+
+            if (__instance.TestRebuild())
+                __instance.RebuildGaugeList();
+
+            if (__instance.gaugeCount == 0)
+                return false;
+
+            __instance.visibleGauges.Clear();
+            for (int i = __instance.gaugeCount; i-- > 0;)
+            {
+                TemperatureGauge gauge = __instance.gauges[i];
+                gauge.GaugeUpdate();
+                if (gauge.gaugeActive)
+                    __instance.visibleGauges.Add(gauge);
+            }
+
+            __instance.visibleGaugeCount = __instance.visibleGauges.Count;
+
+            if (__instance.visibleGaugeCount > 0)
+            {
+                __instance.visibleGauges.Sort();
+
+                for (int i = 0; i < __instance.visibleGaugeCount; i++)
+                    __instance.visibleGauges[i].rTrf.SetSiblingIndex(i);
+            }
+            return false;
+        }
+
+        private static bool VolumeNormalizer_Update_Prefix(VolumeNormalizer __instance)
+        {
+            float newVolume;
+            if (GameSettings.SOUND_NORMALIZER_ENABLED)
+            {
+                __instance.threshold = GameSettings.SOUND_NORMALIZER_THRESHOLD;
+                __instance.sharpness = GameSettings.SOUND_NORMALIZER_RESPONSIVENESS;
+                AudioListener.GetOutputData(__instance.samples, 0);
+                __instance.level = 0f;
+
+                for (int i = 0; i < __instance.sampleCount; i += 1 + GameSettings.SOUND_NORMALIZER_SKIPSAMPLES)
+                    __instance.level = Mathf.Max(__instance.level, Mathf.Abs(__instance.samples[i]));
+
+                if (__instance.level > __instance.threshold)
+                    newVolume = __instance.threshold / __instance.level;
+                else
+                    newVolume = 1f;
+
+                newVolume = Mathf.Lerp(AudioListener.volume, newVolume * GameSettings.MASTER_VOLUME, __instance.sharpness * Time.deltaTime);
+            }
+            else
+            {
+                newVolume = Mathf.Lerp(AudioListener.volume, GameSettings.MASTER_VOLUME, __instance.sharpness * Time.deltaTime);
+            }
+
+            if (newVolume != __instance.volume)
+                AudioListener.volume = newVolume;
+
+            __instance.volume = newVolume;
+
+            return false;
+
+        }
+
+        private static bool CollisionEnhancer_FixedUpdate_Prefix(CollisionEnhancer __instance)
+        {
+            Part part = __instance.part;
+            Vector3 position = part.partTransform.position;
+
+            if (part.packed)
+            {
+                __instance.lastPos = position;
+                __instance.wasPacked = true;
+                return false;
+            }
+
+            if (__instance.framesToSkip > 0)
+            {
+                __instance.lastPos = position;
+                __instance.framesToSkip--;
+                return false;
+            }
+
+            if (part.vessel.heightFromTerrain > 1000f)
+            {
+                __instance.lastPos = position;
+                return false;
+            }
+
+            if (!__instance.wasPacked)
+                __instance.lastPos -= FloatingOrigin.Offset;
+            else
+                __instance.wasPacked = false;
+
+            CollisionEnhancerBehaviour mode = __instance.OnTerrainPunchThrough;
+
+            if (mode < CollisionEnhancerBehaviour.COLLIDE // only handle EXPLODE, TRANSLATE and TRANSLATE_BACK_SPLAT
+                && !CollisionEnhancer.bypass 
+                && part.State != PartStates.DEAD 
+                && (__instance.lastPos - position).sqrMagnitude > CollisionEnhancer.minDistSqr
+                && Physics.Linecast(__instance.lastPos, position, out RaycastHit hit, 32768, QueryTriggerInteraction.Ignore)) // linecast against the "LocalScenery" layer
+            {
+                Vector3 rbVelocity = __instance.rb.velocity;
+                Debug.Log("[F: " + Time.frameCount + "]: [" + __instance.name + "] Collision Enhancer Punch Through - vel: " + rbVelocity.magnitude, __instance.gameObject);
+
+                if (mode == CollisionEnhancerBehaviour.EXPLODE 
+                    && !CheatOptions.NoCrashDamage 
+                    && rbVelocity.sqrMagnitude > part.crashTolerance * part.crashTolerance)
+                {
+                    GameEvents.onCollision.Fire(new EventReport(FlightEvents.COLLISION, part, part.partInfo.title, Localizer.Format("#autoLOC_204427")));
+                    part.explode();
+                }
+                else
+                {
+                    Vector3 upAxis = FlightGlobals.getUpAxis(FlightGlobals.currentMainBody, hit.point);
+
+                    if (!hit.point.IsInvalid())
+                        __instance.transform.position = hit.point + upAxis * CollisionEnhancer.upFactor;
+
+                    if (mode == CollisionEnhancerBehaviour.TRANSLATE_BACK_SPLAT)
+                    {
+                        __instance.rb.velocity = Vector3.zero;
+                    }
+                    else
+                    {
+                        Vector3 frameVelocity = Krakensbane.GetFrameVelocityV3f();
+                        Vector3 totalVelocity = rbVelocity + frameVelocity;
+                        float totalVelMagnitude = totalVelocity.magnitude;
+                        Vector3 totalVelNormalized = totalVelMagnitude > 1E-05f ? totalVelocity / totalVelMagnitude : Vector3.zero;
+                        Vector3 newVel = Vector3.Reflect(totalVelNormalized, hit.normal * Mathf.Sign(Vector3.Dot(hit.normal, upAxis))).normalized * totalVelMagnitude * __instance.translateBackVelocityFactor - frameVelocity;
+                        __instance.rb.velocity = newVel.IsInvalid() ? Vector3.zero : newVel;
+                    }
+                }
+                GameEvents.OnCollisionEnhancerHit.Fire(part, hit);
+                GameEvents.onPartExplodeGroundCollision.Fire(part);
+            }
+
+            __instance.lastPos = position;
+
+            return false;
+        }
+
+        private static void Part_OnDestroy_Postfix(Part __instance)
+        {
+            if (__instance.hl.IsNullOrDestroyed())
+                return;
+
+            Highlighter hl = __instance.hl;
+            if (hl.highlightableRenderers != null)
+            {
+                for (int i = hl.highlightableRenderers.Count; i-- > 0;)
+                    hl.highlightableRenderers[i].CleanUp();
+
+                hl.highlightableRenderers.Clear();
+            }
+
+            hl.renderersDirty = true;
+        }
+
+        private static bool Highlighter_UpdateRenderers_Prefix(Highlighter __instance, out bool __result)
+        {
+            __result = __instance.renderersDirty;
+            if (__result)
+            {
+                List<Renderer> renderers = new List<Renderer>();
+                __instance.GrabRenderers(__instance.tr, ref renderers);
+                __instance.highlightableRenderers = new List<Highlighter.RendererCache>();
+                int count = renderers.Count;
+                for (int i = 0; i < count; i++)
+                {
+                    Highlighter.RendererCache item = new Highlighter.RendererCache(renderers[i], __instance.opaqueMaterial, __instance.zTestFloat, __instance.stencilRefFloat);
+                    __instance.highlightableRenderers.Add(item);
+                }
+                __instance.highlighted = false;
+                __instance.renderersDirty = false;
+                __instance.currentColor = Color.clear;
+            }
+            return false;
+        }
+
+        private static bool FlightIntegrator_PrecalcRadiation_Prefix(FlightIntegrator __instance, PartThermalData ptd)
+        {
+            Part part = ptd.part;
+            double num = __instance.cacheRadiationFactor * 0.001;
+            ptd.emissScalar = part.emissiveConstant * num;
+            ptd.absorbScalar = part.absorptiveConstant * num;
+            ptd.sunFlux = 0.0;
+            ptd.bodyFlux = __instance.bodyEmissiveFlux + __instance.bodyAlbedoFlux;
+            double num2 = part.radiativeArea * (1.0 - part.skinExposedAreaFrac);
+            ptd.expFlux = 0.0;
+            ptd.unexpFlux = 0.0;
+            ptd.brtUnexposed = __instance.backgroundRadiationTemp;
+            ptd.brtExposed = Numerics.Lerp(__instance.backgroundRadiationTemp, __instance.backgroundRadiationTempExposed, ptd.convectionTempMultiplier);
+
+            if (part.DragCubes.None || part.ShieldedFromAirstream)
+                return false;
+
+            bool computeSunFlux = __instance.vessel.directSunlight;
+            bool computeBodyFlux = ptd.bodyFlux > 0.0;
+
+            if (!computeSunFlux && !computeBodyFlux)
+                return false;
+
+            float[] dragCubeAreaOccluded = part.DragCubes.areaOccluded;
+
+            if (computeSunFlux)
+            {
+                Vector3 sunLocalDir = part.partTransform.InverseTransformDirection(__instance.sunVector);
+
+                double sunArea = 0.0;
+                if (sunLocalDir.x > 0.0)
+                    sunArea += dragCubeAreaOccluded[0] * sunLocalDir.x; // right
+                else
+                    sunArea += dragCubeAreaOccluded[1] * -sunLocalDir.x; // left
+
+                if (sunLocalDir.y > 0.0)
+                    sunArea += dragCubeAreaOccluded[2] * sunLocalDir.y; // up
+                else
+                    sunArea += dragCubeAreaOccluded[3] * -sunLocalDir.y; // down
+
+                if (sunLocalDir.z > 0.0)
+                    sunArea += dragCubeAreaOccluded[4] * sunLocalDir.z; // forward
+                else
+                    sunArea += dragCubeAreaOccluded[5] * -sunLocalDir.z; // back
+
+                sunArea *= ptd.sunAreaMultiplier;
+
+                if (sunArea > 0.0)
+                {
+                    ptd.sunFlux = ptd.absorbScalar * __instance.solarFlux;
+                    if (ptd.exposed)
+                    {
+                        double num3 = ((double)Vector3.Dot(__instance.sunVector, __instance.nVel) + 1.0) * 0.5;
+                        double num4 = Math.Min(sunArea, part.skinExposedArea * num3);
+                        double num5 = Math.Min(sunArea - num4, num2 * (1.0 - num3));
+                        ptd.expFlux += ptd.sunFlux * num4;
+                        ptd.unexpFlux += ptd.sunFlux * num5;
+                    }
+                    else
+                    {
+                        ptd.expFlux += ptd.sunFlux * sunArea;
+                    }
+                }
+            }
+
+            if (computeBodyFlux)
+            {
+                Vector3 bodyLocalDir = part.partTransform.InverseTransformDirection(-__instance.vessel.upAxis);
+
+                double bodyArea = 0.0;
+                if (bodyLocalDir.x > 0.0)
+                    bodyArea += dragCubeAreaOccluded[0] * bodyLocalDir.x; // right
+                else
+                    bodyArea += dragCubeAreaOccluded[1] * -bodyLocalDir.x; // left
+
+                if (bodyLocalDir.y > 0.0)
+                    bodyArea += dragCubeAreaOccluded[2] * bodyLocalDir.y; // up
+                else
+                    bodyArea += dragCubeAreaOccluded[3] * -bodyLocalDir.y; // down
+
+                if (bodyLocalDir.z > 0.0)
+                    bodyArea += dragCubeAreaOccluded[4] * bodyLocalDir.z; // forward
+                else
+                    bodyArea += dragCubeAreaOccluded[5] * -bodyLocalDir.z; // back
+
+                bodyArea *= ptd.bodyAreaMultiplier;
+
+                if (bodyArea > 0.0)
+                {
+                    ptd.bodyFlux = UtilMath.Lerp(0.0, ptd.bodyFlux, __instance.densityThermalLerp) * ptd.absorbScalar;
+                    if (ptd.exposed)
+                    {
+                        double num6 = (Vector3.Dot(-__instance.vessel.upAxis, __instance.nVel) + 1f) * 0.5f;
+                        double num7 = Math.Min(bodyArea, part.skinExposedArea * num6);
+                        double num8 = Math.Min(bodyArea - num7, num2 * (1.0 - num6));
+                        ptd.expFlux += ptd.bodyFlux * num7;
+                        ptd.unexpFlux += ptd.bodyFlux * num8;
+                    }
+                    else
+                    {
+                        ptd.expFlux += ptd.bodyFlux * bodyArea;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static bool CModuleLinkedMesh_TrackAnchor_Prefix(CModuleLinkedMesh __instance, bool setTgtAnchor, Vector3 rDir, Vector3 rPos, Quaternion rRot)
+        {
+            CModuleLinkedMesh st = __instance;
+
+            if (st.targetAnchor.IsNotNullOrDestroyed())
+            {
+                if (!st.tweakingTarget && !st.part.PartTweakerSelected)
+                {
+                    if (setTgtAnchor && st.compoundPart.IsNotNullOrDestroyed() && st.compoundPart.transform.IsNotNullOrDestroyed())
+                    {
+                        st.targetAnchor.position = st.compoundPart.transform.TransformPoint(rPos);
+                        st.targetAnchor.rotation = st.compoundPart.transform.rotation * rRot;
+                    }
+                }
+                else
+                {
+                    st.compoundPart.targetPosition = st.transform.InverseTransformPoint(st.targetAnchor.position);
+                    st.compoundPart.targetRotation = st.targetAnchor.localRotation;
+                    st.compoundPart.UpdateWorldValues();
+                }
+            }
+
+            bool lineRotationComputed = false;
+            Quaternion lineRotation = default;
+            if (st.endCap.IsNotNullOrDestroyed())
+            {
+                Vector3 vector = st.line.position - st.endCap.position;
+                float magnitude = vector.magnitude;
+                if (magnitude != 0f)
+                {
+                    if (magnitude < st.lineMinimumLength)
+                    {
+                        st.line.gameObject.SetActive(false);
+                    }
+                    else
+                    {
+                        st.line.gameObject.SetActive(true);
+                        lineRotation = Quaternion.LookRotation(vector / magnitude, st.transform.forward);
+                        lineRotationComputed = true;
+                        st.line.rotation = lineRotation;
+                        Vector3 localScale = st.line.localScale;
+                        st.line.localScale = new Vector3(localScale.x, localScale.y, magnitude * st.part.scaleFactor);
+                        st.endCap.rotation = lineRotation;
+                    }
+                }
+            }
+            else if (st.transform.IsNotNullOrDestroyed() && st.targetAnchor.IsNotNullOrDestroyed())
+            {
+                Vector3 vector = st.transform.position - st.targetAnchor.position;
+                float magnitude = vector.magnitude;
+                if (magnitude != 0f)
+                {
+                    if (magnitude < st.lineMinimumLength)
+                    {
+                        st.line.gameObject.SetActive(false);
+                    }
+                    else
+                    {
+                        st.line.gameObject.SetActive(true);
+                        if (float.IsNaN(magnitude) || float.IsInfinity(magnitude))
+                        {
+                            Debug.LogError(string.Concat("[CModuleLinkedMesh]: Object ", st.name, ": Look vector magnitude invalid. Vector is (", vector.x, ", ", vector.y, ", ", vector.z, "). Transform ", st.transform.position.IsInvalid() ? "invalid" : "valid", " ", st.transform.position, ", target ", st.targetAnchor.position.IsInvalid() ? "invalid" : "valid", ", ", st.targetAnchor.position));
+                            return false;
+                        }
+                        lineRotation = Quaternion.LookRotation(vector / magnitude, st.transform.forward);
+                        lineRotationComputed = true;
+                        st.line.rotation = lineRotation;
+                        Vector3 localScale = st.line.localScale;
+                        st.line.localScale = new Vector3(localScale.x, localScale.y, magnitude * st.part.scaleFactor);
+                    }
+                }
+            }
+            if (st.startCap.IsNotNullOrDestroyed())
+            {
+                if (!lineRotationComputed)
+                    st.startCap.rotation = st.line.rotation;
+                else
+                    st.startCap.rotation = lineRotation;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Very unlikely to be necessary, but in theory nodeType could differ from the string stored in the nodeTypes hashset
+        /// </summary>
+        private static void ModuleDockingNode_OnLoad_Postfix(ModuleDockingNode __instance)
+        {
+            if (__instance.nodeTypes.Count == 1)
+                __instance.nodeType = __instance.nodeTypes.First();
+        }
+
+        /// <summary>
+        /// This is called n² times where n is the amount of loaded docking port modules in the scene.
+        /// We optimize the method, mainly by avoiding going through the hashset of modules types if there is only one type defined
+        /// which is seemingly always the case (I didn't found any stock or modded part having multiple ones).
+        /// Test case with 20 docking ports : 1.6% of the frame time in stock, 0.8% with the patch
+        /// </summary>
+        private static bool ModuleDockingNode_FindNodeApproaches_Prefix(ModuleDockingNode __instance, out ModuleDockingNode __result)
+        {
+            __result = null;
+            if (__instance.part.packed)
+                return false;
+
+            for (int i = FlightGlobals.VesselsLoaded.Count; i-- > 0;)
+            {
+                Vessel vessel = FlightGlobals.VesselsLoaded[i];
+
+                if (vessel.packed)
+                    continue;
+
+                for (int j = vessel.dockingPorts.Count; j-- > 0;)
+                {
+                    if (!(vessel.dockingPorts[j] is ModuleDockingNode other))
+                        continue;
+
+                    if (other.part.IsNullOrDestroyed()
+                        || other.part.RefEquals(__instance.part)
+                        || other.part.State == PartStates.DEAD
+                        || other.state != __instance.st_ready.name
+                        || other.gendered != __instance.gendered
+                        || (__instance.gendered && other.genderFemale == __instance.genderFemale)
+                        || other.snapRotation != __instance.snapRotation
+                        || (__instance.snapRotation && other.snapOffset != __instance.snapOffset))
+                    {
+                        continue;
+                    }
+
+                    bool checkRequired = false;
+                    // fast path when only one node type
+                    if (__instance.nodeTypes.Count == 1)
+                    {
+                        if (other.nodeTypes.Count == 1)
+                            checkRequired = __instance.nodeType == other.nodeType;
+                        else
+                            checkRequired = other.nodeTypes.Contains(__instance.nodeType);
+                    }
+                    // slow path checking the hashSet
+                    else
+                    {
+                        foreach (string nodeType in __instance.nodeTypes)
+                        {
+                            if (other.nodeTypes.Count == 1)
+                                checkRequired = nodeType == other.nodeType;
+                            else
+                                checkRequired = other.nodeTypes.Contains(nodeType);
+
+                            if (checkRequired)
+                                break;
+                        }
+                    }
+
+                    if (checkRequired && __instance.CheckDockContact(__instance, other, __instance.acquireRange, __instance.acquireMinFwdDot, __instance.acquireMinRollDot))
+                    {
+                        __result = other;
+                        return false;
+                    }
+
+                }
+            }
+
+            return false;
+        }
+
+        private class FIIntegrationData
+        {
+            public Vector3 vesselPreIntegrationAccelF;
+            public bool hasVesselPreIntegrationAccel;
+            public Vector3 krakensbaneFrameVelocityF;
+
+            public double dragMult;
+            public double dragTail;
+            public double dragTip;
+            public double dragSurf;
+            public double dragCdPower;
+
+            public double liftMach;
+
+            public void Populate(FlightIntegrator fi)
+            {
+                vesselPreIntegrationAccelF = fi.vessel.precalc.integrationAccel;
+                hasVesselPreIntegrationAccel = !vesselPreIntegrationAccelF.IsZero();
+                krakensbaneFrameVelocityF = Krakensbane.GetFrameVelocity();
+
+                float mach = (float)fi.mach;
+
+                dragMult = PhysicsGlobals.Instance.dragCurveMultiplier.Evaluate(mach);
+                dragTail = PhysicsGlobals.Instance.dragCurveTail.Evaluate(mach);
+                dragTip = PhysicsGlobals.Instance.dragCurveTip.Evaluate(mach);
+                dragSurf = PhysicsGlobals.Instance.dragCurveSurface.Evaluate(mach);
+                dragCdPower = PhysicsGlobals.Instance.dragCurveCdPower.Evaluate(mach);
+
+                liftMach = PhysicsGlobals.BodyLiftCurve.liftMachCurve.Evaluate(mach); // maybe should be done on demand, as this doesn't apply in all cases...
+            }
+        }
+
+        private static FastStack<Part> partStack = new FastStack<Part>();
+        private static FIIntegrationData fiData = new FIIntegrationData();
+
+        private static bool FlightIntegrator_Integrate_Prefix(FlightIntegrator __instance)
+        {
+            fiData.Populate(__instance);
+
+            // preorder traversal of the part tree
+            partStack.EnsureCapacity(__instance.vessel.parts.Count);
+            partStack.Push(__instance.partRef);
+            while (partStack.TryPop(out Part part))
+            {
+                IntegratePart(__instance, fiData, part);
+
+                for (int i = part.children.Count; i-- > 0;)
+                {
+                    Part childPart = part.children[i];
+                    if (childPart.isAttached)
+                        partStack.Push(childPart);
+                }
+            }
+
+            return false;
+        }
+
+        private static void IntegratePart(FlightIntegrator fi, FIIntegrationData fiData, Part part)
+        {
+            bool hasRb = part.rb.IsNotNullOrDestroyed();
+            bool hasServoRb = part.servoRb.IsNotNullOrDestroyed();
+
+            // base force integration
+            if (hasRb)
+            {
+                if (fiData.hasVesselPreIntegrationAccel)
+                    part.rb.AddForce(fiData.vesselPreIntegrationAccelF, ForceMode.Acceleration);
+
+                if (!part.force.IsZero())
+                    part.rb.AddForce(part.force);
+
+                if (!part.torque.IsZero())
+                    part.rb.AddTorque(part.torque);
+
+                for (int i = part.forces.Count; i-- > 0;)
+                {
+                    Part.ForceHolder force = part.forces[i];
+                    part.rb.AddForceAtPosition(force.force, force.pos);
+                }
+            }
+
+            if (hasServoRb)
+            {
+                part.servoRb.AddForce(fiData.vesselPreIntegrationAccelF, ForceMode.Acceleration);
+            }
+            part.forces.Clear();
+            part.force.Zero();
+            part.torque.Zero();
+
+            // UpdateAerodynamics(part);
+            Rigidbody partOrParentRb = part.rb;
+            if (!hasRb)
+            {
+                Part parent = part.parent;
+                while (partOrParentRb.IsNullOrDestroyed() && parent.IsNotNullOrDestroyed())
+                {
+                    partOrParentRb = parent.rb;
+                    parent = parent.parent;
+                }
+            }
+
+            if (partOrParentRb.IsNotNullOrDestroyed())
+            {
+                part.aerodynamicArea = 0.0;
+                part.exposedArea = fi.CalculateAreaExposed(part);
+                part.submergedDynamicPressurekPa = 0.0;
+                part.dynamicPressurekPa = 0.0;
+
+                if (part.angularDragByFI)
+                {
+                    if (hasRb)
+                        part.rb.angularDrag = 0f;
+
+                    if (hasServoRb)
+                        part.servoRb.angularDrag = 0f;
+                }
+
+                part.dragVector = partOrParentRb.velocity + fiData.krakensbaneFrameVelocityF;
+                part.dragVectorSqrMag = part.dragVector.sqrMagnitude;
+
+                bool hasVelocity = false;
+                if (part.dragVectorSqrMag != 0f)
+                {
+                    hasVelocity = true;
+                    part.dragVectorMag = Mathf.Sqrt(part.dragVectorSqrMag);
+                    part.dragVectorDir = part.dragVector / part.dragVectorMag;
+                    part.dragVectorDirLocal = -part.partTransform.InverseTransformDirection(part.dragVectorDir);
+                    part.dragScalar = 0f;
+                }
+                else
+                {
+                    part.dragVectorMag = 0f;
+                    part.dragVectorDir.Zero();
+                    part.dragVectorDirLocal.Zero();
+                    part.dragScalar = 0f;
+                }
+
+                double submergedPortion = part.submergedPortion;
+
+                if (!part.ShieldedFromAirstream && (part.atmDensity > 0.0 || submergedPortion > 0.0))
+                {
+                    if (!part.dragCubes.none)
+                    {
+                        SetDragCubeDrag(fiData, part.dragCubes, part.dragVectorDirLocal);
+                    }
+
+                    part.aerodynamicArea = fi.CalculateAerodynamicArea(part);
+                    if (fi.cacheApplyDrag && hasVelocity && (partOrParentRb.RefEquals(part.rb) || fi.cacheApplyDragToNonPhysicsParts))
+                    {
+                        double emergedPortion = 1.0;
+                        bool isInWater = false;
+                        double pressure;
+                        if (fi.currentMainBody.ocean)
+                        {
+                            if (submergedPortion > 0.0)
+                            {
+                                isInWater = true;
+                                double waterDensity = fi.currentMainBody.oceanDensity * 1000.0;
+                                if (submergedPortion >= 1.0)
+                                {
+                                    emergedPortion = 0.0;
+                                    part.submergedDynamicPressurekPa = waterDensity;
+                                    pressure = waterDensity * fi.cacheBuoyancyWaterAngularDragScalar * part.waterAngularDragMultiplier;
+                                }
+                                else
+                                {
+                                    emergedPortion = 1.0 - submergedPortion;
+                                    part.submergedDynamicPressurekPa = waterDensity;
+                                    pressure = part.staticPressureAtm * emergedPortion + submergedPortion * waterDensity * fi.cacheBuoyancyWaterAngularDragScalar * part.waterAngularDragMultiplier;
+                                }
+                            }
+                            else
+                            {
+                                part.dynamicPressurekPa = part.atmDensity;
+                                pressure = part.staticPressureAtm;
+                            }
+                        }
+                        else
+                        {
+                            part.dynamicPressurekPa = part.atmDensity;
+                            pressure = part.staticPressureAtm;
+                        }
+
+                        double dragSqrMag = 0.0005 * part.dragVectorSqrMag;
+                        part.dynamicPressurekPa *= dragSqrMag;
+                        part.submergedDynamicPressurekPa *= dragSqrMag;
+                        if (hasRb && part.angularDragByFI)
+                        {
+                            if (isInWater)
+                            {
+                                pressure += part.dynamicPressurekPa * FlightIntegrator.KPA2ATM * emergedPortion;
+                                pressure += part.submergedDynamicPressurekPa * FlightIntegrator.KPA2ATM * fi.cacheBuoyancyWaterAngularDragScalar * part.waterAngularDragMultiplier * submergedPortion;
+                            }
+                            else
+                            {
+                                pressure = part.dynamicPressurekPa * FlightIntegrator.KPA2ATM;
+                            }
+
+                            if (pressure < 0.0)
+                                pressure = 0.0;
+
+                            float rbAngularDrag = part.angularDrag * (float)pressure * fi.cacheAngularDragMultiplier;
+                            part.rb.angularDrag = rbAngularDrag;
+                            if (hasServoRb)
+                                part.servoRb.angularDrag = rbAngularDrag;
+                        }
+
+                        double dragValue = fi.CalculateDragValue(part) * fi.pseudoReDragMult;
+                        if (!double.IsNaN(dragValue) && dragValue != 0.0)
+                        {
+                            part.dragScalar = (float)(part.dynamicPressurekPa * dragValue * emergedPortion) * fi.cacheDragMultiplier;
+                            fi.ApplyAeroDrag(part, partOrParentRb, fi.cacheDragUsesAcceleration ? ForceMode.Acceleration : ForceMode.Force);
+                        }
+                        else
+                        {
+                            part.dragScalar = 0f;
+                        }
+
+                        if (!part.hasLiftModule && (!part.bodyLiftOnlyUnattachedLiftActual || part.bodyLiftOnlyProvider == null || !part.bodyLiftOnlyProvider.IsLifting))
+                        {
+                            double bodyLiftScalar = part.bodyLiftMultiplier * fi.cacheBodyLiftMultiplier * fiData.liftMach;
+                            if (isInWater)
+                                bodyLiftScalar *= part.dynamicPressurekPa * emergedPortion + part.submergedDynamicPressurekPa * part.submergedLiftScalar * submergedPortion;
+                            else
+                                bodyLiftScalar *= part.dynamicPressurekPa;
+
+                            part.bodyLiftScalar = (float)bodyLiftScalar;
+                            if (part.bodyLiftScalar != 0f && part.DragCubes.LiftForce != Vector3.zero && !part.DragCubes.LiftForce.IsInvalid())
+                            {
+                                fi.ApplyAeroLift(part, partOrParentRb, fi.cacheDragUsesAcceleration ? ForceMode.Acceleration : ForceMode.Force);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Replacement for DragCubes.SetDrag() and DragCubes.DragCubeAddSurfaceDragDirection()
+        /// </summary>
+        private static void SetDragCubeDrag(FIIntegrationData fiData, DragCubeList dragCubes, Vector3 direction)
+        {
+            direction *= -1f;
+
+            if (dragCubes.rotateDragVector)
+                direction = dragCubes.dragVectorRotation * direction;
+                
+            double dotSum = 0.0;
+            double area = 0.0;
+            double areaDrag = 0.0;
+            double crossSectionalArea = 0.0;
+            double exposedArea = 0.0;
+            double liftForceX = 0.0;
+            double liftForceY = 0.0;
+            double liftForceZ = 0.0;
+            double depth = 0.0;
+            double taperDot = 0.0;
+            double dragCoeff = 0.0;
+
+            for (int i = 0; i < 6; i++)
+            {
+                Vector3 faceDir = faceDirections[i];
+                double areaOccluded = dragCubes.areaOccluded[i];
+                double weightedDrag = dragCubes.weightedDrag[i];
+
+                double dot = Vector3.Dot(direction, faceDir);
+                double dotNormalized = (dot + 1.0) * 0.5;
+                double drag; // = PhysicsGlobals.DragCurveValue(__instance.SurfaceCurves, dotNormalized, machNumber);
+
+                if (dotNormalized <= 0.5)
+                    drag = Numerics.Lerp(fiData.dragTail, fiData.dragSurf, dotNormalized * 2.0) * fiData.dragMult;
+                else
+                    drag = Numerics.Lerp(fiData.dragSurf, fiData.dragTip, (dotNormalized - 0.5) * 2.0) * fiData.dragMult;
+
+                double areaOccludedByDrag = areaOccluded * drag;
+                area += areaOccludedByDrag;
+                double dragCd = areaOccludedByDrag;
+
+                if (dragCd < 1.0)
+                    dragCd = Math.Pow(dragCubes.DragCurveCd.Evaluate((float)weightedDrag), fiData.dragCdPower);
+
+                areaDrag += areaOccludedByDrag * dragCd;
+                crossSectionalArea += areaOccluded * Numerics.Clamp01(dot);
+
+                double weightedDragMod = (!(weightedDrag < 1.0) || !(weightedDrag > 0.01)) ? 1.0 : (1.0 / weightedDrag);
+                exposedArea += areaOccludedByDrag / fiData.dragMult * weightedDragMod;
+
+                if (dot > 0.0)
+                {
+                    dotSum += dot;
+                    double bodyLift = dragCubes.BodyLiftCurve.liftCurve.Evaluate((float)dot);
+                    double weightedBodylift = dot * areaOccluded * weightedDrag * bodyLift * -1.0;
+
+                    if (!double.IsNaN(weightedBodylift) && weightedBodylift > 0.0)
+                    {
+                        liftForceX += faceDir.x * weightedBodylift;
+                        liftForceY += faceDir.y * weightedBodylift;
+                        liftForceZ += faceDir.z * weightedBodylift;
+                    }
+
+                    depth += dot * dragCubes.weightedDepth[i];
+                    taperDot += dot * weightedDragMod;
+                }
+            }
+
+            if (dotSum > 0.0)
+            {
+                double invDotSum = 1f / dotSum;
+                depth *= invDotSum;
+                taperDot *= invDotSum;
+            }
+
+            if (area > 0.0)
+            {
+                dragCoeff = areaDrag / area;
+                areaDrag = area * dragCoeff;
+            }
+            else
+            {
+                dragCoeff = 0.0;
+                areaDrag = 0.0;
+            }
+
+            dragCubes.cubeData = new CubeData()
+            {
+                dragVector = direction,
+                liftForce = new Vector3((float)liftForceX, (float)liftForceY, (float)liftForceZ),
+                area = (float)area,
+                areaDrag = (float)areaDrag,
+                depth = (float)depth,
+                crossSectionalArea = (float)crossSectionalArea,
+                exposedArea = (float)exposedArea,
+                dragCoeff = (float)dragCoeff,
+                taperDot = (float)taperDot
+            };
+        }
+
+        private static bool Part_isKerbalEVA_Prefix(Part __instance, out bool __result)
+        {
+            if (__instance.modules == null)
+            {
+                __result = false;
+                return false;
+            }
+
+            __instance.cachedModules ??= new Dictionary<Type, PartModule>();
+
+            if (!__instance.cachedModules.TryGetValue(typeof(KerbalEVA), out PartModule module))
+            {
+                List<PartModule> modules = __instance.modules.modules;
+                for (int i = modules.Count; i-- > 0;)
+                {
+                    if (modules[i] is KerbalEVA)
+                    {
+                        module = modules[i];
+                        break;
+                    }
+                }
+                __instance.cachedModules[typeof(KerbalEVA)] = module;
+            }
+
+            __result = module.IsNotNullRef();
+            return false;
         }
 
         #region VesselPrecalculate.CalculatePhysicsStats optimizations
@@ -67,8 +1216,7 @@ namespace KSPCommunityFixes.Performance
             {
                 int partCount = vessel.Parts.Count;
                 Transform vesselTransform = vessel.ReferenceTransform;
-                Matrix4x4 vesselInverseMatrixF = vesselTransform.worldToLocalMatrix;
-                Matrix4x4D vesselInverseMatrix = vesselInverseMatrixF.ToMatrix4x4D();
+                TransformMatrix vesselInverseMatrix = TransformMatrix.WorldToLocal(vesselTransform);
                 QuaternionD vesselInverseRotation = QuaternionD.Inverse(vesselTransform.rotation);
                 Vector3d com = Vector3d.zero;
                 Vector3d velocity = Vector3d.zero;
@@ -424,7 +1572,8 @@ namespace KSPCommunityFixes.Performance
         static bool FlightIntegrator_UpdateMassStats_Prefix(FlightIntegrator __instance)
         {
             List<Part> parts = __instance.vessel.parts;
-            for (int i = __instance.partCount; i-- > 0;)
+            int partCount = parts.Count;
+            for (int i = partCount; i-- > 0;)
             {
                 Part part = parts[i];
 
@@ -447,12 +1596,12 @@ namespace KSPCommunityFixes.Performance
                 part.thermalMassReciprocal = 1.0 / part.thermalMass;
             }
 
-            for (int i = __instance.partCount; i-- > 0;)
+            for (int i = partCount; i-- > 0;)
             {
                 Part part = parts[i];
                 if (part.rb.IsNotNullOrDestroyed())
                 {
-                    float physicsMass = part.mass + part.resourceMass + __instance.GetPhysicslessChildMass(part); // further optimization : don't use recursion, avoid the null check
+                    float physicsMass = part.mass + part.resourceMass + GetPhysicslessChildsMass(part);
                     physicsMass = Mathf.Clamp(physicsMass, part.partInfo.MinimumMass, Mathf.Abs(physicsMass));
                     part.physicsMass = physicsMass;
 
@@ -488,9 +1637,191 @@ namespace KSPCommunityFixes.Performance
             return false;
         }
 
+
+        // Recursion is faster than a stack based approach here
+        private static float GetPhysicslessChildsMass(Part part)
+        {
+            float mass = 0f;
+            for (int i = part.children.Count; i-- > 0;)
+            {
+                if (part.children[i].rb.IsNullOrDestroyed())
+                {
+                    Part childPart = part.children[i];
+                    mass += childPart.mass + childPart.resourceMass + GetPhysicslessChildsMass(childPart);
+                }
+            }
+            return mass;
+        }
+
+
         #endregion
 
         #region FlightIntegrator.UpdateOcclusion optimizations
+
+        static bool FlightIntegrator_UpdateOcclusionConvection_Prefix(FlightIntegrator __instance)
+        {
+            FlightIntegrator fi = __instance;
+
+            if (fi.mach <= 1.0)
+            {
+                if (fi.wasMachConvectionEnabled)
+                {
+                    for (int i = 0; i < fi.partThermalDataCount; i++)
+                    {
+                        PartThermalData partThermalData = fi.partThermalDataList[i];
+                        partThermalData.convectionCoeffMultiplier = 1.0;
+                        partThermalData.convectionAreaMultiplier = 1.0;
+                        partThermalData.convectionTempMultiplier = 1.0;
+                    }
+                    fi.wasMachConvectionEnabled = false;
+                }
+                return false;
+            }
+
+            bool requiresSort = false;
+            if (fi.partThermalDataCount != fi.partThermalDataList.Count)
+            {
+                fi.recreateThermalGraph = true;
+                fi.CheckThermalGraph();
+            }
+
+            List<OcclusionData> occlusionDataList = fi.occlusionConv;
+            OcclusionCone[] occluders = fi.occludersConvection;
+            Vector3d velocity = fi.nVel;
+
+            int lastPartIndex = fi.partThermalDataCount - 1;
+            int partIndex = fi.partThermalDataCount;
+            QuaternionDPointRotation velToUp = new QuaternionDPointRotation(Numerics.FromToRotation(velocity, Vector3d.up));
+            while (partIndex-- > 0)
+            {
+                OcclusionData occlusionDataToUpdate = occlusionDataList[partIndex];
+                UpdateOcclusionData(occlusionDataToUpdate, velocity, velToUp);
+                if (!requiresSort && partIndex < lastPartIndex && occlusionDataList[partIndex + 1].maximumDot < occlusionDataToUpdate.maximumDot)
+                    requiresSort = true;
+            }
+
+            if (requiresSort)
+                occlusionDataList.Sort();
+
+            double sqrtMach = Math.Sqrt(fi.mach);
+            double sqrtMachAng = Math.Asin(1.0 / sqrtMach);
+            double detachAngle = 0.7957 * (1.0 - 1.0 / (fi.mach * sqrtMach));
+
+            OcclusionData occlusionData = fi.occlusionConv[lastPartIndex];
+            PartThermalData ptd = occlusionData.ptd;
+
+            ptd.convectionCoeffMultiplier = 1.0;
+            ptd.convectionAreaMultiplier = 1.0;
+            ptd.convectionTempMultiplier = 1.0;
+
+            occlusionData.convCone.Setup(occlusionData, sqrtMach, sqrtMachAng, detachAngle);
+            fi.occludersConvection[0] = occlusionData.convCone;
+            fi.occludersConvectionCount = 1;
+            //FXCamera.Instance.ApplyObliqueness((float)occlusionData.convCone.shockAngle); // empty method
+
+            int index = lastPartIndex;
+            while (index-- > 0)
+            {
+                occlusionData = fi.occlusionConv[index];
+                ptd = occlusionData.ptd;
+                ptd.convectionCoeffMultiplier = 1.0;
+                ptd.convectionAreaMultiplier = 1.0;
+                ptd.convectionTempMultiplier = 1.0;
+
+                double minExtentsX = occlusionData.minExtents.x;
+                double minExtentsY = occlusionData.minExtents.y;
+                double maxExtentsX = occlusionData.maxExtents.x;
+                double maxExtentsY = occlusionData.maxExtents.y;
+
+                double projectedCenterX = occlusionData.projectedCenter.x;
+                double projectedCenterY = occlusionData.projectedCenter.y;
+                double projectedCenterZ = occlusionData.projectedCenter.z;
+
+                for (int i = 0; i < fi.occludersConvectionCount; i++)
+                {
+                    OcclusionCone occluder = occluders[i];
+                    double offsetX = occluder.offset.x;
+                    double offsetY = occluder.offset.y;
+                    double minX = offsetX + minExtentsX;
+                    double minY = offsetY + minExtentsY;
+                    double maxX = offsetX + maxExtentsX;
+                    double maxY = offsetY + maxExtentsY;
+                    double centralExtentX = occluder.extents.x;
+                    double centralExtentY = occluder.extents.y;
+                    double centralExtentXInv = -centralExtentX;
+                    double centralExtentYInv = -centralExtentY;
+
+                    double mid = (maxX - minX) * (maxY - minY);
+                    double rectRect = 0.0;
+                    if (maxX >= centralExtentXInv && minX <= centralExtentX && maxY >= centralExtentYInv && minY <= centralExtentY && mid != 0.0)
+                    {
+                        double midX = Math.Min(centralExtentX, maxX) - Math.Max(centralExtentXInv, minX);
+                        if (midX < 0.0) midX = 0.0;
+
+                        double midY = Math.Min(centralExtentY, maxY) - Math.Max(centralExtentYInv, minY);
+                        if (midY < 0.0) midY = 0.0;
+
+                        rectRect = midX * midY / mid;
+                        if (double.IsNaN(rectRect)) // it could be nice to put that outside the inner loop
+                        {
+                            rectRect = 0.0;
+                            if (GameSettings.FI_LOG_TEMP_ERROR)
+                                Debug.LogError($"[FlightIntegrator]: For part " + occlusionData.ptd.part.name + ", rectRect is NaN");
+                        }
+                    }
+
+                    double areaOfIntersection = 1.0;
+                    if (rectRect < 0.99)
+                    {
+                        double angleDiff = occluder.shockNoseDot - occlusionData.centroidDot;
+                        double existingConeRadius = occluder.radius + angleDiff * FastApproximateTan(occluder.shockAngle);
+
+                        double x = projectedCenterX - occluder.center.x;
+                        double y = projectedCenterY - occluder.center.y;
+                        double z = projectedCenterZ - occluder.center.z;
+                        double sqrDistance = x * x + y * y + z * z;
+
+                        areaOfIntersection = OcclusionData.AreaOfIntersection(existingConeRadius, occlusionData.projectedRadius, sqrDistance);
+                    }
+                    else
+                    {
+                        rectRect = 1.0;
+                    }
+
+                    double num4 = 1.0 - areaOfIntersection;
+                    double num5 = areaOfIntersection - rectRect;
+                    ptd.convectionTempMultiplier = num4 * ptd.convectionTempMultiplier + num5 * occluder.shockConvectionTempMult + rectRect * occluder.occludeConvectionTempMult;
+                    ptd.convectionCoeffMultiplier = num4 * ptd.convectionCoeffMultiplier + num5 * occluder.shockConvectionCoeffMult + rectRect * occluder.occludeConvectionCoeffMult;
+
+                    double shockStats = 1.0 - rectRect + rectRect * occluder.occludeConvectionAreaMult;
+
+                    ptd.convectionAreaMultiplier *= shockStats;
+                    if (ptd.convectionAreaMultiplier < 0.001)
+                    {
+                        ptd.convectionAreaMultiplier = 0.0;
+                        break;
+                    }
+                }
+                if (ptd.convectionAreaMultiplier > 0.0)
+                {
+                    occlusionData.convCone.Setup(occlusionData, sqrtMach, sqrtMachAng, detachAngle);
+                    fi.occludersConvection[fi.occludersConvectionCount] = occlusionData.convCone;
+                    fi.occludersConvectionCount++;
+                }
+            }
+
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double FastApproximateTan(double angle)
+        {
+            const double pisqby4 = 2.4674011002723397;
+            const double adjpisqby4 = 2.471688400562703;
+            const double adj1minus8bypisq = 0.189759681063053;
+            double angleSqr = angle * angle;
+            return angle * (adjpisqby4 - adj1minus8bypisq * angleSqr) / (pisqby4 - angleSqr);
+        }
 
         static bool FlightIntegrator_UpdateOcclusionSolar_Prefix(FlightIntegrator __instance)
         {
@@ -713,7 +2044,7 @@ namespace KSPCommunityFixes.Performance
             double maxY = cY + eY;
             double maxZ = cZ + eZ;
 
-            Matrix4x4D localToWorldMatrix = (Matrix4x4D)part.partTransform.localToWorldMatrix; // 10% of the load.
+            TransformMatrix localToWorldMatrix = TransformMatrix.LocalToWorld(part.partTransform);
 
             // 10% of the load is here, probably worth it to extract the matrix components and to manually inline (the MultiplyPoint3x4 method is **not** inlined)
             Vector3d boundVert1 = localToWorldMatrix.MultiplyPoint3x4(minX, minY, minZ);
@@ -764,7 +2095,7 @@ namespace KSPCommunityFixes.Performance
             velToUp.RotatePointGetXZ(boundVert8, out vertX, out vertZ);
             FindExtentsMinMax(vertX, vertZ, ref minExtentX, ref minExtentY, ref maxExtentX, ref maxExtentY);
 
-            Vector3d worldBoundsCenter = Numerics.MultiplyPoint3x4(ref localToWorldMatrix, cX, cY, cZ);
+            Vector3d worldBoundsCenter = localToWorldMatrix.MultiplyPoint3x4(cX, cY, cZ);
             occlusionData.centroidDot = Vector3d.Dot(worldBoundsCenter, velocity);
             occlusionData.projectedCenter = worldBoundsCenter - occlusionData.centroidDot * velocity;
             occlusionData.boundsCenter = new Vector3((float)cX, (float)cY, (float)cZ);

--- a/KSPCommunityFixes/Performance/FlightPerf.cs
+++ b/KSPCommunityFixes/Performance/FlightPerf.cs
@@ -1,0 +1,843 @@
+﻿// Enable cross checking our implementations results with the stock implementations results
+// Warning : very log-spammy and performance destroying, don't leave this enabled if you don't need to.
+// #define DEBUG_FLIGHTINTEGRATOR
+
+using HarmonyLib;
+using KSPCommunityFixes.Library;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using UnityEngine;
+using Debug = UnityEngine.Debug;
+
+namespace KSPCommunityFixes.Performance
+{
+    internal class FlightPerf : BasePatch
+    {
+        protected override void ApplyPatches(List<PatchInfo> patches)
+        {
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(FlightIntegrator), nameof(FlightIntegrator.UpdateOcclusionSolar)),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(FlightIntegrator), nameof(FlightIntegrator.UpdateOcclusionBody)),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(FlightIntegrator), nameof(FlightIntegrator.UpdateMassStats)),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(VesselPrecalculate), nameof(VesselPrecalculate.CalculatePhysicsStats)),
+                this));
+
+            // other offenders, in aero situations :
+
+            // AddSurfaceDragDirection : 7%
+            // - could turn the curves (1.6%) into lookup tables
+            // - general float to double pass, not sure how practical due to working a lot with float-backed drag cubes, relevant at least for the Mathf.Pow() call
+            // - multiple InverseTransform calls, use the matrix instead
+
+            // general optimization pass on UpdateOcclusionConvection() : 4.4%
+
+            // In general, Integrate() should benefit from being made a non recursive loop, and that might open a few optimizations
+            // by moving some expensive matrix / quaternion stuff outside that loop.
+
+            // In a similar vein, there are a few thing to be done about FloatingOrigin and more specifically Vessel.SetPosition (at least, pre-computing the quaternion rotation)
+        }
+
+        #region VesselPrecalculate.CalculatePhysicsStats optimizations
+
+        /// <summary>
+        /// 40-60% faster than the stock method depending on the situation.
+        /// Hard to optimize further, a large chunk of the time is spent getting transform / rb properties (~40%)
+        /// and performing unavoidable double/float conversions (~10%).
+        /// </summary>
+        private static bool VesselPrecalculate_CalculatePhysicsStats_Prefix(VesselPrecalculate __instance)
+        {
+            Vessel vessel = __instance.vessel;
+            bool isMasslessOrNotLoaded = true;
+
+            if (vessel.loaded)
+            {
+                int partCount = vessel.Parts.Count;
+                Transform vesselTransform = vessel.ReferenceTransform;
+                Matrix4x4 vesselInverseMatrixF = vesselTransform.worldToLocalMatrix;
+                Matrix4x4D vesselInverseMatrix = vesselInverseMatrixF.ToMatrix4x4D();
+                QuaternionD vesselInverseRotation = QuaternionD.Inverse(vesselTransform.rotation);
+                Vector3d com = Vector3d.zero;
+                Vector3d velocity = Vector3d.zero;
+                Vector3d angularVelocity = Vector3d.zero;
+                double vesselMass = 0.0;
+
+                if (vessel.packed && partCount > 0)
+                    Physics.SyncTransforms();
+
+                VesselPrePartBufferEnsureCapacity(partCount);
+                int index = partCount;
+                int rbPartCount = 0;
+                while (index-- > 0)
+                {
+                    Part part = vessel.parts[index];
+                    if (part.rb.IsNotNullOrDestroyed())
+                    {
+                        Vector3d partPosition = part.partTransform.position;
+                        QuaternionD partRotation = part.partTransform.rotation;
+                        vesselPrePartBuffer[rbPartCount] = new PartVesselPreData(partPosition, partRotation, index);
+                        rbPartCount++;
+#if DEBUG_FLIGHTINTEGRATOR
+                        double deviation = ((partPosition + partRotation * part.CoMOffset) - part.rb.worldCenterOfMass).magnitude;
+                        if (deviation > 0.001)
+                            Debug.LogWarning($"[KSPCF:FIPerf] KSPCF calculated WorldCenterOfMass is deviating from stock by {deviation:F3}m for part {part.partInfo.title} on vessel {vessel.GetDisplayName()}");
+#endif
+                        double physicsMass = part.physicsMass;
+                        // note : on flight scene load, the parts RBs center of mass won't be set until the vessel gets out of the packed
+                        // state (see FI.UpdateMassStats()), it will initially be set to whatever PhysX has computed from the RB colliders.
+                        // This result in an inconsistent vessel CoM (and all derived stats) being computed for several frames. 
+                        // For performance reasons we don't use rb.worldCenterOfMass, but instead re-compute it from Part.CoMOffset, but
+                        // this also has the side effect of fixing those inconsistencies.
+                        com.Add((partPosition + partRotation * part.CoMOffset) * physicsMass);
+                        velocity.Add((Vector3d)part.rb.velocity * physicsMass);
+                        angularVelocity.Add(vesselInverseRotation * part.rb.angularVelocity * physicsMass);
+                        vesselMass += physicsMass;
+                    }
+                }
+
+                if (vesselMass > 0.0)
+                {
+                    isMasslessOrNotLoaded = false;
+                    vessel.totalMass = vesselMass;
+                    double vesselMassRecip = 1.0 / vesselMass;
+                    vessel.CoMD = com * vesselMassRecip;
+                    vessel.rb_velocityD = velocity * vesselMassRecip;
+                    vessel.velocityD = vessel.rb_velocityD + Krakensbane.GetFrameVelocity();
+                    vessel.CoM = vessel.CoMD;
+                    vessel.localCoM = vessel.vesselTransform.InverseTransformPoint(vessel.CoM);
+                    vessel.rb_velocity = vessel.rb_velocityD;
+                    vessel.angularVelocityD = angularVelocity * vesselMassRecip;
+                    vessel.angularVelocity = vessel.angularVelocityD;
+
+                    if (vessel.angularVelocityD == Vector3d.zero && vessel.packed)
+                    {
+                        vessel.MOI.Zero();
+                        vessel.angularMomentum.Zero();
+                    }
+                    else
+                    {
+                        InertiaTensor inertiaTensor = new InertiaTensor();
+                        for (int i = 0; i < rbPartCount; i++)
+                        {
+                            PartVesselPreData partPreData = vesselPrePartBuffer[i];
+                            Part part = vessel.parts[partPreData.partIndex];
+
+                            // add part inertia tensor to vessel inertia tensor
+                            Vector3d principalMoments = part.rb.inertiaTensor;
+                            QuaternionD princAxesRot = vesselInverseRotation * partPreData.rotation * (QuaternionD)part.rb.inertiaTensorRotation;
+                            inertiaTensor.AddPartInertiaTensor(principalMoments, princAxesRot);
+
+                            // add part mass and position contribution to vessel inertia tensor
+                            double rbMass = Math.Max(part.partInfo.minimumRBMass, part.physicsMass);
+                            // Note : the stock MoI code fails to account for the additional RB of servo parts.
+                            // On servo parts, the part physicsMass is redistributed equally between the part RB and the servo RB, and since when
+                            // computing the MoI, the stock code uses only the rb.mass, some mass will be unacounted for. Ideally we should do
+                            // the full additional MoI calcs with the servo RB, but as a shorthand fix we just include the whole physicsMass instead
+                            // of half of it like what stock would do. If we want to replicate exactely stock, uncomment those :
+                            // if (part.servoRb.IsNotNullRef())
+                            //     rbMass *= 0.5;
+                            // Note 2 : another side effect of using Part.physicsMass instead of rb.mass is that mass will be correct on scene
+                            // loads, before FI.UpdateMassStats() has run (when it hasn't run yet, rb.mass is set to 1 for all parts)
+                            Vector3d partPosition = vesselInverseMatrix.MultiplyVector(partPreData.position - vessel.CoMD);
+                            inertiaTensor.AddPartMass(rbMass, partPosition);
+                        }
+
+                        vessel.MOI = inertiaTensor.MoI;
+                        vessel.angularMomentum.x = (float)(inertiaTensor.m00 * vessel.angularVelocityD.x);
+                        vessel.angularMomentum.y = (float)(inertiaTensor.m11 * vessel.angularVelocityD.y);
+                        vessel.angularMomentum.z = (float)(inertiaTensor.m22 * vessel.angularVelocityD.z);
+                    }
+                }
+
+#if DEBUG_FLIGHTINTEGRATOR
+                VerifyPhysicsStats(__instance);
+#endif
+            }
+
+            if (isMasslessOrNotLoaded)
+            {
+                if (vessel.packed)
+                {
+                    if (vessel.LandedOrSplashed)
+                    {
+                        vessel.CoMD = __instance.worldSurfacePos + __instance.worldSurfaceRot * vessel.localCoM;
+                    }
+                    else
+                    {
+                        if (!vessel.orbitDriver.Ready)
+                        {
+                            vessel.orbitDriver.orbit.Init();
+                            vessel.orbitDriver.updateFromParameters(setPosition: false);
+                        }
+                        vessel.CoMD = vessel.mainBody.position + vessel.orbitDriver.pos;
+                    }
+                }
+                else
+                {
+                    vessel.CoMD = vessel.vesselTransform.TransformPoint(vessel.localCoM);
+                }
+
+                vessel.CoM = vessel.CoMD;
+
+                if (vessel.rootPart.IsNotNullOrDestroyed() && vessel.rootPart.rb.IsNotNullOrDestroyed())
+                {
+                    vessel.rb_velocity = vessel.rootPart.rb.GetPointVelocity(vessel.CoM);
+                    vessel.rb_velocityD = vessel.rb_velocity;
+                    vessel.velocityD = (Vector3d)vessel.rb_velocity + Krakensbane.GetFrameVelocity();
+                    vessel.angularVelocityD = (vessel.angularVelocity = Quaternion.Inverse(vessel.ReferenceTransform.rotation) * vessel.rootPart.rb.angularVelocity);
+                }
+                else
+                {
+                    vessel.rb_velocity.Zero();
+                    vessel.rb_velocityD.Zero();
+                    vessel.velocityD.Zero();
+                    vessel.angularVelocity.Zero();
+                    vessel.angularVelocityD.Zero();
+                }
+                vessel.MOI.Zero();
+                vessel.angularMomentum.Zero();
+            }
+            __instance.firstStatsRunComplete = true;
+            return false;
+        }
+
+        private readonly struct PartVesselPreData
+        {
+            public readonly int partIndex;
+            public readonly Vector3d position;
+            public readonly QuaternionD rotation;
+
+            public PartVesselPreData(Vector3d position, QuaternionD rotation, int partIndex)
+            {
+                this.position = position;
+                this.rotation = rotation;
+                this.partIndex = partIndex;
+            }
+        }
+
+        private static void VesselPrePartBufferEnsureCapacity(int partCount)
+        {
+            if (vesselPrePartBuffer.Length < partCount)
+                vesselPrePartBuffer = new PartVesselPreData[(int)(partCount * 1.25)];
+        }
+
+        private static PartVesselPreData[] vesselPrePartBuffer = new PartVesselPreData[300];
+
+        private struct InertiaTensor
+        {
+            public double m00;
+            public double m11;
+            public double m22;
+
+            public void AddPartInertiaTensor(Vector3d principalMoments, QuaternionD princAxesRot)
+            {
+                // inverse the princAxesRot quaternion
+                double invpx = -princAxesRot.x;
+                double invpy = -princAxesRot.y;
+                double invpz = -princAxesRot.z;
+
+                // prepare inverse rotation
+                double ipx2 = invpx * 2.0;
+                double ipy2 = invpy * 2.0;
+                double ipz2 = invpz * 2.0;
+                double ipx2x = invpx * ipx2;
+                double ipy2y = invpy * ipy2;
+                double ipz2z = invpz * ipz2;
+                double ipy2x = invpx * ipy2;
+                double ipz2x = invpx * ipz2;
+                double ipz2y = invpy * ipz2;
+                double ipx2w = princAxesRot.w * ipx2;
+                double ipy2w = princAxesRot.w * ipy2;
+                double ipz2w = princAxesRot.w * ipz2;
+
+                // inverse rotate column 0
+                double ir0x = principalMoments.x * (1.0 - (ipy2y + ipz2z));
+                double ir0y = principalMoments.y * (ipy2x + ipz2w);
+                double ir0z = principalMoments.z * (ipz2x - ipy2w);
+
+                // inverse rotate column 1
+                double ir1x = principalMoments.x * (ipy2x - ipz2w);
+                double ir1y = principalMoments.y * (1.0 - (ipx2x + ipz2z));
+                double ir1z = principalMoments.z * (ipz2y + ipx2w);
+
+                // inverse rotate column 2
+                double ir2x = principalMoments.x * (ipz2x + ipy2w);
+                double ir2y = principalMoments.y * (ipz2y - ipx2w);
+                double ir2z = principalMoments.z * (1.0 - (ipx2x + ipy2y));
+
+                // prepare rotation
+                double qx2 = princAxesRot.x * 2.0;
+                double qy2 = princAxesRot.y * 2.0;
+                double qz2 = princAxesRot.z * 2.0;
+                double qx2x = princAxesRot.x * qx2;
+                double qy2y = princAxesRot.y * qy2;
+                double qz2z = princAxesRot.z * qz2;
+                double qy2x = princAxesRot.x * qy2;
+                double qz2x = princAxesRot.x * qz2;
+                double qz2y = princAxesRot.y * qz2;
+                double qx2w = princAxesRot.w * qx2;
+                double qy2w = princAxesRot.w * qy2;
+                double qz2w = princAxesRot.w * qz2;
+
+                // rotate column 0
+                m00 += (1.0 - (qy2y + qz2z)) * ir0x + (qy2x - qz2w) * ir0y + (qz2x + qy2w) * ir0z;
+
+                // rotate column 1
+                m11 += (qy2x + qz2w) * ir1x + (1.0 - (qx2x + qz2z)) * ir1y + (qz2y - qx2w) * ir1z;
+
+                // rotate column 2
+                m22 += (qz2x - qy2w) * ir2x + (qz2y + qx2w) * ir2y + (1.0 - (qx2x + qy2y)) * ir2z;
+            }
+
+            public void AddPartMass(double partMass, Vector3d partPosition)
+            {
+                double massLever = partMass * partPosition.sqrMagnitude;
+                double invMass = -partMass;
+
+                m00 += invMass * partPosition.x * partPosition.x + massLever;
+                m11 += invMass * partPosition.y * partPosition.y + massLever;
+                m22 += invMass * partPosition.z * partPosition.z + massLever;
+            }
+
+            public Vector3 MoI => new Vector3((float)m00, (float)m11, (float)m22);
+        }
+
+        private static void VerifyPhysicsStats(VesselPrecalculate vesselPre)
+        {
+            Vessel vessel = vesselPre.Vessel;
+            if (!vessel.loaded)
+                return;
+
+            Transform referenceTransform = vessel.ReferenceTransform;
+            int partCount = vessel.Parts.Count;
+            QuaternionD vesselInverseRotation = QuaternionD.Inverse(referenceTransform.rotation);
+            Vector3d pCoM = Vector3d.zero;
+            Vector3d pVel = Vector3d.zero;
+            Vector3d pAngularVel = Vector3d.zero;
+            double vesselMass = 0.0; // vessel.totalMass
+            int index = partCount;
+            while (index-- > 0)
+            {
+                Part part = vessel.parts[index];
+                if (part.rb != null)
+                {
+                    double physicsMass = part.physicsMass;
+                    pCoM += (Vector3d)part.rb.worldCenterOfMass * physicsMass;
+                    Vector3d vector3d = (Vector3d)part.rb.velocity * physicsMass;
+                    pVel += vector3d;
+                    pAngularVel += vesselInverseRotation * part.rb.angularVelocity * physicsMass;
+                    vesselMass += physicsMass;
+                }
+            }
+            if (vesselMass > 0.0)
+            {
+                double vesselMassRecip = 1.0 / vesselMass;
+                Vector3d vCoMD = pCoM * vesselMassRecip; // vessel.CoMD
+                Vector3d vRbVelD = pVel * vesselMassRecip; // vessel.rb_velocityD
+                Vector3d vAngVelD = pAngularVel * vesselMassRecip; // vessel.angularVelocityD
+                Vector3 vMoI = vessel.MOI;
+                if (vAngVelD == Vector3d.zero && vessel.packed)
+                {
+                    vMoI.Zero();
+                }
+                else
+                {
+                    Matrix4x4 inertiaTensor = Matrix4x4.zero;
+                    Matrix4x4 mIdentity = Matrix4x4.identity;
+                    Matrix4x4 m2 = Matrix4x4.identity;
+                    Matrix4x4 m3 = Matrix4x4.identity;
+                    Quaternion vesselInverseRotationF = vesselInverseRotation;
+                    for (int i = 0; i < partCount; i++)
+                    {
+                        Part part2 = vessel.parts[i];
+                        if (part2.rb != null)
+                        {
+                            KSPUtil.ToDiagonalMatrix2(part2.rb.inertiaTensor, ref mIdentity);
+                            Quaternion partRot = vesselInverseRotationF * part2.transform.rotation * part2.rb.inertiaTensorRotation;
+                            Quaternion invPartRot = Quaternion.Inverse(partRot);
+                            Matrix4x4 mPart = Matrix4x4.TRS(Vector3.zero, partRot, Vector3.one);
+                            Matrix4x4 invMPart = Matrix4x4.TRS(Vector3.zero, invPartRot, Vector3.one);
+                            Matrix4x4 right = mPart * mIdentity * invMPart;
+                            KSPUtil.Add(ref inertiaTensor, ref right);
+                            Vector3 lever = referenceTransform.InverseTransformDirection(part2.rb.position - vCoMD);
+                            KSPUtil.ToDiagonalMatrix2(part2.rb.mass * lever.sqrMagnitude, ref m2);
+                            KSPUtil.Add(ref inertiaTensor, ref m2);
+                            KSPUtil.OuterProduct2(lever, (0f - part2.rb.mass) * lever, ref m3);
+                            KSPUtil.Add(ref inertiaTensor, ref m3);
+                        }
+                    }
+                    vMoI = KSPUtil.Diag(inertiaTensor);
+                }
+
+                string warnings = string.Empty;
+
+                double vMassDiff = Math.Abs(vesselMass - vessel.totalMass);
+                if (vMassDiff > vesselMass / 1e6)
+                    warnings += $"Mass diverging by {vMassDiff:F6} ({vMassDiff / (vesselMass > 0.0 ? vesselMass : 1.0):P5}) ";
+
+                double vCoMDDiff = (vessel.CoMD - vCoMD).magnitude;
+                if (vCoMDDiff > vCoMD.magnitude / 1e6)
+                    warnings += $"CoM diverging by {vCoMDDiff:F6} ({vCoMDDiff / (vCoMD.magnitude > 0.0 ? vCoMD.magnitude : 1.0):P5}) ";
+
+                double vVelDiff = (vessel.rb_velocityD - vRbVelD).magnitude;
+                if (vVelDiff > vRbVelD.magnitude / 1e6)
+                    warnings += $"Velocity diverging by {vVelDiff:F6} ({vVelDiff / (vRbVelD.magnitude > 0.0 ? vRbVelD.magnitude : 1.0):P5}) ";
+
+                double vAngVelDDiff = (vessel.angularVelocityD - vAngVelD).magnitude;
+                if (vAngVelDDiff > vAngVelD.magnitude / 1e6)
+                    warnings += $"Angular velocity diverging by {vAngVelDDiff:F6} ({vAngVelDDiff / (vAngVelD.magnitude > 0.0 ? vAngVelD.magnitude : 1.0):P5}) ";
+
+                double vMoIDiff = (vessel.MOI - vMoI).magnitude;
+                if (vMoIDiff > vMoI.magnitude / 1e5)
+                    warnings += $"MoI diverging by {vMoIDiff:F6} ({vMoIDiff / (vMoI.magnitude > 0.0 ? vMoI.magnitude : 1.0):P5}) ";
+
+                if (warnings.Length > 0)
+                {
+                    Debug.LogWarning($"[KSPCF:FIPerf] CalculatePhysicsStats : diverging stats for vessel {vessel.GetDisplayName()}\n{warnings}");
+                }
+            }
+        }
+
+        #endregion
+
+        #region FlightIntegrator.UpdateMassStats optimizations
+
+        // Avoid setting RigidBody.mass and RigidBody.centerOfMass for all parts on every update if they didn't change
+        // Setting these properties is quite costly on the PhysX side, especially centerOfMass (1% to 2% of the frame time
+        // depending on the situation), and centerOfMass should almost never change unless something is changing CoMOffset.
+        // Setting mass is less costly and will change relatively often but avoiding setting when unecessary is still a decent improvement.
+        // We also take the opportunity to make a few optimizations (faster null checks, inlined inner loop, using the PartResourceList
+        // backing list instead of going through the custom indexer...)
+        static bool FlightIntegrator_UpdateMassStats_Prefix(FlightIntegrator __instance)
+        {
+            List<Part> parts = __instance.vessel.parts;
+            for (int i = __instance.partCount; i-- > 0;)
+            {
+                Part part = parts[i];
+
+                List<PartResource> partResources = part._resources.dict.list;
+                float resourceMass = 0f;
+                double resourceThermalMass = 0.0;
+                for (int j = partResources.Count; j-- > 0;)
+                {
+                    PartResource partResource = partResources[j];
+                    float resMass = (float)partResource.amount * partResource.info.density;
+                    resourceMass += resMass;
+                    resourceThermalMass += resMass * partResource.info._specificHeatCapacity;
+                }
+
+                part.resourceMass = resourceMass;
+                part.resourceThermalMass = resourceThermalMass;
+                part.thermalMass = part.mass * __instance.cacheStandardSpecificHeatCapacity * part.thermalMassModifier + part.resourceThermalMass;
+                __instance.SetSkinThermalMass(part);
+                part.thermalMass = Math.Max(part.thermalMass - part.skinThermalMass, 0.1);
+                part.thermalMassReciprocal = 1.0 / part.thermalMass;
+            }
+
+            for (int i = __instance.partCount; i-- > 0;)
+            {
+                Part part = parts[i];
+                if (part.rb.IsNotNullOrDestroyed())
+                {
+                    float physicsMass = part.mass + part.resourceMass + __instance.GetPhysicslessChildMass(part); // further optimization : don't use recursion, avoid the null check
+                    physicsMass = Mathf.Clamp(physicsMass, part.partInfo.MinimumMass, Mathf.Abs(physicsMass));
+                    part.physicsMass = physicsMass;
+
+                    if (!part.packed)
+                    {
+                        float rbMass = Mathf.Max(part.partInfo.MinimumRBMass, physicsMass);
+                        bool hasServoRB = part.servoRb.IsNotNullOrDestroyed();
+
+                        if (hasServoRB)
+                            rbMass *= 0.5f;
+
+                        // unfortunately, there is some internal fp manipulation when setting rb.mass
+                        // resulting in tiny deltas between what we set and the value we read back.
+                        if (Math.Abs(part.rb.mass - rbMass) > rbMass / 1e6f)
+                        {
+                            part.rb.mass = rbMass;
+                            if (hasServoRB)
+                                part.servoRb.mass = rbMass;
+                        }
+
+                        // Either this doesn't happen with rb.centerOfMass, or the built-in Vector3 equality
+                        // epsilon takes cares of it. I guess this might happen still if a large offset is defined...
+                        if (part.rb.centerOfMass != part.CoMOffset)
+                            part.rb.centerOfMass = part.CoMOffset;
+                    }
+                }
+                else
+                {
+                    part.physicsMass = 0.0;
+                }
+            }
+
+            return false;
+        }
+
+        #endregion
+
+        #region FlightIntegrator.UpdateOcclusion optimizations
+
+        static bool FlightIntegrator_UpdateOcclusionSolar_Prefix(FlightIntegrator __instance)
+        {
+            FlightIntegrator fi = __instance;
+            List<OcclusionData> occlusionDataList = fi.occlusionSun;
+            OcclusionCylinder[] occluders = fi.occludersSun;
+            Vector3d velocity = fi.sunVector;
+
+            bool requiresSort = false;
+
+            if (fi.partThermalDataCount != fi.partThermalDataList.Count)
+            {
+                fi.recreateThermalGraph = true;
+                fi.CheckThermalGraph();
+            }
+
+            int lastPartIndex = fi.partThermalDataCount - 1;
+            int partIndex = fi.partThermalDataCount;
+            QuaternionDPointRotation velToUp = new QuaternionDPointRotation(Numerics.FromToRotation(velocity, Vector3d.up));
+            while (partIndex-- > 0)
+            {
+                OcclusionData occlusionDataToUpdate = occlusionDataList[partIndex];
+                UpdateOcclusionData(occlusionDataToUpdate, velocity, velToUp);
+                if (!requiresSort && partIndex < lastPartIndex && occlusionDataList[partIndex + 1].maximumDot < occlusionDataToUpdate.maximumDot)
+                    requiresSort = true;
+            }
+
+            if (requiresSort)
+                occlusionDataList.Sort();
+
+            OcclusionData occlusionData = occlusionDataList[lastPartIndex];
+            occlusionData.ptd.sunAreaMultiplier = 1.0;
+            occlusionData.sunCyl.Setup(occlusionData);
+            occluders[0] = occlusionData.sunCyl;
+
+            // O(n²) [n = part count] situation here, so micro-optimizing the inner loop is critical.
+            int occluderCount = 1;
+            int index = lastPartIndex;
+            while (index-- > 0)
+            {
+                occlusionData = occlusionDataList[index];
+                double minExtentsX = occlusionData.minExtents.x;
+                double minExtentsY = occlusionData.minExtents.y;
+                double maxExtentsX = occlusionData.maxExtents.x;
+                double maxExtentsY = occlusionData.maxExtents.y;
+
+                double areaMultiplier = 1.0;
+
+                for (int i = 0; i < occluderCount; i++)
+                {
+                    // GetCylinderOcclusion
+                    OcclusionCylinder occluder = occluders[i];
+                    double offsetX = occluder.offset.x;
+                    double offsetY = occluder.offset.y;
+                    double minX = offsetX + minExtentsX;
+                    double minY = offsetY + minExtentsY;
+                    double maxX = offsetX + maxExtentsX;
+                    double maxY = offsetY + maxExtentsY;
+                    double centralExtentX = occluder.extents.x;
+                    double centralExtentY = occluder.extents.y;
+                    double centralExtentXInv = -centralExtentX;
+                    double centralExtentYInv = -centralExtentY;
+
+                    double mid = (maxX - minX) * (maxY - minY);
+                    if (maxX >= centralExtentXInv && minX <= centralExtentX && maxY >= centralExtentYInv && minY <= centralExtentY && mid != 0.0)
+                    {
+                        double midX = Math.Min(centralExtentX, maxX) - Math.Max(centralExtentXInv, minX);
+                        if (midX < 0.0) midX = 0.0;
+
+                        double midY = Math.Min(centralExtentY, maxY) - Math.Max(centralExtentYInv, minY);
+                        if (midY < 0.0) midY = 0.0;
+
+                        double rectRect = midX * midY / mid;
+                        if (double.IsNaN(rectRect)) // it could be nice to put that outside the inner loop
+                        {
+                            if (GameSettings.FI_LOG_TEMP_ERROR)
+                                Debug.LogError("[FlightIntegrator]: For part " + occlusionData.ptd.part.name + ", rectRect is NaN");
+                        }
+                        else
+                        {
+                            areaMultiplier -= rectRect;
+                        }
+                    }
+
+                    if (areaMultiplier < 0.001)
+                    {
+                        areaMultiplier = 0.0;
+                        break;
+                    }
+                }
+
+                occlusionData.ptd.sunAreaMultiplier = areaMultiplier;
+                if (areaMultiplier > 0)
+                {
+                    occlusionData.sunCyl.Setup(occlusionData);
+                    occluders[occluderCount] = occlusionData.sunCyl;
+                    occluderCount++;
+                }
+            }
+
+            return false;
+        }
+
+        static bool FlightIntegrator_UpdateOcclusionBody_Prefix(FlightIntegrator __instance)
+        {
+            FlightIntegrator fi = __instance;
+            List<OcclusionData> occlusionDataList = fi.occlusionBody;
+            OcclusionCylinder[] occluders = fi.occludersBody;
+            Vector3d velocity = -fi.vessel.upAxis;
+
+            bool requiresSort = false;
+
+            if (fi.partThermalDataCount != fi.partThermalDataList.Count)
+            {
+                fi.recreateThermalGraph = true;
+                fi.CheckThermalGraph();
+            }
+
+            int lastPartIndex = fi.partThermalDataCount - 1;
+            int partIndex = fi.partThermalDataCount;
+            QuaternionDPointRotation velToUp = new QuaternionDPointRotation(Numerics.FromToRotation(velocity, Vector3d.up));
+            while (partIndex-- > 0)
+            {
+                OcclusionData occlusionDataToUpdate = occlusionDataList[partIndex];
+                UpdateOcclusionData(occlusionDataToUpdate, velocity, velToUp);
+                if (!requiresSort && partIndex < lastPartIndex && occlusionDataList[partIndex + 1].maximumDot < occlusionDataToUpdate.maximumDot)
+                    requiresSort = true;
+            }
+
+            if (requiresSort)
+                occlusionDataList.Sort();
+
+            OcclusionData occlusionData = occlusionDataList[lastPartIndex];
+            occlusionData.ptd.bodyAreaMultiplier = 1.0;
+            occlusionData.bodyCyl.Setup(occlusionData);
+            occluders[0] = occlusionData.bodyCyl;
+
+            int occluderCount = 1;
+            int index = lastPartIndex;
+            while (index-- > 0)
+            {
+                occlusionData = occlusionDataList[index];
+                double minExtentsX = occlusionData.minExtents.x;
+                double minExtentsY = occlusionData.minExtents.y;
+                double maxExtentsX = occlusionData.maxExtents.x;
+                double maxExtentsY = occlusionData.maxExtents.y;
+
+                double areaMultiplier = 1.0;
+
+                for (int i = 0; i < occluderCount; i++)
+                {
+                    // GetCylinderOcclusion
+                    OcclusionCylinder occluder = occluders[i];
+                    double offsetX = occluder.offset.x;
+                    double offsetY = occluder.offset.y;
+                    double minX = offsetX + minExtentsX;
+                    double minY = offsetY + minExtentsY;
+                    double maxX = offsetX + maxExtentsX;
+                    double maxY = offsetY + maxExtentsY;
+                    double centralExtentX = occluder.extents.x;
+                    double centralExtentY = occluder.extents.y;
+
+                    double mid = (maxX - minX) * (maxY - minY);
+                    if (!(maxX < 0.0 - centralExtentX) && !(minX > centralExtentX) && !(maxY < 0.0 - centralExtentY) && !(minY > centralExtentY) && mid != 0.0)
+                    {
+                        double rectRect = Math.Max(0.0, Math.Min(centralExtentX, maxX) - Math.Max(0.0 - centralExtentX, minX)) * Math.Max(0.0, Math.Min(centralExtentY, maxY) - Math.Max(0.0 - centralExtentY, minY)) / mid;
+                        if (double.IsNaN(rectRect))
+                        {
+                            if (GameSettings.FI_LOG_TEMP_ERROR)
+                                Debug.LogError("[FlightIntegrator]: For part " + occlusionData.ptd.part.name + ", rectRect is NaN");
+                        }
+                        else
+                        {
+                            areaMultiplier -= rectRect;
+                        }
+                    }
+
+                    if (areaMultiplier < 0.001)
+                    {
+                        areaMultiplier = 0.0;
+                        break;
+                    }
+                }
+
+                occlusionData.ptd.bodyAreaMultiplier = areaMultiplier;
+                if (areaMultiplier > 0)
+                {
+                    occlusionData.bodyCyl.Setup(occlusionData);
+                    occluders[occluderCount] = occlusionData.bodyCyl;
+                    occluderCount++;
+                }
+            }
+            return false;
+        }
+
+        // a lot of stuff is actually unused in OcclusionData
+        // boundsVertices (only used in the scope of OcclusionData.Update, we use local vars and inline stuff instead)
+        // projectedVertices, projectedDots : part of an alternative thermal thing that isn't activated / never called
+        // useDragArea is always true, so the involved code paths are never taken
+        static void UpdateOcclusionData(OcclusionData occlusionData, Vector3d velocity, QuaternionDPointRotation velToUp)
+        {
+            Part part = occlusionData.part;
+
+            if (part.IsNullOrDestroyed() || part.partTransform.IsNullOrDestroyed())
+                return;
+
+            Vector3 center = occlusionData.part.DragCubes.WeightedCenter;
+            Vector3 size = occlusionData.part.DragCubes.WeightedSize;
+
+            double cX = center.x;
+            double cY = center.y;
+            double cZ = center.z;
+            double eX = size.x * 0.5;
+            double eY = size.y * 0.5;
+            double eZ = size.z * 0.5;
+            double minX = cX - eX;
+            double minY = cY - eY;
+            double minZ = cZ - eZ;
+            double maxX = cX + eX;
+            double maxY = cY + eY;
+            double maxZ = cZ + eZ;
+
+            Matrix4x4D localToWorldMatrix = (Matrix4x4D)part.partTransform.localToWorldMatrix; // 10% of the load.
+
+            // 10% of the load is here, probably worth it to extract the matrix components and to manually inline (the MultiplyPoint3x4 method is **not** inlined)
+            Vector3d boundVert1 = localToWorldMatrix.MultiplyPoint3x4(minX, minY, minZ);
+            Vector3d boundVert2 = localToWorldMatrix.MultiplyPoint3x4(maxX, maxY, maxZ);
+            Vector3d boundVert3 = localToWorldMatrix.MultiplyPoint3x4(minX, minY, maxZ);
+            Vector3d boundVert4 = localToWorldMatrix.MultiplyPoint3x4(minX, maxY, minZ);
+            Vector3d boundVert5 = localToWorldMatrix.MultiplyPoint3x4(maxX, minY, minZ);
+            Vector3d boundVert6 = localToWorldMatrix.MultiplyPoint3x4(minX, maxY, maxZ);
+            Vector3d boundVert7 = localToWorldMatrix.MultiplyPoint3x4(maxX, minY, maxZ);
+            Vector3d boundVert8 = localToWorldMatrix.MultiplyPoint3x4(maxX, maxY, minZ);
+
+            double minDot = double.MaxValue;
+            double maxDot = double.MinValue;
+            double minExtentX = double.MaxValue;
+            double minExtentY = double.MaxValue;
+            double maxExtentX = double.MinValue;
+            double maxExtentY = double.MinValue;
+
+            FindDotMinMax(Vector3d.Dot(boundVert1, velocity), ref minDot, ref maxDot);
+            velToUp.RotatePointGetXZ(boundVert1, out double vertX, out double vertZ);
+            FindExtentsMinMax(vertX, vertZ, ref minExtentX, ref minExtentY, ref maxExtentX, ref maxExtentY);
+
+            FindDotMinMax(Vector3d.Dot(boundVert2, velocity), ref minDot, ref maxDot);
+            velToUp.RotatePointGetXZ(boundVert2, out vertX, out vertZ);
+            FindExtentsMinMax(vertX, vertZ, ref minExtentX, ref minExtentY, ref maxExtentX, ref maxExtentY);
+
+            FindDotMinMax(Vector3d.Dot(boundVert3, velocity), ref minDot, ref maxDot);
+            velToUp.RotatePointGetXZ(boundVert3, out vertX, out vertZ);
+            FindExtentsMinMax(vertX, vertZ, ref minExtentX, ref minExtentY, ref maxExtentX, ref maxExtentY);
+
+            FindDotMinMax(Vector3d.Dot(boundVert4, velocity), ref minDot, ref maxDot);
+            velToUp.RotatePointGetXZ(boundVert4, out vertX, out vertZ);
+            FindExtentsMinMax(vertX, vertZ, ref minExtentX, ref minExtentY, ref maxExtentX, ref maxExtentY);
+
+            FindDotMinMax(Vector3d.Dot(boundVert5, velocity), ref minDot, ref maxDot);
+            velToUp.RotatePointGetXZ(boundVert5, out vertX, out vertZ);
+            FindExtentsMinMax(vertX, vertZ, ref minExtentX, ref minExtentY, ref maxExtentX, ref maxExtentY);
+
+            FindDotMinMax(Vector3d.Dot(boundVert6, velocity), ref minDot, ref maxDot);
+            velToUp.RotatePointGetXZ(boundVert6, out vertX, out vertZ);
+            FindExtentsMinMax(vertX, vertZ, ref minExtentX, ref minExtentY, ref maxExtentX, ref maxExtentY);
+
+            FindDotMinMax(Vector3d.Dot(boundVert7, velocity), ref minDot, ref maxDot);
+            velToUp.RotatePointGetXZ(boundVert7, out vertX, out vertZ);
+            FindExtentsMinMax(vertX, vertZ, ref minExtentX, ref minExtentY, ref maxExtentX, ref maxExtentY);
+
+            FindDotMinMax(Vector3d.Dot(boundVert8, velocity), ref minDot, ref maxDot);
+            velToUp.RotatePointGetXZ(boundVert8, out vertX, out vertZ);
+            FindExtentsMinMax(vertX, vertZ, ref minExtentX, ref minExtentY, ref maxExtentX, ref maxExtentY);
+
+            Vector3d worldBoundsCenter = Numerics.MultiplyPoint3x4(ref localToWorldMatrix, cX, cY, cZ);
+            occlusionData.centroidDot = Vector3d.Dot(worldBoundsCenter, velocity);
+            occlusionData.projectedCenter = worldBoundsCenter - occlusionData.centroidDot * velocity;
+            occlusionData.boundsCenter = new Vector3((float)cX, (float)cY, (float)cZ);
+            occlusionData.minimumDot = minDot;
+            occlusionData.maximumDot = maxDot;
+            occlusionData.minExtents = new Vector2((float)minExtentX, (float)minExtentY); // minExtents / maxExtents : ideally flatten into double fields
+            occlusionData.maxExtents = new Vector2((float)maxExtentX, (float)maxExtentY);
+
+            occlusionData.extents = (occlusionData.maxExtents - occlusionData.minExtents) * 0.5f; // extents, center : ideally flatten into double fields
+            occlusionData.center = occlusionData.minExtents + occlusionData.extents;
+
+            occlusionData.projectedArea = part.DragCubes.CrossSectionalArea;
+            occlusionData.invFineness = part.DragCubes.TaperDot;
+            occlusionData.maxWidthDepth = part.DragCubes.Depth;
+
+            occlusionData.projectedRadius = Math.Sqrt(occlusionData.projectedArea / Math.PI);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void FindExtentsMinMax(double x, double z, ref double minExtentX, ref double minExtentY, ref double maxExtentX, ref double maxExtentY)
+        {
+            maxExtentX = Math.Max(maxExtentX, x);
+            maxExtentY = Math.Max(maxExtentY, z);
+            minExtentX = Math.Min(minExtentX, x);
+            minExtentY = Math.Min(minExtentY, z);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void FindDotMinMax(double dot, ref double minDot, ref double maxDot)
+        {
+            if (dot < minDot)
+                minDot = dot;
+
+            if (dot > maxDot)
+                maxDot = dot;
+        }
+
+        private struct QuaternionDPointRotation
+        {
+            private double qx2x;
+            private double qy2y;
+            private double qz2z;
+            private double qy2x;
+            private double qz2x;
+            private double qz2y;
+            private double qx2w;
+            private double qy2w;
+            private double qz2w;
+
+            public QuaternionDPointRotation(QuaternionD rotation)
+            {
+                double qx2 = rotation.x * 2.0;
+                double qy2 = rotation.y * 2.0;
+                double qz2 = rotation.z * 2.0;
+                qx2x = rotation.x * qx2;
+                qy2y = rotation.y * qy2;
+                qz2z = rotation.z * qz2;
+                qy2x = rotation.x * qy2;
+                qz2x = rotation.x * qz2;
+                qz2y = rotation.y * qz2;
+                qx2w = rotation.w * qx2;
+                qy2w = rotation.w * qy2;
+                qz2w = rotation.w * qz2;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void RotatePointGetXZ(Vector3d point, out double x, out double z)
+            {
+                x = (1.0 - (qy2y + qz2z)) * point.x + (qy2x - qz2w) * point.y + (qz2x + qy2w) * point.z;
+                z = (qz2x - qy2w) * point.x + (qz2y + qx2w) * point.y + (1.0 - (qx2x + qy2y)) * point.z;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/KSPCommunityFixes/Performance/FloatingOriginPerf.cs
+++ b/KSPCommunityFixes/Performance/FloatingOriginPerf.cs
@@ -1,0 +1,262 @@
+﻿using KSPCommunityFixes.Library;
+using System;
+using System.Collections.Generic;
+using Unity.Collections;
+using UnityEngine;
+
+namespace KSPCommunityFixes.Performance
+{
+    internal class FloatingOriginPerf : BasePatch
+    {
+        protected override Version VersionMin => new Version(1, 12, 3);
+
+        protected override void ApplyPatches()
+        {
+            AddPatch(PatchType.Override, typeof(FloatingOrigin), nameof(FloatingOrigin.setOffset));
+        }
+
+        private static HashSet<int> activePS = new HashSet<int>(200);
+
+        private static void FloatingOrigin_setOffset_Override(FloatingOrigin fo, Vector3d refPos, Vector3d nonFrame)
+        {
+            if (refPos.IsInvalid())
+                return;
+
+            if (double.IsInfinity(refPos.sqrMagnitude))
+                return;
+
+            fo.SetOffsetThisFrame = true;
+            fo.offset = refPos;
+            fo.reverseoffset = new Vector3d(0.0 - refPos.x, 0.0 - refPos.y, 0.0 - refPos.z);
+            fo.offsetNonKrakensbane = fo.offset + nonFrame;
+
+            Vector3 offsetF = fo.offset;
+            Vector3 offsetNonKrakensbaneF = fo.offsetNonKrakensbane;
+            float deltaTime = Time.deltaTime;
+            Vector3 frameVelocity = Krakensbane.GetFrameVelocity();
+
+            activePS.Clear();
+
+            List<CelestialBody> bodies = FlightGlobals.Bodies;
+            for (int i = bodies.Count; i-- > 0;)
+                bodies[i].position -= fo.offsetNonKrakensbane;
+
+            bool needCoMRecalc = fo.offset.sqrMagnitude > fo.CoMRecalcOffsetMaxSqr;
+            List<Vessel> vessels = FlightGlobals.Vessels;
+
+            for (int i = vessels.Count; i-- > 0;)
+            {
+                Vessel vessel = vessels[i];
+
+                if (vessel.state == Vessel.State.DEAD)
+                    continue;
+
+                Vector3d vesselOffset = (!vessel.loaded || vessel.packed || vessel.LandedOrSplashed) ? fo.offsetNonKrakensbane : fo.offset;
+                vessel.SetPosition((Vector3d)vessel.transform.position - vesselOffset);
+
+                if (needCoMRecalc && vessel.packed)
+                {
+                    vessel.precalc.CalculatePhysicsStats();
+                }
+                else
+                {
+                    vessel.CoMD -= vesselOffset;
+                    vessel.CoM = vessel.CoMD;
+                }
+
+                // Update legacy (?) particle system
+                for (int j = vessel.parts.Count; j-- > 0;)
+                {
+                    Part part = vessel.parts[j];
+
+                    if (part.fxGroups.Count == 0)
+                        continue;
+
+                    bool partDataComputed = false;
+                    bool hasRigidbody = false;
+                    Vector3 partVelocity = Vector3.zero;
+
+                    for (int k = part.fxGroups.Count; k-- > 0;)
+                    {
+                        FXGroup fXGroup = part.fxGroups[k];
+                        for (int l = fXGroup.fxEmittersNewSystem.Count; l-- > 0;)
+                        {
+                            ParticleSystem particleSystem = fXGroup.fxEmittersNewSystem[l];
+
+                            int particleCount = particleSystem.particleCount;
+                            if (particleCount == 0 || particleSystem.main.simulationSpace != ParticleSystemSimulationSpace.World)
+                                continue;
+
+                            activePS.Add(particleSystem.GetInstanceIDFast());
+
+                            if (!partDataComputed)
+                            {
+                                partDataComputed = true;
+                                Rigidbody partRB = part.Rigidbody;
+                                if (partRB.IsNotNullOrDestroyed())
+                                {
+                                    hasRigidbody = true;
+                                    partVelocity = partRB.velocity + frameVelocity;
+                                }
+                            }
+
+                            NativeArray<ParticleSystem.Particle> particleBuffer = particleSystem.GetParticlesNativeArray(ref particleCount);
+                            for (int pIdx = particleCount; pIdx-- > 0;)
+                            {
+                                Vector3 particlePos = particleBuffer.GetParticlePosition(pIdx);
+
+                                if (hasRigidbody)
+                                {
+                                    float scalar = UnityEngine.Random.value * deltaTime;
+                                    particlePos.Substract(partVelocity.x * scalar, partVelocity.y * scalar, partVelocity.z * scalar);
+                                }
+
+                                particlePos.Substract(offsetNonKrakensbaneF);
+                                particleBuffer.SetParticlePosition(pIdx, particlePos);
+                            }
+                            particleSystem.SetParticles(particleBuffer, particleCount);
+                        }
+                    }
+                }
+            }
+
+            // update "new" (but just as shitty) particle system (this replicate a call to EffectBehaviour.OffsetParticles())
+            Vector3 systemVelocity = Vector3.zero;
+
+            List<ParticleSystem> pSystems = EffectBehaviour.emitters;
+            for (int i = pSystems.Count; i-- > 0;)
+            {
+                ParticleSystem particleSystem = pSystems[i];
+
+                if (particleSystem.IsNullOrDestroyed())
+                {
+                    pSystems.RemoveAt(i);
+                    continue;
+                }
+
+                int particleCount = particleSystem.particleCount;
+                if (particleCount == 0 || particleSystem.main.simulationSpace != ParticleSystemSimulationSpace.World)
+                    continue;
+
+                activePS.Add(particleSystem.GetInstanceIDFast());
+
+                bool hasRigidbody = false;
+                Rigidbody rb = particleSystem.GetComponentInParent<Rigidbody>();
+                if (rb.IsNotNullRef())
+                {
+                    hasRigidbody = true;
+                    systemVelocity = rb.velocity + frameVelocity;
+                }
+
+                NativeArray<ParticleSystem.Particle> particleBuffer = particleSystem.GetParticlesNativeArray(ref particleCount);
+                for (int pIdx = particleCount; pIdx-- > 0;)
+                {
+                    Vector3 particlePos = particleBuffer.GetParticlePosition(pIdx);
+
+                    if (hasRigidbody)
+                    {
+                        float scalar = UnityEngine.Random.value * deltaTime;
+                        particlePos.Substract(systemVelocity.x * scalar, systemVelocity.y * scalar, systemVelocity.z * scalar);
+                    }
+
+                    particlePos.Substract(offsetNonKrakensbaneF);
+                    particleBuffer.SetParticlePosition(pIdx, particlePos);
+                }
+                particleSystem.SetParticles(particleBuffer, particleCount);
+            }
+
+            List<KSPParticleEmitter> pSystemsKSP = EffectBehaviour.kspEmitters;
+            for (int i = pSystemsKSP.Count; i-- > 0;)
+            {
+                KSPParticleEmitter particleSystemKSP = pSystemsKSP[i];
+
+                if (particleSystemKSP.IsNullOrDestroyed())
+                {
+                    pSystemsKSP.RemoveAt(i);
+                    continue;
+                }
+
+                int particleCount = particleSystemKSP.ps.particleCount;
+                if (particleCount == 0 || !particleSystemKSP.useWorldSpace)
+                    continue;
+
+                activePS.Add(particleSystemKSP.ps.GetInstanceIDFast());
+
+                bool hasRigidbody = false;
+                Rigidbody rb = particleSystemKSP.GetComponentInParent<Rigidbody>();
+                if (rb.IsNotNullRef())
+                {
+                    hasRigidbody = true;
+                    systemVelocity = rb.velocity + frameVelocity;
+                }
+
+                NativeArray<ParticleSystem.Particle> particleBuffer = particleSystemKSP.ps.GetParticlesNativeArray(ref particleCount);
+                for (int pIdx = particleCount; pIdx-- > 0;)
+                {
+                    Vector3 particlePos = particleBuffer.GetParticlePosition(pIdx);
+
+                    if (hasRigidbody)
+                    {
+                        float scalar = UnityEngine.Random.value * deltaTime;
+                        particlePos.Substract(systemVelocity.x * scalar, systemVelocity.y * scalar, systemVelocity.z * scalar);
+                    }
+
+                    particlePos.Substract(offsetNonKrakensbaneF);
+                    particleBuffer.SetParticlePosition(pIdx, particlePos);
+                }
+                particleSystemKSP.ps.SetParticles(particleBuffer, particleCount);
+            }
+
+            // Just have another handling of the same stuff, sometimes overlapping, sometimes not, because why not ?
+            for (int i = fo.particleSystems.Count; i-- > 0;)
+            {
+                ParticleSystem particleSystem = fo.particleSystems[i];
+                if (particleSystem.IsNullOrDestroyed() || activePS.Contains(particleSystem.GetInstanceIDFast()))
+                {
+                    fo.particleSystems.RemoveAt(i);
+                    continue;
+                }
+
+                int particleCount = particleSystem.particleCount;
+                if (particleCount == 0)
+                    continue;
+
+                if (particleSystem.main.simulationSpace != ParticleSystemSimulationSpace.World)
+                    continue;
+
+                if (activePS.Contains(particleSystem.GetInstanceIDFast()))
+                {
+                    fo.particleSystems.RemoveAt(i);
+                    continue;
+                }
+
+                NativeArray<ParticleSystem.Particle> particleBuffer = particleSystem.GetParticlesNativeArray(ref particleCount);
+                for (int pIdx = particleCount; pIdx-- > 0;)
+                {
+                    Vector3 particlePos = particleBuffer.GetParticlePosition(pIdx);
+                    particlePos.Substract(offsetNonKrakensbaneF);
+                    particleBuffer.SetParticlePosition(pIdx, particlePos);
+                }
+
+                particleSystem.SetParticles(particleBuffer, particleCount);
+            }
+
+            // more particle system (explosions, fireworks...) moving in here, but this is getting silly, I don't care anymore...
+            if (FlightGlobals.ActiveVessel != null && FlightGlobals.ActiveVessel.radarAltitude < fo.altToStopMovingExplosions)
+                FXMonger.OffsetPositions(-fo.offsetNonKrakensbane);
+
+            for (int i = FlightGlobals.physicalObjects.Count; i-- > 0;)
+            {
+                physicalObject physicalObject = FlightGlobals.physicalObjects[i];
+                if (physicalObject.IsNotNullOrDestroyed())
+                {
+                    Transform obj = physicalObject.transform;
+                    obj.position -= offsetF;
+                }
+            }
+
+            FloatingOrigin.TerrainShaderOffset += fo.offsetNonKrakensbane;
+            GameEvents.onFloatingOriginShift.Fire(fo.offset, nonFrame);
+        }
+    }
+}

--- a/KSPCommunityFixes/Performance/IMGUIOptimization.cs
+++ b/KSPCommunityFixes/Performance/IMGUIOptimization.cs
@@ -18,11 +18,9 @@ namespace KSPCommunityFixes.Performance
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(GUILayoutUtility), nameof(GUILayoutUtility.Begin))));
+            AddPatch(PatchType.Prefix, typeof(GUILayoutUtility), nameof(GUILayoutUtility.Begin));
         }
 
         static bool GUILayoutUtility_Begin_Prefix(int instanceID)

--- a/KSPCommunityFixes/Performance/IMGUIOptimization.cs
+++ b/KSPCommunityFixes/Performance/IMGUIOptimization.cs
@@ -22,8 +22,7 @@ namespace KSPCommunityFixes.Performance
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(GUILayoutUtility), nameof(GUILayoutUtility.Begin)),
-                this));
+                AccessTools.Method(typeof(GUILayoutUtility), nameof(GUILayoutUtility.Begin))));
         }
 
         static bool GUILayoutUtility_Begin_Prefix(int instanceID)

--- a/KSPCommunityFixes/Performance/LocalizerPerf.cs
+++ b/KSPCommunityFixes/Performance/LocalizerPerf.cs
@@ -26,22 +26,21 @@ namespace KSPCommunityFixes.Performance
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
                 AccessTools.Method(typeof(Localizer), nameof(Localizer.Format), new[] { typeof(string) }),
-                this, nameof(Localizer_FormatNoParams_Prefix)));
+                nameof(Localizer_FormatNoParams_Prefix)));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
                 AccessTools.Method(typeof(Localizer), nameof(Localizer.Format), new[] { typeof(string), typeof(string[]) }),
-                this, nameof(Localizer_FormatStringParams_Prefix)));
+                nameof(Localizer_FormatStringParams_Prefix)));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
                 AccessTools.Method(typeof(Localizer), nameof(Localizer.Format), new[] { typeof(string), typeof(object[]) }),
-                this, nameof(Localizer_FormatObjectParams_Prefix)));
+                nameof(Localizer_FormatObjectParams_Prefix)));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(Localizer), nameof(Localizer.TranslateBranch)),
-                this));
+                AccessTools.Method(typeof(Localizer), nameof(Localizer.TranslateBranch))));
         }
 
         private static bool Localizer_FormatNoParams_Prefix(string template, out string __result)

--- a/KSPCommunityFixes/Performance/LocalizerPerf.cs
+++ b/KSPCommunityFixes/Performance/LocalizerPerf.cs
@@ -19,28 +19,17 @@ namespace KSPCommunityFixes.Performance
     {
         private static Thread mainThread;
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
             mainThread = Thread.CurrentThread;
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(Localizer), nameof(Localizer.Format), new[] { typeof(string) }),
-                nameof(Localizer_FormatNoParams_Prefix)));
+            AddPatch(PatchType.Prefix, typeof(Localizer), nameof(Localizer.Format), new[] { typeof(string) }, nameof(Localizer_FormatNoParams_Prefix));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(Localizer), nameof(Localizer.Format), new[] { typeof(string), typeof(string[]) }),
-                nameof(Localizer_FormatStringParams_Prefix)));
+            AddPatch(PatchType.Prefix, typeof(Localizer), nameof(Localizer.Format), new[] { typeof(string), typeof(string[]) }, nameof(Localizer_FormatStringParams_Prefix));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(Localizer), nameof(Localizer.Format), new[] { typeof(string), typeof(object[]) }),
-                nameof(Localizer_FormatObjectParams_Prefix)));
+            AddPatch(PatchType.Prefix, typeof(Localizer), nameof(Localizer.Format), new[] { typeof(string), typeof(object[]) }, nameof(Localizer_FormatObjectParams_Prefix));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(Localizer), nameof(Localizer.TranslateBranch))));
+            AddPatch(PatchType.Prefix, typeof(Localizer), nameof(Localizer.TranslateBranch));
         }
 
         private static bool Localizer_FormatNoParams_Prefix(string template, out string __result)

--- a/KSPCommunityFixes/Performance/LowerMinPhysicsDTPerFrame.cs
+++ b/KSPCommunityFixes/Performance/LowerMinPhysicsDTPerFrame.cs
@@ -29,13 +29,11 @@ namespace KSPCommunityFixes.Performance
         {
             patches.Add(
                 new PatchInfo(PatchMethodType.Prefix,
-                    AccessTools.Method(typeof(SettingsScreen), nameof(SettingsScreen.Awake)),
-                    this));
+                    AccessTools.Method(typeof(SettingsScreen), nameof(SettingsScreen.Awake))));
 
             patches.Add(
                 new PatchInfo(PatchMethodType.Prefix,
-                    AccessTools.Method(typeof(ReflectedSettingsWindow), nameof(SetupReflectionValues)),
-                    this));
+                    AccessTools.Method(typeof(ReflectedSettingsWindow), nameof(SetupReflectionValues))));
         }
 
         static void SettingsScreen_Awake_Prefix(SettingsScreen __instance)

--- a/KSPCommunityFixes/Performance/LowerMinPhysicsDTPerFrame.cs
+++ b/KSPCommunityFixes/Performance/LowerMinPhysicsDTPerFrame.cs
@@ -25,15 +25,11 @@ namespace KSPCommunityFixes.Performance
 
         protected override Version VersionMin => new Version(1, 12, 3);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(
-                new PatchInfo(PatchMethodType.Prefix,
-                    AccessTools.Method(typeof(SettingsScreen), nameof(SettingsScreen.Awake))));
+            AddPatch(PatchType.Prefix, typeof(SettingsScreen), nameof(SettingsScreen.Awake));
 
-            patches.Add(
-                new PatchInfo(PatchMethodType.Prefix,
-                    AccessTools.Method(typeof(ReflectedSettingsWindow), nameof(SetupReflectionValues))));
+            AddPatch(PatchType.Prefix, typeof(ReflectedSettingsWindow), nameof(SetupReflectionValues));
         }
 
         static void SettingsScreen_Awake_Prefix(SettingsScreen __instance)

--- a/KSPCommunityFixes/Performance/MemoryLeaks.cs
+++ b/KSPCommunityFixes/Performance/MemoryLeaks.cs
@@ -30,7 +30,7 @@ namespace KSPCommunityFixes.Performance
 
         protected override Version VersionMin => new Version(1, 12, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
             ConfigNode settingsNode = KSPCommunityFixes.SettingsNode.GetNode("MEMORY_LEAKS_DEBUGGING");
             if (settingsNode != null)
@@ -48,120 +48,58 @@ namespace KSPCommunityFixes.Performance
 #endif
 
             // removing PartSet finalizers
-
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(PartSet), nameof(PartSet.HookEvents))));
+            AddPatch(PatchType.Postfix, typeof(PartSet), nameof(PartSet.HookEvents));
 
             // Specific GameEvents leaks
-
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(CommNetVessel), nameof(CommNetVessel.OnDestroy))));
-
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(StageGroup), nameof(StageGroup.OnDestroy))));
-
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleProceduralFairing), nameof(ModuleProceduralFairing.OnDestroy))));
-
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleScienceExperiment), nameof(ModuleScienceExperiment.OnAwake))));
+            AddPatch(PatchType.Prefix, typeof(CommNetVessel), nameof(CommNetVessel.OnDestroy));
+            AddPatch(PatchType.Postfix, typeof(StageGroup), nameof(StageGroup.OnDestroy));
+            AddPatch(PatchType.Postfix, typeof(ModuleProceduralFairing), nameof(ModuleProceduralFairing.OnDestroy));
+            AddPatch(PatchType.Prefix, typeof(ModuleScienceExperiment), nameof(ModuleScienceExperiment.OnAwake));
 
             // protopartsnapshot leaks a reference to a copy of the root part because of how it's created
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ProtoPartSnapshot), nameof(ProtoPartSnapshot.Load))));
-
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ProtoPartSnapshot), nameof(ProtoPartSnapshot.ConfigurePart))));
+            AddPatch(PatchType.Postfix, typeof(ProtoPartSnapshot), nameof(ProtoPartSnapshot.Load));
+            AddPatch(PatchType.Postfix, typeof(ProtoPartSnapshot), nameof(ProtoPartSnapshot.ConfigurePart));
 
             // Parts and vessels don't unhook themselves from things when they're destroyed or unloaded
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Part), nameof(Part.OnDestroy))));
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Part), nameof(Part.ReleaseAutoStruts))));
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Vessel), nameof(Vessel.Unload))));
+            AddPatch(PatchType.Postfix, typeof(Part), nameof(Part.OnDestroy));
+            AddPatch(PatchType.Postfix, typeof(Part), nameof(Part.ReleaseAutoStruts));
+            AddPatch(PatchType.Postfix, typeof(Vessel), nameof(Vessel.Unload));
 
             // Kerbals
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Kerbal), nameof(Kerbal.OnDestroy))));
-
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(InternalSeat), nameof(InternalSeat.DespawnCrew))));
+            AddPatch(PatchType.Postfix, typeof(Kerbal), nameof(Kerbal.OnDestroy));
+            AddPatch(PatchType.Prefix, typeof(InternalSeat), nameof(InternalSeat.DespawnCrew));
 
             // EffectList dictionary enumerator leaks
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(EffectList), nameof(EffectList.Initialize))));
-
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(EffectList), nameof(EffectList.OnSave))));
+            AddPatch(PatchType.Postfix, typeof(EffectList), nameof(EffectList.Initialize));
+            AddPatch(PatchType.Postfix, typeof(EffectList), nameof(EffectList.OnSave));
 
             // Pooled Audio onRelease delegate leak
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(AudioMultiPooledFX.PooledAudioSource), nameof(AudioMultiPooledFX.PooledAudioSource.Reset))));
+            AddPatch(PatchType.Postfix, typeof(AudioMultiPooledFX.PooledAudioSource), nameof(AudioMultiPooledFX.PooledAudioSource.Reset));
 
             // various static fields keeping deep reference stacks around...
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(CraftSearch), nameof(CraftSearch.OnDestroy))));
-
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(EngineersReport), nameof(EngineersReport.OnAppDestroy))));
-
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(FlightIntegrator), nameof(FlightIntegrator.OnDestroy))));
+            AddPatch(PatchType.Postfix, typeof(CraftSearch), nameof(CraftSearch.OnDestroy));
+            AddPatch(PatchType.Postfix, typeof(EngineersReport), nameof(EngineersReport.OnAppDestroy));
+            AddPatch(PatchType.Postfix, typeof(FlightIntegrator), nameof(FlightIntegrator.OnDestroy));
 
             // Various singleton MonoBehaviours are scene-specific. They are using a static accessor that isn't nulled
             // when the instance is destroyed, causing anything still referenced to never be GCed.
             // There are way too many of them t fix them all, but we try to patch the worst offenders here.
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(InventoryPanelController), nameof(InventoryPanelController.OnDestroy))));
+            AddPatch(PatchType.Postfix, typeof(InventoryPanelController), nameof(InventoryPanelController.OnDestroy));
+            AddPatch(PatchType.Postfix, typeof(EVAConstructionModeController), nameof(EVAConstructionModeController.OnDestroy));
+            AddPatch(PatchType.Postfix, typeof(FuelFlowOverlay), nameof(FuelFlowOverlay.OnDestroy));
+            AddPatch(PatchType.Postfix, typeof(ApplicationLauncher), nameof(ApplicationLauncher.RemoveApplication));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(EVAConstructionModeController), nameof(EVAConstructionModeController.OnDestroy))));
-
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(FuelFlowOverlay), nameof(FuelFlowOverlay.OnDestroy))));
-
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.RemoveApplication))));
-
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.RemoveModApplication)),
-                nameof(ApplicationLauncher_RemoveApplication_Postfix)));
+            AddPatch(PatchType.Postfix, typeof(ApplicationLauncher), nameof(ApplicationLauncher.RemoveModApplication), nameof(ApplicationLauncher_RemoveApplication_Postfix));
 
             // KSC Vessel Markers inherit from this class. they don't get cleaned up properly
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(AnchoredDialog), nameof(AnchoredDialog.Terminate))));
+            AddPatch(PatchType.Postfix, typeof(AnchoredDialog), nameof(AnchoredDialog.Terminate));
 
             // general cleanup on scene switches
 
@@ -172,13 +110,9 @@ namespace KSPCommunityFixes.Performance
             // fix some previously silently failing code that was refering to dead instances, 
             // and is throwing because we actually remove references to those dead instances
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(UIPartActionControllerInventory), nameof(UIPartActionControllerInventory.UpdateCursorOverPAWs))));
+            AddPatch(PatchType.Prefix, typeof(UIPartActionControllerInventory), nameof(UIPartActionControllerInventory.UpdateCursorOverPAWs));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(UIPartActionInventory), nameof(UIPartActionInventory.Update))));
+            AddPatch(PatchType.Prefix, typeof(UIPartActionInventory), nameof(UIPartActionInventory.Update));
         }
 
         private enum KSPScene

--- a/KSPCommunityFixes/Performance/MemoryLeaks.cs
+++ b/KSPCommunityFixes/Performance/MemoryLeaks.cs
@@ -51,102 +51,87 @@ namespace KSPCommunityFixes.Performance
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(PartSet), nameof(PartSet.HookEvents)),
-                this));
+                AccessTools.Method(typeof(PartSet), nameof(PartSet.HookEvents))));
 
             // Specific GameEvents leaks
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(CommNetVessel), nameof(CommNetVessel.OnDestroy)),
-                this));
+                AccessTools.Method(typeof(CommNetVessel), nameof(CommNetVessel.OnDestroy))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(StageGroup), nameof(StageGroup.OnDestroy)),
-                this));
+                AccessTools.Method(typeof(StageGroup), nameof(StageGroup.OnDestroy))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleProceduralFairing), nameof(ModuleProceduralFairing.OnDestroy)),
-                this));
+                AccessTools.Method(typeof(ModuleProceduralFairing), nameof(ModuleProceduralFairing.OnDestroy))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleScienceExperiment), nameof(ModuleScienceExperiment.OnAwake)),
-                this));
+                AccessTools.Method(typeof(ModuleScienceExperiment), nameof(ModuleScienceExperiment.OnAwake))));
 
             // protopartsnapshot leaks a reference to a copy of the root part because of how it's created
 
-            patches.Add(new PatchInfo(PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ProtoPartSnapshot), nameof(ProtoPartSnapshot.Load)),
-                this));
-            patches.Add(new PatchInfo(PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ProtoPartSnapshot), nameof(ProtoPartSnapshot.ConfigurePart)),
-                this));
+            patches.Add(new PatchInfo(
+                PatchMethodType.Postfix,
+                AccessTools.Method(typeof(ProtoPartSnapshot), nameof(ProtoPartSnapshot.Load))));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Postfix,
+                AccessTools.Method(typeof(ProtoPartSnapshot), nameof(ProtoPartSnapshot.ConfigurePart))));
 
             // Parts and vessels don't unhook themselves from things when they're destroyed or unloaded
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Part), nameof(Part.OnDestroy)),
-                this));
+                AccessTools.Method(typeof(Part), nameof(Part.OnDestroy))));
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Part), nameof(Part.ReleaseAutoStruts)),
-                this));
+                AccessTools.Method(typeof(Part), nameof(Part.ReleaseAutoStruts))));
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Vessel), nameof(Vessel.Unload)),
-                this));
+                AccessTools.Method(typeof(Vessel), nameof(Vessel.Unload))));
 
             // Kerbals
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Kerbal), nameof(Kerbal.OnDestroy)),
-                this));
+                AccessTools.Method(typeof(Kerbal), nameof(Kerbal.OnDestroy))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(InternalSeat), nameof(InternalSeat.DespawnCrew)),
-                this));
+                AccessTools.Method(typeof(InternalSeat), nameof(InternalSeat.DespawnCrew))));
 
             // EffectList dictionary enumerator leaks
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(EffectList), nameof(EffectList.Initialize)),
-                this));
+                AccessTools.Method(typeof(EffectList), nameof(EffectList.Initialize))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(EffectList), nameof(EffectList.OnSave)),
-                this));
+                AccessTools.Method(typeof(EffectList), nameof(EffectList.OnSave))));
 
             // Pooled Audio onRelease delegate leak
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(AudioMultiPooledFX.PooledAudioSource), nameof(AudioMultiPooledFX.PooledAudioSource.Reset)),
-                this));
+                AccessTools.Method(typeof(AudioMultiPooledFX.PooledAudioSource), nameof(AudioMultiPooledFX.PooledAudioSource.Reset))));
 
             // various static fields keeping deep reference stacks around...
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(CraftSearch), nameof(CraftSearch.OnDestroy)),
-                this));
+                AccessTools.Method(typeof(CraftSearch), nameof(CraftSearch.OnDestroy))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(EngineersReport), nameof(EngineersReport.OnAppDestroy)),
-                this));
+                AccessTools.Method(typeof(EngineersReport), nameof(EngineersReport.OnAppDestroy))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(FlightIntegrator), nameof(FlightIntegrator.OnDestroy)),
-                this));
+                AccessTools.Method(typeof(FlightIntegrator), nameof(FlightIntegrator.OnDestroy))));
 
             // Various singleton MonoBehaviours are scene-specific. They are using a static accessor that isn't nulled
             // when the instance is destroyed, causing anything still referenced to never be GCed.
@@ -154,35 +139,29 @@ namespace KSPCommunityFixes.Performance
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(InventoryPanelController), nameof(InventoryPanelController.OnDestroy)),
-                this));
+                AccessTools.Method(typeof(InventoryPanelController), nameof(InventoryPanelController.OnDestroy))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(EVAConstructionModeController), nameof(EVAConstructionModeController.OnDestroy)),
-                this));
+                AccessTools.Method(typeof(EVAConstructionModeController), nameof(EVAConstructionModeController.OnDestroy))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(FuelFlowOverlay), nameof(FuelFlowOverlay.OnDestroy)),
-                this));
+                AccessTools.Method(typeof(FuelFlowOverlay), nameof(FuelFlowOverlay.OnDestroy))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.RemoveApplication)),
-                this));
+                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.RemoveApplication))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
                 AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.RemoveModApplication)),
-                this,
-                "ApplicationLauncher_RemoveApplication_Postfix"));
+                nameof(ApplicationLauncher_RemoveApplication_Postfix)));
 
             // KSC Vessel Markers inherit from this class. they don't get cleaned up properly
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(AnchoredDialog), nameof(AnchoredDialog.Terminate)),
-                this));
+                AccessTools.Method(typeof(AnchoredDialog), nameof(AnchoredDialog.Terminate))));
 
             // general cleanup on scene switches
 
@@ -195,13 +174,11 @@ namespace KSPCommunityFixes.Performance
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(UIPartActionControllerInventory), nameof(UIPartActionControllerInventory.UpdateCursorOverPAWs)),
-                this));
+                AccessTools.Method(typeof(UIPartActionControllerInventory), nameof(UIPartActionControllerInventory.UpdateCursorOverPAWs))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(UIPartActionInventory), nameof(UIPartActionInventory.Update)),
-                this));
+                AccessTools.Method(typeof(UIPartActionInventory), nameof(UIPartActionInventory.Update))));
         }
 
         private enum KSPScene

--- a/KSPCommunityFixes/Performance/MemoryLeaks.cs
+++ b/KSPCommunityFixes/Performance/MemoryLeaks.cs
@@ -1,4 +1,6 @@
-﻿using CommNet;
+﻿//#define LOG_PART_UPWARD_CACHE_LEAKS
+
+using CommNet;
 using HarmonyLib;
 using KSP.UI;
 using KSP.UI.Screens;
@@ -741,7 +743,7 @@ namespace KSPCommunityFixes.Performance
             __instance.parent = __instance.potentialParent = null;
             __instance.internalModel = null;
 
-#if DEBUG
+#if LOG_PART_UPWARD_CACHE_LEAKS
             if (FlightGlobals.objectToPartUpwardsCache.Values.Contains(__instance))
             {
                 Debug.LogError($"Destroying part {__instance.GetInstanceID()} while it's still in the objectToPartUpwardsCache");

--- a/KSPCommunityFixes/Performance/MinorPerfTweaks.cs
+++ b/KSPCommunityFixes/Performance/MinorPerfTweaks.cs
@@ -1,5 +1,4 @@
-﻿using HarmonyLib;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using UnityEngine;
 

--- a/KSPCommunityFixes/Performance/MinorPerfTweaks.cs
+++ b/KSPCommunityFixes/Performance/MinorPerfTweaks.cs
@@ -1,8 +1,7 @@
 ﻿using HarmonyLib;
 using System;
 using System.Collections.Generic;
-using System.Reflection;
-using System.Reflection.Emit;
+using UnityEngine;
 
 namespace KSPCommunityFixes.Performance
 {
@@ -13,18 +12,73 @@ namespace KSPCommunityFixes.Performance
         protected override void ApplyPatches(List<PatchInfo> patches)
         {
             patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(Part), nameof(Part.isKerbalEVA)),
-                this));
+                PatchMethodType.Override,
+                AccessTools.Method(typeof(Part), nameof(Part.isKerbalEVA))));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Override,
+                AccessTools.Method(typeof(VolumeNormalizer), nameof(VolumeNormalizer.Update))));
         }
 
-        private static IEnumerable<CodeInstruction> Part_isKerbalEVA_Transpiler(IEnumerable<CodeInstruction> instructions)
+        // Called (sometimes multiple times) in Part.FixedUpdate()
+        public static bool Part_isKerbalEVA_Override(Part part)
         {
-            MethodInfo isKerbalEVAFast = AccessTools.Method(typeof(KSPObjectsExtensions), nameof(KSPObjectsExtensions.IsKerbalEVA));
+            part.cachedModules ??= new Dictionary<Type, PartModule>(10);
 
-            yield return new CodeInstruction(OpCodes.Ldarg_0);
-            yield return new CodeInstruction(OpCodes.Call, isKerbalEVAFast);
-            yield return new CodeInstruction(OpCodes.Ret);
+            if (!part.cachedModules.TryGetValue(typeof(KerbalEVA), out PartModule module))
+            {
+                if (part.modules == null)
+                    return false;
+
+                List<PartModule> modules = part.modules.modules;
+                int moduleCount = modules.Count;
+                for (int i = 0; i < moduleCount; i++)
+                {
+                    if (modules[i] is KerbalEVA)
+                    {
+                        module = modules[i];
+                        break;
+                    }
+                }
+
+                part.cachedModules[typeof(KerbalEVA)] = module;
+            }
+
+            return module.IsNotNullRef();
+        }
+
+        // setting AudioListener.volume is actually quite costly (0.7% of the frame time),
+        // so avoid setting it when the value hasn't actually changed...
+        [TranspileInDebug]
+        private static void VolumeNormalizer_Update_Override(VolumeNormalizer vn)
+        {
+            float newVolume;
+            if (GameSettings.SOUND_NORMALIZER_ENABLED)
+            {
+                vn.threshold = GameSettings.SOUND_NORMALIZER_THRESHOLD;
+                vn.sharpness = GameSettings.SOUND_NORMALIZER_RESPONSIVENESS;
+                AudioListener.GetOutputData(vn.samples, 0);
+                vn.level = 0f;
+
+                for (int i = 0; i < vn.sampleCount; i += 1 + GameSettings.SOUND_NORMALIZER_SKIPSAMPLES)
+                    vn.level = Mathf.Max(vn.level, Mathf.Abs(vn.samples[i]));
+
+                if (vn.level > vn.threshold)
+                    newVolume = vn.threshold / vn.level;
+                else
+                    newVolume = 1f;
+
+                newVolume = Mathf.Lerp(AudioListener.volume, newVolume * GameSettings.MASTER_VOLUME, vn.sharpness * Time.deltaTime);
+            }
+            else
+            {
+                newVolume = Mathf.Lerp(AudioListener.volume, GameSettings.MASTER_VOLUME, vn.sharpness * Time.deltaTime);
+            }
+
+            if (newVolume != vn.volume)
+                AudioListener.volume = newVolume;
+
+            vn.volume = newVolume;
         }
     }
 }

--- a/KSPCommunityFixes/Performance/MinorPerfTweaks.cs
+++ b/KSPCommunityFixes/Performance/MinorPerfTweaks.cs
@@ -1,0 +1,30 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace KSPCommunityFixes.Performance
+{
+    internal class MinorPerfTweaks : BasePatch
+    {
+        protected override Version VersionMin => new Version(1, 12, 3);
+
+        protected override void ApplyPatches(List<PatchInfo> patches)
+        {
+            patches.Add(new PatchInfo(
+                PatchMethodType.Transpiler,
+                AccessTools.Method(typeof(Part), nameof(Part.isKerbalEVA)),
+                this));
+        }
+
+        private static IEnumerable<CodeInstruction> Part_isKerbalEVA_Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            MethodInfo isKerbalEVAFast = AccessTools.Method(typeof(KSPObjectsExtensions), nameof(KSPObjectsExtensions.IsKerbalEVA));
+
+            yield return new CodeInstruction(OpCodes.Ldarg_0);
+            yield return new CodeInstruction(OpCodes.Call, isKerbalEVAFast);
+            yield return new CodeInstruction(OpCodes.Ret);
+        }
+    }
+}

--- a/KSPCommunityFixes/Performance/MinorPerfTweaks.cs
+++ b/KSPCommunityFixes/Performance/MinorPerfTweaks.cs
@@ -45,7 +45,6 @@ namespace KSPCommunityFixes.Performance
 
         // setting AudioListener.volume is actually quite costly (0.7% of the frame time),
         // so avoid setting it when the value hasn't actually changed...
-        [TranspileInDebug]
         private static void VolumeNormalizer_Update_Override(VolumeNormalizer vn)
         {
             float newVolume;

--- a/KSPCommunityFixes/Performance/MinorPerfTweaks.cs
+++ b/KSPCommunityFixes/Performance/MinorPerfTweaks.cs
@@ -9,15 +9,11 @@ namespace KSPCommunityFixes.Performance
     {
         protected override Version VersionMin => new Version(1, 12, 3);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Override,
-                AccessTools.Method(typeof(Part), nameof(Part.isKerbalEVA))));
+            AddPatch(PatchType.Override, typeof(Part), nameof(Part.isKerbalEVA));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Override,
-                AccessTools.Method(typeof(VolumeNormalizer), nameof(VolumeNormalizer.Update))));
+            AddPatch(PatchType.Override, typeof(VolumeNormalizer), nameof(VolumeNormalizer.Update));
         }
 
         // Called (sometimes multiple times) in Part.FixedUpdate()

--- a/KSPCommunityFixes/Performance/ModuleDockingNodeFindOtherNodesFaster.cs
+++ b/KSPCommunityFixes/Performance/ModuleDockingNodeFindOtherNodesFaster.cs
@@ -14,15 +14,11 @@ namespace KSPCommunityFixes.Performance
     {
         protected override Version VersionMin => new Version(1, 12, 3);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.FindNodeApproaches))));
+            AddPatch(PatchType.Prefix, typeof(ModuleDockingNode), nameof(ModuleDockingNode.FindNodeApproaches));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnLoad))));
+            AddPatch(PatchType.Postfix, typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnLoad));
         }
 
         // Very unlikely to be necessary, but in theory nodeType could differ from the string stored 

--- a/KSPCommunityFixes/Performance/ModuleDockingNodeFindOtherNodesFaster.cs
+++ b/KSPCommunityFixes/Performance/ModuleDockingNodeFindOtherNodesFaster.cs
@@ -1,0 +1,103 @@
+﻿// ModuleDockingNode.FindNodeApproaches() is called n² times where n is the amount of loaded docking port modules in the scene.
+// We optimize the method, mainly by avoiding going through the hashset of modules types if there is only one type defined
+// which is seemingly always the case (I didn't found any stock or modded part having multiple ones).
+// Test case with 20 docking ports : 1.6% of the frame time in stock, 0.8% with the patch
+
+using System;
+using HarmonyLib;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace KSPCommunityFixes.Performance
+{
+    internal class ModuleDockingNodeFindOtherNodesFaster : BasePatch
+    {
+        protected override Version VersionMin => new Version(1, 12, 3);
+
+        protected override void ApplyPatches(List<PatchInfo> patches)
+        {
+            patches.Add(new PatchInfo(
+                PatchMethodType.Prefix,
+                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.FindNodeApproaches)),
+                this));
+
+            patches.Add(new PatchInfo(
+                PatchMethodType.Postfix,
+                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnLoad)),
+                this));
+        }
+
+        // Very unlikely to be necessary, but in theory nodeType could differ from the string stored 
+        // in the nodeTypes hashset due to space chars sanitizing.
+        private static void ModuleDockingNode_OnLoad_Postfix(ModuleDockingNode __instance)
+        {
+            if (__instance.nodeTypes.Count == 1)
+                __instance.nodeType = __instance.nodeTypes.First();
+        }
+
+        private static bool ModuleDockingNode_FindNodeApproaches_Prefix(ModuleDockingNode __instance, out ModuleDockingNode __result)
+        {
+            __result = null;
+            if (__instance.part.packed)
+                return false;
+
+            for (int i = FlightGlobals.VesselsLoaded.Count; i-- > 0;)
+            {
+                Vessel vessel = FlightGlobals.VesselsLoaded[i];
+
+                if (vessel.packed)
+                    continue;
+
+                for (int j = vessel.dockingPorts.Count; j-- > 0;)
+                {
+                    if (!(vessel.dockingPorts[j] is ModuleDockingNode other))
+                        continue;
+
+                    if (other.part.IsNullOrDestroyed()
+                        || other.part.RefEquals(__instance.part)
+                        || other.part.State == PartStates.DEAD
+                        || other.state != __instance.st_ready.name
+                        || other.gendered != __instance.gendered
+                        || (__instance.gendered && other.genderFemale == __instance.genderFemale)
+                        || other.snapRotation != __instance.snapRotation
+                        || (__instance.snapRotation && other.snapOffset != __instance.snapOffset))
+                    {
+                        continue;
+                    }
+
+                    bool checkRequired = false;
+                    // fast path when only one node type
+                    if (__instance.nodeTypes.Count == 1)
+                    {
+                        if (other.nodeTypes.Count == 1)
+                            checkRequired = __instance.nodeType == other.nodeType;
+                        else
+                            checkRequired = other.nodeTypes.Contains(__instance.nodeType);
+                    }
+                    // slow path checking the hashSet
+                    else
+                    {
+                        foreach (string nodeType in __instance.nodeTypes)
+                        {
+                            if (other.nodeTypes.Count == 1)
+                                checkRequired = nodeType == other.nodeType;
+                            else
+                                checkRequired = other.nodeTypes.Contains(nodeType);
+
+                            if (checkRequired)
+                                break;
+                        }
+                    }
+
+                    if (checkRequired && __instance.CheckDockContact(__instance, other, __instance.acquireRange, __instance.acquireMinFwdDot, __instance.acquireMinRollDot))
+                    {
+                        __result = other;
+                        return false;
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/KSPCommunityFixes/Performance/ModuleDockingNodeFindOtherNodesFaster.cs
+++ b/KSPCommunityFixes/Performance/ModuleDockingNodeFindOtherNodesFaster.cs
@@ -18,13 +18,11 @@ namespace KSPCommunityFixes.Performance
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.FindNodeApproaches)),
-                this));
+                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.FindNodeApproaches))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnLoad)),
-                this));
+                AccessTools.Method(typeof(ModuleDockingNode), nameof(ModuleDockingNode.OnLoad))));
         }
 
         // Very unlikely to be necessary, but in theory nodeType could differ from the string stored 

--- a/KSPCommunityFixes/Performance/OnDemandPartBuoyancy.cs
+++ b/KSPCommunityFixes/Performance/OnDemandPartBuoyancy.cs
@@ -20,8 +20,7 @@ namespace KSPCommunityFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(PartBuoyancy), "FixedUpdate"),
-                this));
+                AccessTools.Method(typeof(PartBuoyancy), nameof(PartBuoyancy.FixedUpdate))));
 
             GameEvents.onLevelWasLoaded.Add(OnLevelLoaded);
         }

--- a/KSPCommunityFixes/Performance/OnDemandPartBuoyancy.cs
+++ b/KSPCommunityFixes/Performance/OnDemandPartBuoyancy.cs
@@ -16,11 +16,9 @@ namespace KSPCommunityFixes
         private static float lastFixedTime;
         
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(PartBuoyancy), nameof(PartBuoyancy.FixedUpdate))));
+            AddPatch(PatchType.Prefix, typeof(PartBuoyancy), nameof(PartBuoyancy.FixedUpdate));
 
             GameEvents.onLevelWasLoaded.Add(OnLevelLoaded);
         }

--- a/KSPCommunityFixes/Performance/OptimizedModuleRaycasts.cs
+++ b/KSPCommunityFixes/Performance/OptimizedModuleRaycasts.cs
@@ -18,13 +18,11 @@ namespace KSPCommunityFixes.Performance
         {
             patches.Add(
                 new PatchInfo(PatchMethodType.Transpiler,
-                    AccessTools.Method(typeof(ModuleEngines), nameof(ModuleEngines.EngineExhaustDamage)),
-                    this));
+                    AccessTools.Method(typeof(ModuleEngines), nameof(ModuleEngines.EngineExhaustDamage))));
 
             patches.Add(
                 new PatchInfo(PatchMethodType.Prefix,
-                    AccessTools.Method(typeof(ModuleDeployableSolarPanel), nameof(ModuleDeployableSolarPanel.CalculateTrackingLOS)),
-                    this));
+                    AccessTools.Method(typeof(ModuleDeployableSolarPanel), nameof(ModuleDeployableSolarPanel.CalculateTrackingLOS))));
 
             KSPCommunityFixes.Instance.StartCoroutine(ResetSyncOnFixedEnd());
         }

--- a/KSPCommunityFixes/Performance/OptimizedModuleRaycasts.cs
+++ b/KSPCommunityFixes/Performance/OptimizedModuleRaycasts.cs
@@ -14,15 +14,11 @@ namespace KSPCommunityFixes.Performance
 
         protected override Version VersionMin => new Version(1, 12, 3);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(
-                new PatchInfo(PatchMethodType.Transpiler,
-                    AccessTools.Method(typeof(ModuleEngines), nameof(ModuleEngines.EngineExhaustDamage))));
+            AddPatch(PatchType.Transpiler, typeof(ModuleEngines), nameof(ModuleEngines.EngineExhaustDamage));
 
-            patches.Add(
-                new PatchInfo(PatchMethodType.Prefix,
-                    AccessTools.Method(typeof(ModuleDeployableSolarPanel), nameof(ModuleDeployableSolarPanel.CalculateTrackingLOS))));
+            AddPatch(PatchType.Prefix, typeof(ModuleDeployableSolarPanel), nameof(ModuleDeployableSolarPanel.CalculateTrackingLOS));
 
             KSPCommunityFixes.Instance.StartCoroutine(ResetSyncOnFixedEnd());
         }

--- a/KSPCommunityFixes/Performance/PQSCoroutineLeak.cs
+++ b/KSPCommunityFixes/Performance/PQSCoroutineLeak.cs
@@ -18,13 +18,11 @@ namespace KSPCommunityFixes.Performance
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(PQS), nameof(PQS.StartSphere)),
-                this));
+                AccessTools.Method(typeof(PQS), nameof(PQS.StartSphere))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(PQS), nameof(PQS.ResetAndWait)),
-                this));
+                AccessTools.Method(typeof(PQS), nameof(PQS.ResetAndWait))));
         }
 
         // StartCoroutine(UpdateSphere());

--- a/KSPCommunityFixes/Performance/PQSCoroutineLeak.cs
+++ b/KSPCommunityFixes/Performance/PQSCoroutineLeak.cs
@@ -14,15 +14,11 @@ namespace KSPCommunityFixes.Performance
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(PQS), nameof(PQS.StartSphere))));
+            AddPatch(PatchType.Transpiler, typeof(PQS), nameof(PQS.StartSphere));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(PQS), nameof(PQS.ResetAndWait))));
+            AddPatch(PatchType.Transpiler, typeof(PQS), nameof(PQS.ResetAndWait));
         }
 
         // StartCoroutine(UpdateSphere());

--- a/KSPCommunityFixes/Performance/PQSUpdateNoMemoryAlloc.cs
+++ b/KSPCommunityFixes/Performance/PQSUpdateNoMemoryAlloc.cs
@@ -11,11 +11,9 @@ namespace KSPCommunityFixes.Performance
         // 
         protected override Version VersionMin => new Version(1, 11, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(PQS), nameof(PQS.BuildTangents))));
+            AddPatch(PatchType.Prefix, typeof(PQS), nameof(PQS.BuildTangents));
         }
 
         static bool PQS_BuildTangents_Prefix(PQ quad)

--- a/KSPCommunityFixes/Performance/PQSUpdateNoMemoryAlloc.cs
+++ b/KSPCommunityFixes/Performance/PQSUpdateNoMemoryAlloc.cs
@@ -15,8 +15,7 @@ namespace KSPCommunityFixes.Performance
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(PQS), nameof(PQS.BuildTangents)),
-                this));
+                AccessTools.Method(typeof(PQS), nameof(PQS.BuildTangents))));
         }
 
         static bool PQS_BuildTangents_Prefix(PQ quad)

--- a/KSPCommunityFixes/Performance/PartSystemsFastUpdate.cs
+++ b/KSPCommunityFixes/Performance/PartSystemsFastUpdate.cs
@@ -13,19 +13,13 @@ namespace KSPCommunityFixes.Performance
     {
         protected override Version VersionMin => new Version(1, 12, 3);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(TemperatureGaugeSystem), nameof(TemperatureGaugeSystem.Update))));
+            AddPatch(PatchType.Prefix, typeof(TemperatureGaugeSystem), nameof(TemperatureGaugeSystem.Update));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(Highlighter), nameof(Highlighter.UpdateRenderers))));
+            AddPatch(PatchType.Prefix, typeof(Highlighter), nameof(Highlighter.UpdateRenderers));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(CModuleLinkedMesh), nameof(CModuleLinkedMesh.TrackAnchor))));
+            AddPatch(PatchType.Prefix, typeof(CModuleLinkedMesh), nameof(CModuleLinkedMesh.TrackAnchor));
 
             // next thing to look into : Part.Update calling GetBlackBodyRadiation() all the time, even when no renderers in temperatureRenderer : 1% frame time with 1000 parts.
         }

--- a/KSPCommunityFixes/Performance/ProgressTrackingSpeedBoost.cs
+++ b/KSPCommunityFixes/Performance/ProgressTrackingSpeedBoost.cs
@@ -6,16 +6,12 @@ namespace KSPCommunityFixes.Performance
 {
     public class ProgressTrackingSpeedBoost : BasePatch
     {
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ProgressTracking), nameof(ProgressTracking.Update))));
+            AddPatch(PatchType.Prefix, typeof(ProgressTracking), nameof(ProgressTracking.Update));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.DeclaredConstructor(typeof(KSPAchievements.CelestialBodySubtree), new Type[] { typeof(CelestialBody) }),
-                nameof(CelestialBodySubtree_Constructor_Postfix)));
+            AddPatch(PatchType.Postfix, AccessTools.DeclaredConstructor(typeof(KSPAchievements.CelestialBodySubtree), new Type[] { typeof(CelestialBody) }),
+                nameof(CelestialBodySubtree_Constructor_Postfix));
         }
 
         static bool ProgressTracking_Update_Prefix(ProgressTracking __instance)

--- a/KSPCommunityFixes/Performance/ProgressTrackingSpeedBoost.cs
+++ b/KSPCommunityFixes/Performance/ProgressTrackingSpeedBoost.cs
@@ -10,13 +10,11 @@ namespace KSPCommunityFixes.Performance
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ProgressTracking), nameof(ProgressTracking.Update)),
-                this));
+                AccessTools.Method(typeof(ProgressTracking), nameof(ProgressTracking.Update))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
                 AccessTools.DeclaredConstructor(typeof(KSPAchievements.CelestialBodySubtree), new Type[] { typeof(CelestialBody) }),
-                this,
                 nameof(CelestialBodySubtree_Constructor_Postfix)));
         }
 

--- a/KSPCommunityFixes/Performance/SceneLoadSpeedBoost.cs
+++ b/KSPCommunityFixes/Performance/SceneLoadSpeedBoost.cs
@@ -20,15 +20,11 @@ namespace KSPCommunityFixes
 
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(GamePersistence), "SaveGame", new Type[] { typeof(Game), typeof(string), typeof(string), typeof(SaveMode) })));
+            AddPatch(PatchType.Transpiler, typeof(GamePersistence), "SaveGame", new Type[] { typeof(Game), typeof(string), typeof(string), typeof(SaveMode) });
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(GamePersistence), "LoadGame", new Type[] { typeof(string), typeof(string), typeof(bool), typeof(bool) })));
+            AddPatch(PatchType.Transpiler, typeof(GamePersistence), "LoadGame", new Type[] { typeof(string), typeof(string), typeof(bool), typeof(bool) });
 
             //patches.Add(new PatchInfo(
             //    PatchMethodType.Prefix,

--- a/KSPCommunityFixes/Performance/SceneLoadSpeedBoost.cs
+++ b/KSPCommunityFixes/Performance/SceneLoadSpeedBoost.cs
@@ -24,13 +24,11 @@ namespace KSPCommunityFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(GamePersistence), "SaveGame", new Type[] { typeof(Game), typeof(string), typeof(string), typeof(SaveMode) }),
-                this));
+                AccessTools.Method(typeof(GamePersistence), "SaveGame", new Type[] { typeof(Game), typeof(string), typeof(string), typeof(SaveMode) })));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(GamePersistence), "LoadGame", new Type[] { typeof(string), typeof(string), typeof(bool), typeof(bool) }),
-                this));
+                AccessTools.Method(typeof(GamePersistence), "LoadGame", new Type[] { typeof(string), typeof(string), typeof(bool), typeof(bool) })));
 
             //patches.Add(new PatchInfo(
             //    PatchMethodType.Prefix,

--- a/KSPCommunityFixes/Properties/AssemblyInfo.cs
+++ b/KSPCommunityFixes/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //      Revision
 //
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.35.0.0")]
+[assembly: AssemblyFileVersion("1.35.1.0")]
 
-[assembly: KSPAssembly("KSPCommunityFixes", 1, 35, 0)]
+[assembly: KSPAssembly("KSPCommunityFixes", 1, 35, 1)]
 [assembly: KSPAssemblyDependency("MultipleModulePartAPI", 1, 0, 0)]

--- a/KSPCommunityFixes/Properties/AssemblyInfo.cs
+++ b/KSPCommunityFixes/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //      Revision
 //
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.35.1.0")]
+[assembly: AssemblyFileVersion("1.35.2.0")]
 
-[assembly: KSPAssembly("KSPCommunityFixes", 1, 35, 1)]
+[assembly: KSPAssembly("KSPCommunityFixes", 1, 35, 2)]
 [assembly: KSPAssemblyDependency("MultipleModulePartAPI", 1, 0, 0)]

--- a/KSPCommunityFixes/QoL/AltimeterHorizontalPosition.cs
+++ b/KSPCommunityFixes/QoL/AltimeterHorizontalPosition.cs
@@ -40,13 +40,11 @@ namespace KSPCommunityFixes
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(MapView), nameof(MapView.enterMapView)),
-                this));
+                AccessTools.Method(typeof(MapView), nameof(MapView.enterMapView))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(MapView), nameof(MapView.exitMapView)),
-                this));
+                AccessTools.Method(typeof(MapView), nameof(MapView.exitMapView))));
         }
 
         public static float altimeterPosition = -1f;

--- a/KSPCommunityFixes/QoL/AltimeterHorizontalPosition.cs
+++ b/KSPCommunityFixes/QoL/AltimeterHorizontalPosition.cs
@@ -34,17 +34,13 @@ namespace KSPCommunityFixes
 
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
             GameEvents.onGUIApplicationLauncherReady.Add(OnGUIApplicationLauncherReady);
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(MapView), nameof(MapView.enterMapView))));
+            AddPatch(PatchType.Prefix, typeof(MapView), nameof(MapView.enterMapView));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(MapView), nameof(MapView.exitMapView))));
+            AddPatch(PatchType.Postfix, typeof(MapView), nameof(MapView.exitMapView));
         }
 
         public static float altimeterPosition = -1f;

--- a/KSPCommunityFixes/QoL/AutoSavedCraftNameAtLaunch.cs
+++ b/KSPCommunityFixes/QoL/AutoSavedCraftNameAtLaunch.cs
@@ -10,12 +10,10 @@ namespace KSPCommunityFixes.QoL
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Constructor(typeof(VesselSpawnDialog.VesselDataItem), new Type[] {typeof(FileInfo), typeof(bool), typeof(bool)}),
-                nameof(VesselDataItem_Ctor_Postfix)));
+            AddPatch(PatchType.Postfix, AccessTools.Constructor(typeof(VesselSpawnDialog.VesselDataItem), new Type[] { typeof(FileInfo), typeof(bool), typeof(bool) }),
+                nameof(VesselDataItem_Ctor_Postfix));
         }
 
         static void VesselDataItem_Ctor_Postfix(VesselSpawnDialog.VesselDataItem __instance, FileInfo fInfo, bool steamItem)

--- a/KSPCommunityFixes/QoL/AutoSavedCraftNameAtLaunch.cs
+++ b/KSPCommunityFixes/QoL/AutoSavedCraftNameAtLaunch.cs
@@ -15,7 +15,7 @@ namespace KSPCommunityFixes.QoL
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
                 AccessTools.Constructor(typeof(VesselSpawnDialog.VesselDataItem), new Type[] {typeof(FileInfo), typeof(bool), typeof(bool)}),
-                this, nameof(VesselDataItem_Ctor_Postfix)));
+                nameof(VesselDataItem_Ctor_Postfix)));
         }
 
         static void VesselDataItem_Ctor_Postfix(VesselSpawnDialog.VesselDataItem __instance, FileInfo fInfo, bool steamItem)

--- a/KSPCommunityFixes/QoL/AutostrutActions.cs
+++ b/KSPCommunityFixes/QoL/AutostrutActions.cs
@@ -16,15 +16,11 @@ namespace KSPCommunityFixes.QoL
 
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Part), nameof(Part.Awake))));
+            AddPatch(PatchType.Postfix, typeof(Part), nameof(Part.Awake));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(Part), nameof(Part.ModulesOnStartFinished))));
+            AddPatch(PatchType.Prefix, typeof(Part), nameof(Part.ModulesOnStartFinished));
 
             kspActionAutostrutOff = new KSPAction(Localizer.Format("#autoLOC_6001318"), KSPActionGroup.None, true); // Autostrut: Disabled
             kspActionAutostrutRoot = new KSPAction(Localizer.Format("#autoLOC_6001320"), KSPActionGroup.None, true); // Autostrut: Root Part

--- a/KSPCommunityFixes/QoL/AutostrutActions.cs
+++ b/KSPCommunityFixes/QoL/AutostrutActions.cs
@@ -20,13 +20,11 @@ namespace KSPCommunityFixes.QoL
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Part), nameof(Part.Awake)),
-                this));
+                AccessTools.Method(typeof(Part), nameof(Part.Awake))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(Part), nameof(Part.ModulesOnStartFinished)),
-                this));
+                AccessTools.Method(typeof(Part), nameof(Part.ModulesOnStartFinished))));
 
             kspActionAutostrutOff = new KSPAction(Localizer.Format("#autoLOC_6001318"), KSPActionGroup.None, true); // Autostrut: Disabled
             kspActionAutostrutRoot = new KSPAction(Localizer.Format("#autoLOC_6001320"), KSPActionGroup.None, true); // Autostrut: Root Part

--- a/KSPCommunityFixes/QoL/BetterEditorUndoRedo.cs
+++ b/KSPCommunityFixes/QoL/BetterEditorUndoRedo.cs
@@ -58,79 +58,72 @@ namespace KSPCommunityFixes.QoL
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(EditorLogic), nameof(EditorLogic.RestoreState)),
-                this));
+                AccessTools.Method(typeof(EditorLogic), nameof(EditorLogic.RestoreState))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(EditorLogic), nameof(EditorLogic.SetupFSM)),
-                this));
+                AccessTools.Method(typeof(EditorLogic), nameof(EditorLogic.SetupFSM))));
 
             // Create backup before moving a part with the rotate/offset tools, instead of after
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(GizmoOffset), nameof(GizmoOffset.OnHandleMoveStart)),
-                this));
+                AccessTools.Method(typeof(GizmoOffset), nameof(GizmoOffset.OnHandleMoveStart))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(GizmoRotate), nameof(GizmoRotate.OnHandleRotateStart)),
-                this));
+                AccessTools.Method(typeof(GizmoRotate), nameof(GizmoRotate.OnHandleRotateStart))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
                 AccessTools.Method(typeof(EditorLogic), nameof(EditorLogic.onRotateGizmoUpdated)),
-                this, nameof(CallModifiedInsteadOfBackupTranspiler)));
+                nameof(CallModifiedInsteadOfBackupTranspiler)));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
                 AccessTools.Method(typeof(EditorLogic), nameof(EditorLogic.onOffsetGizmoUpdated)),
-                this, nameof(CallModifiedInsteadOfBackupTranspiler)));
+                nameof(CallModifiedInsteadOfBackupTranspiler)));
 
             // Create backup before selecting a variant, instead of after
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(UIPartActionVariantSelector), nameof(UIPartActionVariantSelector.SelectVariant)),
-                this));
+                AccessTools.Method(typeof(UIPartActionVariantSelector), nameof(UIPartActionVariantSelector.SelectVariant))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
                 AccessTools.Method(typeof(ModulePartVariants), nameof(ModulePartVariants.onVariantChanged)),
-                this, nameof(CallModifiedInsteadOfBackupTranspiler)));
+                nameof(CallModifiedInsteadOfBackupTranspiler)));
 
             // Move backup creation at the begining of the following methods :
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
                 AccessTools.Method(typeof(Part), nameof(Part.RemoveFromSymmetry)),
-                this, nameof(MoveSetBackupAtStartTranspiler)));
+                nameof(MoveSetBackupAtStartTranspiler)));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
                 AccessTools.Method(typeof(EditorActionGroups), nameof(EditorActionGroups.ResetPart), new []{typeof(EditorActionPartSelector)}),
-                this, nameof(MoveSetBackupAtStartTranspiler)));
+                nameof(MoveSetBackupAtStartTranspiler)));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
                 AccessTools.Method(typeof(EditorActionGroups), nameof(EditorActionGroups.AddActionToGroup)),
-                this, nameof(MoveSetBackupAtStartTranspiler)));
+                nameof(MoveSetBackupAtStartTranspiler)));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
                 AccessTools.Method(typeof(EditorActionGroups), nameof(EditorActionGroups.RemoveActionFromGroup)),
-                this, nameof(MoveSetBackupAtStartTranspiler)));
+                nameof(MoveSetBackupAtStartTranspiler)));
 
 #if BEUR_DEBUG
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(EditorLogic), nameof(EditorLogic.SetBackup)),
-                this));
+                AccessTools.Method(typeof(EditorLogic), nameof(EditorLogic.SetBackup))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(EditorLogic), nameof(EditorLogic.RestoreState)),
-                this));
+                AccessTools.Method(typeof(EditorLogic), nameof(EditorLogic.RestoreState))));
 #endif
         }
 

--- a/KSPCommunityFixes/QoL/BetterEditorUndoRedo.cs
+++ b/KSPCommunityFixes/QoL/BetterEditorUndoRedo.cs
@@ -46,7 +46,7 @@ namespace KSPCommunityFixes.QoL
 
         protected override Version VersionMin => new Version(1, 12, 3); // too many changes in previous versions, too lazy to check
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
             m_EditorLogic_SetBackup = AccessTools.Method(typeof(EditorLogic), nameof(EditorLogic.SetBackup));
             m_EditorLogicSetBackupNoShipModifiedEvent = AccessTools.Method(typeof(BetterEditorUndoRedo), nameof(EditorLogicSetBackupNoShipModifiedEvent));
@@ -56,65 +56,34 @@ namespace KSPCommunityFixes.QoL
             m_RefreshCrewAssignmentFromLiveState = AccessTools.Method(typeof(BetterEditorUndoRedo), nameof(RefreshCrewAssignmentFromLiveState));
             m_ShipConstruct_Contains = AccessTools.Method(typeof(ShipConstruct), nameof(ShipConstruct.Contains), new[] { typeof(Part) });
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(EditorLogic), nameof(EditorLogic.RestoreState))));
+            AddPatch(PatchType.Prefix, typeof(EditorLogic), nameof(EditorLogic.RestoreState));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(EditorLogic), nameof(EditorLogic.SetupFSM))));
+            AddPatch(PatchType.Postfix, typeof(EditorLogic), nameof(EditorLogic.SetupFSM));
 
             // Create backup before moving a part with the rotate/offset tools, instead of after
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(GizmoOffset), nameof(GizmoOffset.OnHandleMoveStart))));
+            AddPatch(PatchType.Prefix, typeof(GizmoOffset), nameof(GizmoOffset.OnHandleMoveStart));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(GizmoRotate), nameof(GizmoRotate.OnHandleRotateStart))));
+            AddPatch(PatchType.Prefix, typeof(GizmoRotate), nameof(GizmoRotate.OnHandleRotateStart));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(EditorLogic), nameof(EditorLogic.onRotateGizmoUpdated)),
-                nameof(CallModifiedInsteadOfBackupTranspiler)));
+            AddPatch(PatchType.Transpiler, typeof(EditorLogic), nameof(EditorLogic.onRotateGizmoUpdated), nameof(CallModifiedInsteadOfBackupTranspiler));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(EditorLogic), nameof(EditorLogic.onOffsetGizmoUpdated)),
-                nameof(CallModifiedInsteadOfBackupTranspiler)));
+            AddPatch(PatchType.Transpiler, typeof(EditorLogic), nameof(EditorLogic.onOffsetGizmoUpdated), nameof(CallModifiedInsteadOfBackupTranspiler));
 
             // Create backup before selecting a variant, instead of after
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(UIPartActionVariantSelector), nameof(UIPartActionVariantSelector.SelectVariant))));
+            AddPatch(PatchType.Prefix, typeof(UIPartActionVariantSelector), nameof(UIPartActionVariantSelector.SelectVariant));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(ModulePartVariants), nameof(ModulePartVariants.onVariantChanged)),
-                nameof(CallModifiedInsteadOfBackupTranspiler)));
+            AddPatch(PatchType.Transpiler, typeof(ModulePartVariants), nameof(ModulePartVariants.onVariantChanged), nameof(CallModifiedInsteadOfBackupTranspiler));
 
             // Move backup creation at the begining of the following methods :
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(Part), nameof(Part.RemoveFromSymmetry)),
-                nameof(MoveSetBackupAtStartTranspiler)));
+            AddPatch(PatchType.Transpiler, typeof(Part), nameof(Part.RemoveFromSymmetry), nameof(MoveSetBackupAtStartTranspiler));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(EditorActionGroups), nameof(EditorActionGroups.ResetPart), new []{typeof(EditorActionPartSelector)}),
-                nameof(MoveSetBackupAtStartTranspiler)));
+            AddPatch(PatchType.Transpiler, typeof(EditorActionGroups), nameof(EditorActionGroups.ResetPart), new []{typeof(EditorActionPartSelector)}, nameof(MoveSetBackupAtStartTranspiler));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(EditorActionGroups), nameof(EditorActionGroups.AddActionToGroup)),
-                nameof(MoveSetBackupAtStartTranspiler)));
+            AddPatch(PatchType.Transpiler, typeof(EditorActionGroups), nameof(EditorActionGroups.AddActionToGroup), nameof(MoveSetBackupAtStartTranspiler));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(EditorActionGroups), nameof(EditorActionGroups.RemoveActionFromGroup)),
-                nameof(MoveSetBackupAtStartTranspiler)));
+            AddPatch(PatchType.Transpiler, typeof(EditorActionGroups), nameof(EditorActionGroups.RemoveActionFromGroup), nameof(MoveSetBackupAtStartTranspiler));
 
 #if BEUR_DEBUG
             patches.Add(new PatchInfo(

--- a/KSPCommunityFixes/QoL/DisableManeuverTool.cs
+++ b/KSPCommunityFixes/QoL/DisableManeuverTool.cs
@@ -30,8 +30,7 @@ namespace KSPCommunityFixes.QoL
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix, 
-                AccessTools.Method(typeof(ManeuverTool), "OnAppAboutToStart"), 
-                this));
+                AccessTools.Method(typeof(ManeuverTool), "OnAppAboutToStart")));
         }
 
         public static bool alwaysDisabled = false;

--- a/KSPCommunityFixes/QoL/DisableManeuverTool.cs
+++ b/KSPCommunityFixes/QoL/DisableManeuverTool.cs
@@ -15,7 +15,7 @@ namespace KSPCommunityFixes.QoL
 
         protected override Version VersionMin => new Version(1, 12, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
             ConfigNode defaultsNode = KSPCommunityFixes.SettingsNode.GetNode("MANEUVER_TOOL_DEFAULTS");
 
@@ -28,9 +28,7 @@ namespace KSPCommunityFixes.QoL
             if (alwaysDisabled)
                 enableManeuverTool = false;
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix, 
-                AccessTools.Method(typeof(ManeuverTool), "OnAppAboutToStart")));
+            AddPatch(PatchType.Prefix, typeof(ManeuverTool), "OnAppAboutToStart");
         }
 
         public static bool alwaysDisabled = false;

--- a/KSPCommunityFixes/QoL/DisableNewGameIntro.cs
+++ b/KSPCommunityFixes/QoL/DisableNewGameIntro.cs
@@ -8,11 +8,9 @@ namespace KSPCommunityFixes.QoL
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ScenarioNewGameIntro), nameof(ScenarioNewGameIntro.OnAwake))));
+            AddPatch(PatchType.Prefix, typeof(ScenarioNewGameIntro), nameof(ScenarioNewGameIntro.OnAwake));
         }
 
         static void ScenarioNewGameIntro_OnAwake_Prefix(ScenarioNewGameIntro __instance)

--- a/KSPCommunityFixes/QoL/DisableNewGameIntro.cs
+++ b/KSPCommunityFixes/QoL/DisableNewGameIntro.cs
@@ -12,8 +12,7 @@ namespace KSPCommunityFixes.QoL
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ScenarioNewGameIntro), nameof(ScenarioNewGameIntro.OnAwake)),
-                this));
+                AccessTools.Method(typeof(ScenarioNewGameIntro), nameof(ScenarioNewGameIntro.OnAwake))));
         }
 
         static void ScenarioNewGameIntro_OnAwake_Prefix(ScenarioNewGameIntro __instance)

--- a/KSPCommunityFixes/QoL/FairingMouseOverPersistence.cs
+++ b/KSPCommunityFixes/QoL/FairingMouseOverPersistence.cs
@@ -8,15 +8,11 @@ namespace KSPCommunityFixes.QoL
     {
         protected override Version VersionMin => new Version(1, 10, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleProceduralFairing), nameof(ModuleProceduralFairing.OnSave))));
+            AddPatch(PatchType.Prefix, typeof(ModuleProceduralFairing), nameof(ModuleProceduralFairing.OnSave));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleProceduralFairing), nameof(ModuleProceduralFairing.OnLoad))));
+            AddPatch(PatchType.Prefix, typeof(ModuleProceduralFairing), nameof(ModuleProceduralFairing.OnLoad));
         }
 
         private static void ModuleProceduralFairing_OnSave_Prefix(ModuleProceduralFairing __instance, ConfigNode node)

--- a/KSPCommunityFixes/QoL/FairingMouseOverPersistence.cs
+++ b/KSPCommunityFixes/QoL/FairingMouseOverPersistence.cs
@@ -12,13 +12,11 @@ namespace KSPCommunityFixes.QoL
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleProceduralFairing), nameof(ModuleProceduralFairing.OnSave)),
-                this));
+                AccessTools.Method(typeof(ModuleProceduralFairing), nameof(ModuleProceduralFairing.OnSave))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleProceduralFairing), nameof(ModuleProceduralFairing.OnLoad)),
-                this));
+                AccessTools.Method(typeof(ModuleProceduralFairing), nameof(ModuleProceduralFairing.OnLoad))));
         }
 
         private static void ModuleProceduralFairing_OnSave_Prefix(ModuleProceduralFairing __instance, ConfigNode node)

--- a/KSPCommunityFixes/QoL/OptionalMakingHistoryDLCFeatures.cs
+++ b/KSPCommunityFixes/QoL/OptionalMakingHistoryDLCFeatures.cs
@@ -18,14 +18,12 @@ namespace KSPCommunityFixes.QoL
 
         protected override Version VersionMin => new Version(1, 12, 3);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
             if (KSPCommunityFixes.SettingsNode.TryGetValue(SETTINGS_TOGGLE_VALUE_NAME, ref isMHDisabledFromConfig) && isMHDisabledFromConfig)
                 isMHEnabled = false;
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ExpansionsLoader), nameof(ExpansionsLoader.InitializeExpansion))));
+            AddPatch(PatchType.Prefix, typeof(ExpansionsLoader), nameof(ExpansionsLoader.InitializeExpansion));
         }
 
         protected override void OnLoadData(ConfigNode node)

--- a/KSPCommunityFixes/QoL/OptionalMakingHistoryDLCFeatures.cs
+++ b/KSPCommunityFixes/QoL/OptionalMakingHistoryDLCFeatures.cs
@@ -25,8 +25,7 @@ namespace KSPCommunityFixes.QoL
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ExpansionsLoader), nameof(ExpansionsLoader.InitializeExpansion)),
-                this));
+                AccessTools.Method(typeof(ExpansionsLoader), nameof(ExpansionsLoader.InitializeExpansion))));
         }
 
         protected override void OnLoadData(ConfigNode node)

--- a/KSPCommunityFixes/QoL/PAWCollapsedInventories.cs
+++ b/KSPCommunityFixes/QoL/PAWCollapsedInventories.cs
@@ -14,27 +14,17 @@ namespace KSPCommunityFixes.UI
 
         protected override Version VersionMin => new Version(1, 11, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleInventoryPart), nameof(ModuleInventoryPart.OnStart))));
+            AddPatch(PatchType.Postfix, typeof(ModuleInventoryPart), nameof(ModuleInventoryPart.OnStart));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleInventoryPart), nameof(ModuleInventoryPart.UpdateMassVolumeDisplay))));
+            AddPatch(PatchType.Postfix, typeof(ModuleInventoryPart), nameof(ModuleInventoryPart.UpdateMassVolumeDisplay));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(UIPartActionInventory), nameof(UIPartActionInventory.Setup))));
+            AddPatch(PatchType.Postfix, typeof(UIPartActionInventory), nameof(UIPartActionInventory.Setup));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(UIPartActionWindow), nameof(UIPartActionWindow.AddCrewInventory), new[] { typeof(ProtoCrewMember) })));
+            AddPatch(PatchType.Transpiler, typeof(UIPartActionWindow), nameof(UIPartActionWindow.AddCrewInventory), new[] { typeof(ProtoCrewMember) });
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(UIPartActionWindow), nameof(UIPartActionWindow.AddCrewInventory), new[] { typeof(ProtoCrewMember) })));
+            AddPatch(PatchType.Postfix, typeof(UIPartActionWindow), nameof(UIPartActionWindow.AddCrewInventory), new[] { typeof(ProtoCrewMember) });
         }
 
         static string GetGroupName(ModuleInventoryPart inventory)

--- a/KSPCommunityFixes/QoL/PAWCollapsedInventories.cs
+++ b/KSPCommunityFixes/QoL/PAWCollapsedInventories.cs
@@ -18,28 +18,23 @@ namespace KSPCommunityFixes.UI
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleInventoryPart), "OnStart"),
-                this));
+                AccessTools.Method(typeof(ModuleInventoryPart), nameof(ModuleInventoryPart.OnStart))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleInventoryPart), "UpdateMassVolumeDisplay"),
-                this));
+                AccessTools.Method(typeof(ModuleInventoryPart), nameof(ModuleInventoryPart.UpdateMassVolumeDisplay))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(UIPartActionInventory), "Setup"),
-                this));
+                AccessTools.Method(typeof(UIPartActionInventory), nameof(UIPartActionInventory.Setup))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(UIPartActionWindow), "AddCrewInventory", new[] { typeof(ProtoCrewMember) }),
-                this));
+                AccessTools.Method(typeof(UIPartActionWindow), nameof(UIPartActionWindow.AddCrewInventory), new[] { typeof(ProtoCrewMember) })));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(UIPartActionWindow), "AddCrewInventory", new[] { typeof(ProtoCrewMember) }),
-                this));
+                AccessTools.Method(typeof(UIPartActionWindow), nameof(UIPartActionWindow.AddCrewInventory), new[] { typeof(ProtoCrewMember) })));
         }
 
         static string GetGroupName(ModuleInventoryPart inventory)

--- a/KSPCommunityFixes/QoL/PAWStockGroups.cs
+++ b/KSPCommunityFixes/QoL/PAWStockGroups.cs
@@ -18,38 +18,31 @@ namespace KSPCommunityFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Part), "Start"),
-                this));
+                AccessTools.Method(typeof(Part), nameof(Part.Start))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleDataTransmitter), "OnStart"),
-                this));
+                AccessTools.Method(typeof(ModuleDataTransmitter), nameof(ModuleDataTransmitter.OnStart))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleCommand), "OnStart"),
-                this));
+                AccessTools.Method(typeof(ModuleCommand), nameof(ModuleCommand.OnStart))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleReactionWheel), "OnStart"),
-                this));
+                AccessTools.Method(typeof(ModuleReactionWheel), nameof(ModuleReactionWheel.OnStart))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleRCS), "OnStart"),
-                this));
+                AccessTools.Method(typeof(ModuleRCS), nameof(ModuleRCS.OnStart))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleGimbal), "OnStart"),
-                this));
+                AccessTools.Method(typeof(ModuleGimbal), nameof(ModuleGimbal.OnStart))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleControlSurface), "OnStart"),
-                this));
+                AccessTools.Method(typeof(ModuleControlSurface), nameof(ModuleControlSurface.OnStart))));
 
             partGroupTitle = Localizer.Format("#autoLOC_6100048"); // Part
             commsGroupTitle = Localizer.Format("#autoLOC_453582"); // Communication

--- a/KSPCommunityFixes/QoL/PAWStockGroups.cs
+++ b/KSPCommunityFixes/QoL/PAWStockGroups.cs
@@ -14,35 +14,21 @@ namespace KSPCommunityFixes
 
         protected override Version VersionMin => new Version(1, 10, 1);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Part), nameof(Part.Start))));
+            AddPatch(PatchType.Postfix, typeof(Part), nameof(Part.Start));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleDataTransmitter), nameof(ModuleDataTransmitter.OnStart))));
+            AddPatch(PatchType.Postfix, typeof(ModuleDataTransmitter), nameof(ModuleDataTransmitter.OnStart));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleCommand), nameof(ModuleCommand.OnStart))));
+            AddPatch(PatchType.Postfix, typeof(ModuleCommand), nameof(ModuleCommand.OnStart));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleReactionWheel), nameof(ModuleReactionWheel.OnStart))));
+            AddPatch(PatchType.Postfix, typeof(ModuleReactionWheel), nameof(ModuleReactionWheel.OnStart));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleRCS), nameof(ModuleRCS.OnStart))));
+            AddPatch(PatchType.Postfix, typeof(ModuleRCS), nameof(ModuleRCS.OnStart));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleGimbal), nameof(ModuleGimbal.OnStart))));
+            AddPatch(PatchType.Postfix, typeof(ModuleGimbal), nameof(ModuleGimbal.OnStart));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ModuleControlSurface), nameof(ModuleControlSurface.OnStart))));
+            AddPatch(PatchType.Postfix, typeof(ModuleControlSurface), nameof(ModuleControlSurface.OnStart));
 
             partGroupTitle = Localizer.Format("#autoLOC_6100048"); // Part
             commsGroupTitle = Localizer.Format("#autoLOC_453582"); // Communication

--- a/KSPCommunityFixes/QoL/ResourceLockActions.cs
+++ b/KSPCommunityFixes/QoL/ResourceLockActions.cs
@@ -16,11 +16,9 @@ namespace KSPCommunityFixes.QoL
 
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Part), nameof(Part.Awake))));
+            AddPatch(PatchType.Postfix, typeof(Part), nameof(Part.Awake));
 
             kspActionResourcesEnableFlow = new KSPAction(Localizer.Format("#autoLOC_444646") + ": " + Localizer.Format("#autoLOC_6001423"), KSPActionGroup.None, true); // Resources: Flow
             kspActionResourcesDisableFlow = new KSPAction(Localizer.Format("#autoLOC_444646") + ": " + Localizer.Format("#autoLOC_215362"), KSPActionGroup.None, true); // Resources: Locked

--- a/KSPCommunityFixes/QoL/ResourceLockActions.cs
+++ b/KSPCommunityFixes/QoL/ResourceLockActions.cs
@@ -20,8 +20,7 @@ namespace KSPCommunityFixes.QoL
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(Part), nameof(Part.Awake)),
-                this));
+                AccessTools.Method(typeof(Part), nameof(Part.Awake))));
 
             kspActionResourcesEnableFlow = new KSPAction(Localizer.Format("#autoLOC_444646") + ": " + Localizer.Format("#autoLOC_6001423"), KSPActionGroup.None, true); // Resources: Flow
             kspActionResourcesDisableFlow = new KSPAction(Localizer.Format("#autoLOC_444646") + ": " + Localizer.Format("#autoLOC_215362"), KSPActionGroup.None, true); // Resources: Locked

--- a/KSPCommunityFixes/QoL/ShowContractFinishDates.cs
+++ b/KSPCommunityFixes/QoL/ShowContractFinishDates.cs
@@ -16,8 +16,7 @@ namespace KSPCommunityFixes.QoL
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix, 
-                AccessTools.Method(typeof(MissionControl), "UpdateInfoPanelContract"), 
-                this));
+                AccessTools.Method(typeof(MissionControl), "UpdateInfoPanelContract")));
         }
 
         private static void MissionControl_UpdateInfoPanelContract_Postfix(MissionControl __instance, Contract contract)

--- a/KSPCommunityFixes/QoL/ShowContractFinishDates.cs
+++ b/KSPCommunityFixes/QoL/ShowContractFinishDates.cs
@@ -12,11 +12,9 @@ namespace KSPCommunityFixes.QoL
 
         protected override Version VersionMin => new Version(1, 12, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix, 
-                AccessTools.Method(typeof(MissionControl), "UpdateInfoPanelContract")));
+            AddPatch(PatchType.Postfix, typeof(MissionControl), "UpdateInfoPanelContract");
         }
 
         private static void MissionControl_UpdateInfoPanelContract_Postfix(MissionControl __instance, Contract contract)

--- a/KSPCommunityFixes/QoL/ToolbarShowHide.cs
+++ b/KSPCommunityFixes/QoL/ToolbarShowHide.cs
@@ -16,44 +16,36 @@ namespace KSPCommunityFixes.QoL
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.SpawnSimpleLayout)),
-                this));
+                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.SpawnSimpleLayout))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.OnDestroy)),
-                this));
+                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.OnDestroy))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.StartupSequence)),
-                this));
+                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.StartupSequence))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.Show)),
-                this));
+                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.Show))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.Hide)),
-                this));
+                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.Hide))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.ShouldItShow)),
-                this));
+                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.ShouldItShow))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.ShouldItHide), Type.EmptyTypes),
-                this));
+                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.ShouldItHide), Type.EmptyTypes)));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
                 AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.ShouldItHide), new Type[] { typeof(GameEvents.VesselSpawnInfo) }),
-                this,
-                "ApplicationLauncher_ShouldItHideVesselSpawn_Prefix"));
+                nameof(ApplicationLauncher_ShouldItHideVesselSpawn_Prefix)));
 
             defaultLayerId = SortingLayer.NameToID("Default");
             appsLayerId = SortingLayer.NameToID("Apps");

--- a/KSPCommunityFixes/QoL/ToolbarShowHide.cs
+++ b/KSPCommunityFixes/QoL/ToolbarShowHide.cs
@@ -12,40 +12,23 @@ namespace KSPCommunityFixes.QoL
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.SpawnSimpleLayout))));
+            AddPatch(PatchType.Postfix, typeof(ApplicationLauncher), nameof(ApplicationLauncher.SpawnSimpleLayout));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.OnDestroy))));
+            AddPatch(PatchType.Postfix, typeof(ApplicationLauncher), nameof(ApplicationLauncher.OnDestroy));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.StartupSequence))));
+            AddPatch(PatchType.Postfix, typeof(ApplicationLauncher), nameof(ApplicationLauncher.StartupSequence));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.Show))));
+            AddPatch(PatchType.Prefix, typeof(ApplicationLauncher), nameof(ApplicationLauncher.Show));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.Hide))));
+            AddPatch(PatchType.Prefix, typeof(ApplicationLauncher), nameof(ApplicationLauncher.Hide));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.ShouldItShow))));
+            AddPatch(PatchType.Prefix, typeof(ApplicationLauncher), nameof(ApplicationLauncher.ShouldItShow));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.ShouldItHide), Type.EmptyTypes)));
+            AddPatch(PatchType.Prefix, typeof(ApplicationLauncher), nameof(ApplicationLauncher.ShouldItHide), Type.EmptyTypes);
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ApplicationLauncher), nameof(ApplicationLauncher.ShouldItHide), new Type[] { typeof(GameEvents.VesselSpawnInfo) }),
-                nameof(ApplicationLauncher_ShouldItHideVesselSpawn_Prefix)));
+            AddPatch(PatchType.Prefix, typeof(ApplicationLauncher), nameof(ApplicationLauncher.ShouldItHide), new Type[] { typeof(GameEvents.VesselSpawnInfo) }, nameof(ApplicationLauncher_ShouldItHideVesselSpawn_Prefix));
 
             defaultLayerId = SortingLayer.NameToID("Default");
             appsLayerId = SortingLayer.NameToID("Apps");

--- a/KSPCommunityFixes/QoL/TweakableWheelsAutostrut.cs
+++ b/KSPCommunityFixes/QoL/TweakableWheelsAutostrut.cs
@@ -14,13 +14,11 @@ namespace KSPCommunityFixes.BugFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleWheelBase), nameof(ModuleWheelBase.OnStart)),
-                this));
+                AccessTools.Method(typeof(ModuleWheelBase), nameof(ModuleWheelBase.OnStart))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(ModuleWheelBase), nameof(ModuleWheelBase.OnStart)),
-                this));
+                AccessTools.Method(typeof(ModuleWheelBase), nameof(ModuleWheelBase.OnStart))));
 
             GameEvents.OnPartLoaderLoaded.Add(OnPartLoaderLoaded);
         }

--- a/KSPCommunityFixes/QoL/TweakableWheelsAutostrut.cs
+++ b/KSPCommunityFixes/QoL/TweakableWheelsAutostrut.cs
@@ -10,15 +10,11 @@ namespace KSPCommunityFixes.BugFixes
     {
         protected override Version VersionMin => new Version(1, 8, 0);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(ModuleWheelBase), nameof(ModuleWheelBase.OnStart))));
+            AddPatch(PatchType.Prefix, typeof(ModuleWheelBase), nameof(ModuleWheelBase.OnStart));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Transpiler,
-                AccessTools.Method(typeof(ModuleWheelBase), nameof(ModuleWheelBase.OnStart))));
+            AddPatch(PatchType.Transpiler, typeof(ModuleWheelBase), nameof(ModuleWheelBase.OnStart));
 
             GameEvents.OnPartLoaderLoaded.Add(OnPartLoaderLoaded);
         }

--- a/KSPCommunityFixes/QoL/UIFloatEditNumericInput.cs
+++ b/KSPCommunityFixes/QoL/UIFloatEditNumericInput.cs
@@ -14,19 +14,13 @@ namespace KSPCommunityFixes
         private static UIPartActionNumericFloatEdit prefab;
         private static readonly Type UI_FloatEdit_Type = typeof(UI_FloatEdit);
 
-        protected override void ApplyPatches(List<PatchInfo> patches)
+        protected override void ApplyPatches()
         {
-            patches.Add(new PatchInfo(
-                PatchMethodType.Postfix,
-                AccessTools.Method(typeof(UIPartActionController), nameof(UIPartActionController.Awake))));
+            AddPatch(PatchType.Postfix, typeof(UIPartActionController), nameof(UIPartActionController.Awake));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(UIPartActionController), nameof(UIPartActionController.GetFieldControl))));
+            AddPatch(PatchType.Prefix, typeof(UIPartActionController), nameof(UIPartActionController.GetFieldControl));
 
-            patches.Add(new PatchInfo(
-                PatchMethodType.Prefix,
-                AccessTools.Method(typeof(UIPartActionController), nameof(UIPartActionController.GetControl))));
+            AddPatch(PatchType.Prefix, typeof(UIPartActionController), nameof(UIPartActionController.GetControl));
         }
 
         static void UIPartActionController_Awake_Postfix(UIPartActionController __instance)

--- a/KSPCommunityFixes/QoL/UIFloatEditNumericInput.cs
+++ b/KSPCommunityFixes/QoL/UIFloatEditNumericInput.cs
@@ -18,18 +18,15 @@ namespace KSPCommunityFixes
         {
             patches.Add(new PatchInfo(
                 PatchMethodType.Postfix,
-                AccessTools.Method(typeof(UIPartActionController), nameof(UIPartActionController.Awake)),
-                this));
+                AccessTools.Method(typeof(UIPartActionController), nameof(UIPartActionController.Awake))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(UIPartActionController), nameof(UIPartActionController.GetFieldControl)),
-                this));
+                AccessTools.Method(typeof(UIPartActionController), nameof(UIPartActionController.GetFieldControl))));
 
             patches.Add(new PatchInfo(
                 PatchMethodType.Prefix,
-                AccessTools.Method(typeof(UIPartActionController), nameof(UIPartActionController.GetControl)),
-                this));
+                AccessTools.Method(typeof(UIPartActionController), nameof(UIPartActionController.GetControl))));
         }
 
         static void UIPartActionController_Awake_Postfix(UIPartActionController __instance)

--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ If doing so in the `Debug` configuration and if your KSP install is modified to 
 
 ### Changelog
 
+##### 1.35.1
+- **FastLoader** : fixed the PNG loader behavior not being similiar as in stock. It was wrongly generating mipmaps, notably resulting in NPOT textures not showing when texture quality wasn't set to full resolution ([see issue #224](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/224)).
+- **FastLoader** : fixed cached PNG textures loading not using the data loaded by the threaded reader, but instead reading the file again synchronously (!). Unsurprisingly, fixing that is massively improving texture loading time.
+
 ##### 1.35.0
 - New KSP performance patch : [**OptimizedModuleRaycasts**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/216) [KSP 1.12.3 - 1.12.5] : Improve engine exhaust damage and solar panel line of sight raycasts performance by avoiding extra physics state synchronization and caching solar panels scaled space raycasts results.
 - New KSP QoL/performance patch : [**OptionalMakingHistoryDLCFeatures**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/218) [KSP 1.12.3 - 1.12.5] : Allow to disable the Making History DLC mission editor and additional launch sites features to decrease memory usage and increase loading speed. The Making History parts will still be available. Can be toggled from the KSPCF in-game settings (requires a restart), or from a MM patch (see `Settings.cfg`)

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ If doing so in the `Debug` configuration and if your KSP install is modified to 
 - New KSP bugfix : [**PartBoundsIgnoreDisabledTransforms**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/208) [KSP 1.12.3 - 1.12.5] : Fix disabled renderers by mesh switchers (B9PartSwitch...) still being considered for part bounds evaluation, resulting in various issues like parts not being occluded from drag in cargo bays, wrong vessel size being reported, etc...
 - **BetterUndoRedo** : Fixed "too much undoing" when undoing offset/rotate editor actions, and other incoherent behavior (see [related issue](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/206))
 - **FastLoader** : Improved DDS loading performance by avoiding an extra copy of the DDS data
+- **MemoryLeaks** : More stock memory leaks fixed, and additional reporting of leaked handlers
 
 ##### 1.34.1
 - Disable BetterEditorUndoRedo when TweakScale/L is installed due to introducing a bug with part attachments in the editor.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ User options are available from the "ESC" in-game settings menu :<br/><img src="
 - [**CollisionManagerFastUpdate**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/174) [KSP 1.11.0 - 1.12.5]<br/>3-4 times faster update of parts inter-collision state, significantly reduce stutter on docking, undocking, decoupling and joint failure events.
 - [**LowerMinPhysicsDTPerFrame**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/175) [KSP 1.12.3 - 1.12.5]<br/>Allow a min value of 0.02 instead of 0.03 for the "Max Physics Delta-Time Per Frame" main menu setting.  This allows for higher and smoother framerate at the expense of the game lagging behind real time.
 - [**OptimizedModuleRaycasts**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/216) [KSP 1.12.3 - 1.12.5]<br/>Improve engine exhaust damage and solar panel line of sight raycasts performance by avoiding extra physics state synchronization and caching solar panels scaled space raycasts results.
+- [**ModuleDockingNodeFindOtherNodesFaster**](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/257) [KSP 1.12.3 - 1.12.5]<br/>Faster lookup of other docking nodes.
+- [**CollisionEnhancerFastUpdate**](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/257) [KSP 1.12.3 - 1.12.5]<br/>Optimization of the `CollisionEnhancer` component (responsible for part to terrain collision detection).
+- [**PartSystemsFastUpdate**](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/257) [KSP 1.12.3 - 1.12.5]<br/>Optimization of various flight scene auxiliary subsystems : temperature gauges, highlighter, strut position tracking...
+- [**MinorPerfTweaks**](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/257) [KSP 1.12.3 - 1.12.5]<br/>Various small performance patches (volume normalizer, eva module checks)
+- [**FlightIntegratorPerf**](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/257) [KSP 1.12.3 - 1.12.5]<br/>General micro-optimization of `FlightIntegrator` and `VesselPrecalculate`, components in charge of most of heavy lifting for newtonian physics as well as atmospheric and thermal physics.
+- [**FloatingOriginPerf**](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/257) [KSP 1.12.3 - 1.12.5]<br/>General micro-optimization of floating origin shifts. Main benefit is in large particle count situations (ie, launches with many engines) but this helps a bit in other cases as well.
 
 #### API and modding tools
 - **MultipleModuleInPartAPI** [KSP 1.8.0 - 1.12.5]<br/>This API allow other plugins to implement PartModules that can exist in multiple occurrence in a single part and won't suffer "module indexing mismatch" persistent data losses following part configuration changes. [See documentation on the wiki](https://github.com/KSPModdingLibs/KSPCommunityFixes/wiki/MultipleModuleInPartAPI).
@@ -189,6 +195,17 @@ The `Start` action of the IDE will trigger a build, update the `GameData` files 
 If doing so in the `Debug` configuration and if your KSP install is modified to be debuggable, you will be able to debug the code from within your IDE (if your IDE provides Unity debugging support).
 
 ### Changelog
+
+##### vNext
+- New KSP performance patches : this update introduce a collection of patches intended to fix various performance bottlenecks mainly relevant in high part count situations. See [PR #257](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/257) and [PR #256](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/256) :
+  - **ModuleDockingNodeFindOtherNodesFaster** : Faster lookup of other docking nodes.
+  - **CollisionEnhancerFastUpdate** : Optimization of the `CollisionEnhancer` component (responsible for part to terrain collision detection).
+  - **PartSystemsFastUpdate** : Optimization of various flight scene auxiliary subsystems : temperature gauges, highlighter, strut position tracking...
+  - **MinorPerfTweaks** : Various small performance patches (volume normalizer, eva module checks)
+  - **FlightIntegratorPerf** : General micro-optimization of `FlightIntegrator` and `VesselPrecalculate`, components in charge of most of heavy lifting for newtonian physics as well as atmospheric and thermal physics.
+  - **FloatingOriginPerf** : General micro-optimization of floating origin shifts. Main benefit is in large particle count situations (ie, launches with many engines) but this helps a bit in other cases as well.
+- Small internal refactor of the patching infrastructure for less verbose patch declaration.
+- Introduced a new "override" patch type, basically an automatic transpiler allowing to replace a method body with another. This has a little less overhead than a prefix doing the same thing, and allow for other patches (including non-KSPCF ones) to prefix the patched method as usual.
 
 ##### 1.35.2
 - **FastLoader** : Fixed a regression introduced in 1.35.1, causing PNG normal maps to be generated with empty mipmaps.

--- a/README.md
+++ b/README.md
@@ -190,6 +190,9 @@ If doing so in the `Debug` configuration and if your KSP install is modified to 
 
 ### Changelog
 
+##### 1.35.2
+- **FastLoader** : Fixed a regression introduced in 1.35.1, causing PNG normal maps to be generated with empty mipmaps.
+
 ##### 1.35.1
 - **FastLoader** : fixed the PNG loader behavior not being similiar as in stock. It was wrongly generating mipmaps, notably resulting in NPOT textures not showing when texture quality wasn't set to full resolution ([see issue #224](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/224)).
 - **FastLoader** : fixed cached PNG textures loading not using the data loaded by the threaded reader, but instead reading the file again synchronously (!). Unsurprisingly, fixing that is massively improving texture loading time.


### PR DESCRIPTION
Many experimental perf improvements, basically a big collection of micro-optimizations for various pieces of code running every frame on every part. Won't do much in low part count situations, and some patches are highly situational (atmospheric flight, docking ports, struts, particles repositionning on floating origin shifts...)

Patches affecting the FlightIntegrator and VesselPrecalculate are broably incompatible with mods trying to override/extend stuff through MFI. There are a bunch of perf issues with "end of the call stack" methods being inefficient because they do extra work that is already done at the call site or can be made faster by using state from the call site, so patching those methods doesn't cut it, but this mean many stock methods aren't called anymore, so if those methods are replaced/prefixed/postfixed with MFI, things will break. Notable examples are FI.UpdateAerodynamics() and FI.Integrate(Part). This could probably be avoided at the cost of some of the perf gains, but I wanted to see how far things could be pushed perf wise. On a side note, there is a bug lurking in the VesselPrecalculate.CalculatePhysicsStats reimplementation, not sure what it is exactely but a side effect is camera target being wrongly offset. Likely something with the CoM calcs.