### PR TITLE
Allow targeting the currently orbited parent body, or any body the parent body is a descendant of

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -308,6 +308,9 @@ KSP_COMMUNITY_FIXES
   // Optional MM-patcheable toggle to always disable the MH features
   OptionalMakingHistoryDLCFeaturesAlwaysDisable = false
 
+  // Allow targeting the parent body of the current craft, or any body in the parent hierarchy
+  TargetParentBody = true
+
   // ##########################
   // Performance tweaks
   // ##########################

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Krafs.Publicizer.2.2.1\build\Krafs.Publicizer.props" Condition="Exists('..\packages\Krafs.Publicizer.2.2.1\build\Krafs.Publicizer.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -214,6 +214,7 @@
     <Compile Include="QoL\AutostrutActions.cs" />
     <Compile Include="QoL\BetterEditorUndoRedo.cs" />
     <Compile Include="QoL\OptionalMakingHistoryDLCFeatures.cs" />
+    <Compile Include="QoL\TargetParentBody.cs" />
     <Compile Include="QoL\ToolbarShowHide.cs" />
     <Compile Include="QoL\DisableNewGameIntro.cs" />
     <Compile Include="QoL\NoIVA.cs" />

--- a/KSPCommunityFixes/QoL/TargetParentBody.cs
+++ b/KSPCommunityFixes/QoL/TargetParentBody.cs
@@ -1,16 +1,19 @@
-﻿using HarmonyLib;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Reflection.Emit;
 using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
 
 namespace KSPCommunityFixes.QoL
 {
     class TargetParentBody : BasePatch
     {
+        protected override Version VersionMin => new Version(1, 8, 0);
+
         protected override void ApplyPatches()
         {
             AddPatch(PatchType.Prefix, typeof(OrbitTargeter), nameof(OrbitTargeter.DropInvalidTargets));
+
             AddPatch(PatchType.Transpiler, typeof(FlightGlobals), nameof(FlightGlobals.UpdateInformation));
         }
 

--- a/KSPCommunityFixes/QoL/TargetParentBody.cs
+++ b/KSPCommunityFixes/QoL/TargetParentBody.cs
@@ -1,0 +1,67 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using System.Reflection;
+
+namespace KSPCommunityFixes.QoL
+{
+    class TargetParentBody : BasePatch
+    {
+        protected override void ApplyPatches()
+        {
+            AddPatch(PatchType.Prefix, typeof(OrbitTargeter), nameof(OrbitTargeter.DropInvalidTargets));
+            AddPatch(PatchType.Transpiler, typeof(FlightGlobals), nameof(FlightGlobals.UpdateInformation));
+        }
+
+        // OrbitTargeter.DropInvalidTargets is only ever used to clear the target if the target is in the Parent body heriarchy
+        // Always return false and do not run the base method
+        private static bool OrbitTargeter_DropInvalidTargets_Prefix(bool __result)
+        {
+            __result = false;
+            return false;
+        }
+
+        // FlightGlobals.UpdateInformation contains two sequential if statements that each make a call to FlightGlobals.SetVesselTarget
+        // to clear the target if the target is the direct parent of the vessel or in the parent body heriarchy
+        // Starting from the end of the if statement making the second call to FlightGlobals.SetVesselTarget, iterate backwards and
+        // replace opcodes with Nop until reaching the beginning of the first if statement
+        static IEnumerable<CodeInstruction> FlightGlobals_UpdateInformation_Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            FieldInfo FlightGlobals_currentMainBody = AccessTools.Field(typeof(FlightGlobals), nameof(FlightGlobals.currentMainBody));
+            MethodInfo FlightGlobals_SetVesselTarget = AccessTools.Method(typeof(FlightGlobals), nameof(FlightGlobals.SetVesselTarget));
+
+            List<CodeInstruction> code = new List<CodeInstruction>(instructions);
+            int numFlightGlobals_currentMainBodysSeen = 0;
+            int numFlightGlobals_SetVesselTargetsSeen = 0;
+            for (int i = 1; i < code.Count; i++)
+            {
+                if (code[i].opcode == OpCodes.Br
+                    && code[i - 1].opcode == OpCodes.Call
+                    && ReferenceEquals(code[i - 1].operand, FlightGlobals_SetVesselTarget))
+                {
+                    numFlightGlobals_SetVesselTargetsSeen++;
+                    if (numFlightGlobals_SetVesselTargetsSeen == 2)
+                    {
+                        for (int j = i; j >= 0; j--)
+                        {
+                            if (code[j].opcode == OpCodes.Ldsfld && ReferenceEquals(code[j].operand, FlightGlobals_currentMainBody))
+                            {
+                                numFlightGlobals_currentMainBodysSeen++;
+                            }
+                            OpCode opcode = code[j].opcode;
+                            code[j].opcode = OpCodes.Nop;
+                            code[j].operand = null;
+                            if (numFlightGlobals_currentMainBodysSeen == 2 && opcode == OpCodes.Ldarg_0)
+                            {
+                                break;
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+            return code;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ User options are available from the "ESC" in-game settings menu :<br/><img src="
 - **ResourceLockActions** [KSP 1.8.0 - 1.12.5]<br/>Add part actions for locking/unlocking resources flow state.
 - [**BetterEditorUndoRedo**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/172) [KSP 1.12.3 - 1.12.5]<br/>Invert the editor undo state capturing logic so part tweaks aren't lost when undoing.  NOTE: this patch is disabled when TweakScale/L is installed.
 - [**OptionalMakingHistoryDLCFeatures**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/218) [KSP 1.12.3 - 1.12.5]<br/>Allow to disable the Making History DLC mission editor and additional launch sites features to decrease memory usage and increase loading speed. The Making History parts will still be available. Can be toggled from the KSPCF in-game settings (requires a restart), or from a MM patch (see `Settings.cfg`).
+- **TargetParentBody** [KSP 1.8.0 - 1.12.5]<br/>Allow targeting the parent body of the current craft, or any body in the parent hierarchy.
 
 #### Performance tweaks 
 


### PR DESCRIPTION
# Problem
In stock KSP, you are unable to target your direct parent body, or any body that the parent body is a descendant of.  This primarily crops up when attempting to plan gravity assist chains, particularly when entering resonant orbits that will return to the initial body.  Some examples of where this can be annoying is in planning of the following assist chains starting from Kerbin:
1. Kerbin(Mun-Mun-Mun)-Kerbin(Mun)-Kerbin(Mun)-Eve
2. Kerbin-Eve-Kerbin-Kerbin-Jool
3. Kerbin-Leverage-Kerbin-Jool

In each case, it can be difficult to set up the first Kerbin flyby without first ejecting from Kerbin blind, since you cannot target Kerbin to see your future close approach.
This limitation is not a result of an inability of the targeting logic to target bodies in the parent hierarchy, but rather dedicated logic for dropping the target if it is.

# Changes
* Use a prefix to skip calling `OrbitTargeter.DropInvalidTargets` entirely.  The only function of this method is to drop the target if it is the current parent or any body the parent body is a descendant of.
* Use a transpiler to modify `FlightGlobals.UpdateInformation`.  One of the primary functions of this method is to check the validity of the current target and drop it if invalid.  The first two branches of the set of if statements call `FlightGlobals.SetVesselTarget` to drop the target if it is the current parent or any body the parent body is a descendant of.  These first two if statements are entirely replaced with Nops.

# Testing
I have taken the following steps to test the changes made
* Run profiling using the unity profiler to confirm there are no performance regressions due to this change.
* Rollback KSP version to 1.8.0 to confirm compatibility.
* Performed numerous ingame tests using the functionality for planning assist chains.
* Used the changes in the course of normal gameplay over the past few weeks.

I have observed no bugs or performance regressions with the latest version of the changes, and additionally have tested that they function alongside Kerbal Engineer Redux targeting behavior.  I have not tested with MechJeb2 targeting behavior.