### PR TITLE
Manual patches

### DIFF
--- a/KSPCommunityFixes/BasePatch.cs
+++ b/KSPCommunityFixes/BasePatch.cs
@@ -43,6 +43,17 @@ namespace KSPCommunityFixes
     {
     }
 
+    /// <summary>
+    /// When applied to a class derived from <see cref="BasePatch"/>, the patch won't be automatically applied.<para/>
+    /// To apply the patch, call <see cref="BasePatch.Patch"/>. Note that if that call happens before ModuleManager
+    /// has patched the configs (ie, before part compilation), <see cref="BasePatch.IgnoreConfig"/> must be overriden
+    /// to return <see langword="true"/>, or the patch won't be applied.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    internal class ManualPatchAttribute : Attribute
+    {
+    }
+
     public abstract class BasePatch
     {
         public static readonly string pluginData = "PluginData";
@@ -64,7 +75,7 @@ namespace KSPCommunityFixes
 
             if (!patch.IgnoreConfig && !KSPCommunityFixes.enabledPatches.Contains(patchType.Name))
             {
-                Debug.Log($"[KSPCommunityFixes] Patch {patchType.Name} not applied (disabled in Settings.cfg)");
+                Debug.Log($"[KSPCommunityFixes] Patch {patchType.Name} not applied (not enabled in Settings.cfg)");
                 return;
             }
 

--- a/KSPCommunityFixes/KSPCommunityFixes.cs
+++ b/KSPCommunityFixes/KSPCommunityFixes.cs
@@ -14,7 +14,6 @@ namespace KSPCommunityFixes
 
         public static string LOC_KSPCF_Title = "KSP Community Fixes";
 
-
         public static Harmony Harmony { get; private set; }
 
         public static HashSet<string> enabledPatches = new HashSet<string>();
@@ -50,6 +49,14 @@ namespace KSPCommunityFixes
             }
         }
 
+        static KSPCommunityFixes()
+        {
+            Harmony = new Harmony("KSPCommunityFixes");
+#if DEBUG
+            Harmony.DEBUG = true;
+#endif
+        }
+
         public static T GetPatchInstance<T>() where T : BasePatch
         {
             if (!patchInstances.TryGetValue(typeof(T), out BasePatch instance))
@@ -72,11 +79,6 @@ namespace KSPCommunityFixes
                 DontDestroyOnLoad(this);
             }
 
-            Harmony = new Harmony("KSPCommunityFixes");
-
-#if DEBUG
-            Harmony.DEBUG = true;
-#endif
             LocalizationUtils.GenerateLocTemplateIfRequested();
             LocalizationUtils.ParseLocalization();
 
@@ -113,10 +115,9 @@ namespace KSPCommunityFixes
             List<Type> patchesTypes = new List<Type>();
             foreach (Type type in Assembly.GetAssembly(basePatchType).GetTypes())
             {
-                if (!type.IsAbstract && type.IsSubclassOf(basePatchType))
+                if (!type.IsAbstract && type.IsSubclassOf(basePatchType) && type.GetCustomAttribute<ManualPatchAttribute>() == null)
                 {
                     patchesTypes.Add(type);
-
                 }
             }
 

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Krafs.Publicizer.2.2.1\build\Krafs.Publicizer.props" Condition="Exists('..\packages\Krafs.Publicizer.2.2.1\build\Krafs.Publicizer.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />


### PR DESCRIPTION
Added a `[ManualPatch]` attribute.

When applied to a class derived from `BasePatch`, the patch won't be automatically applied by the default patching infrastructure.
To apply the patch, call `BasePatch.Patch()` manually. 

Note that if that call happens before ModuleManager has patched the configs (ie, before part compilation), `BasePatch.IgnoreConfig` must be overridden to return `true`, or the patch won't be applied.

Main intended usage is for patches requiring to be applied before ModuleManagerPostLoad.