### PR TITLE
Support cleaned dll files from de4dot or binary patchsets

### DIFF
--- a/KSPCommunityFixes/BugFixes/DoubleCurvePreserveTangents.cs
+++ b/KSPCommunityFixes/BugFixes/DoubleCurvePreserveTangents.cs
@@ -11,31 +11,46 @@ namespace KSPCommunityFixes.BugFixes
 
         protected override void ApplyPatches()
         {
-            AddPatch(PatchType.Transpiler, typeof(DoubleCurve), nameof(DoubleCurve.RecomputeTangents));
+            AddPatch(PatchType.Prefix, typeof(DoubleCurve), nameof(DoubleCurve.RecomputeTangents));
         }
 
-        static IEnumerable<CodeInstruction> DoubleCurve_RecomputeTangents_Transpiler(IEnumerable<CodeInstruction> instructions)
+        static bool DoubleCurve_RecomputeTangents_Prefix(DoubleCurve __instance)
         {
-            // The existing function has a test if ( count == 1 ) and, if true, it
-            // will flatten the tangents of the key regardless of if it is
-            // set to autotangent or not. Since the tangents of a single-key
-            // curve don't matter, let's just return.
-            List<CodeInstruction> code = new List<CodeInstruction>(instructions);
-            for (int i = 1; i < code.Count; ++i)
+            int count = __instance.keys.Count;
+            DoubleKeyframe doubleKeyframe;
+            if (count == 1)
             {
-                if (code[i].opcode == OpCodes.Ldc_I4_1 && code[i - 1].opcode != OpCodes.Ldloc_1)
+                return false;
+            }
+            doubleKeyframe = __instance.keys[0];
+            if (doubleKeyframe.autoTangent)
+            {
+                doubleKeyframe.inTangent = 0.0;
+                doubleKeyframe.outTangent = (__instance.keys[1].value - doubleKeyframe.value) / (__instance.keys[1].time - doubleKeyframe.time);
+                __instance.keys[0] = doubleKeyframe;
+            }
+            int num3 = count - 1;
+            doubleKeyframe = __instance.keys[num3];
+            if (doubleKeyframe.autoTangent)
+            {
+                doubleKeyframe.inTangent = (doubleKeyframe.value - __instance.keys[num3 - 1].value) / (doubleKeyframe.time - __instance.keys[num3 - 1].value);
+                doubleKeyframe.outTangent = 0.0;
+                __instance.keys[num3] = doubleKeyframe;
+            }
+            if (count > 2)
+            {
+                for (int i = 1; i < num3; i++)
                 {
-                    code[i] = new CodeInstruction(OpCodes.Ret);
-                    code[i + 1] = new CodeInstruction(OpCodes.Nop);
-                    code[i + 2] = new CodeInstruction(OpCodes.Nop);
-                    code[i + 3] = new CodeInstruction(OpCodes.Nop);
-                    code[i + 4] = new CodeInstruction(OpCodes.Nop);
-                    code[i + 5] = new CodeInstruction(OpCodes.Nop);
-                    break;
+                    doubleKeyframe = __instance.keys[i];
+                    if (doubleKeyframe.autoTangent)
+                    {
+                        double num4 = (doubleKeyframe.value - __instance.keys[i - 1].value) / (doubleKeyframe.time - __instance.keys[i - 1].value);
+                        double num5 = (__instance.keys[i + 1].value - doubleKeyframe.value) / (__instance.keys[i + 1].time - doubleKeyframe.time);
+                        doubleKeyframe.inTangent = (doubleKeyframe.outTangent = (num4 + num5) * 0.5);
+                    }
                 }
             }
-
-            return code;
+            return false;
         }
     }
 }

--- a/KSPCommunityFixes/BugFixes/ModuleIndexingMismatch.cs
+++ b/KSPCommunityFixes/BugFixes/ModuleIndexingMismatch.cs
@@ -357,12 +357,11 @@ namespace KSPCommunityFixes
                     && code[i + 1].opcode == OpCodes.Ldloc_3
                     && code[i + 2].opcode == OpCodes.Ldloca_S
                     && code[i + 3].opcode == OpCodes.Callvirt && ReferenceEquals(code[i + 3].operand, Part_LoadModule)
-                    && code[i + 4].opcode == OpCodes.Dup
-                    && code[i + 5].opcode == OpCodes.Pop
-                    && code[i + 6].opcode == OpCodes.Pop)
+                    && code[i + 4].opcode == OpCodes.Pop
+                    && code[i + 5].opcode == OpCodes.Br)
                 {
                     originalFound = true;
-                    for (int j = i; j < i + 7; j++)
+                    for (int j = i; j < i + 6; j++)
                     {
                         code[j].opcode = OpCodes.Nop;
                         code[j].operand = null;

--- a/KSPCommunityFixes/KSPCommunityFixes.cs
+++ b/KSPCommunityFixes/KSPCommunityFixes.cs
@@ -72,27 +72,9 @@ namespace KSPCommunityFixes
                 if (File.Exists(dllPath))
                 {
                     Byte[] data = File.ReadAllBytes(dllPath);
-                    using (SHA256 sha256 = SHA256.Create())
+                    if ((data.Length < 10485760) && (KSPCommunityFixes.KspVersion >= new Version(1, 12, 0)))
                     {
-                        String checksum = BitConverter.ToString(sha256.ComputeHash(data));
-                        checksum = checksum.Replace("-", "");
-                        checksum = checksum.ToLower();
-                        if (checksum == "9ec0b701b17dde90f9a77c2297be24eea07346ac41bc3ef48463026d82c77f41") //1.12.5 cleaned by an RTB patcher
-                        {
-                            return true;
-                        }
-                        else if (checksum == "c8aa143bcd5b53013f03b2215e787997df79a036df03eda06b29a42ceae88295") //1.12.4 cleaned by an RTB patcher
-                        {
-                            return true;
-                        }
-                        else if (checksum == "429ee3d018478a82f5dc30bc330867ad3caa5447ae67d87005a19bfce303891b") //1.12.3 cleaned by an RTB patcher
-                        {
-                            return true;
-                        }
-                        else if ((data.Length < 10485760) && (KSPCommunityFixes.KspVersion >= new Version(1, 12, 0)))
-                        {
-                            return true; //most likely a home-cleaned dll, no 1.12.x build of Assembly-CSharp is less than 10MBs.
-                        }
+                        return true; //certainly a home-cleaned dll, no official 1.12.x build of Assembly-CSharp is less than 10MBs.
                     }
                 }
                 return false;

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # KSP Community Fixes
 
+This fork attempts to make KSPCF compatible with a "cleaned" assembly-CSharp using "de4dot  --dont-rename".
+
 This plugin is a collection of code patches for fixing bugs and performance issues in the KSP codebase, and adding small QoL improvements. Entirely new features (especially those already covered by other mods) are out of scope, as well as patches that might alter the stock behaviors to minimize potential mod compatibility issues.
 
 This mod is meant as community project, so feel free to propose additional patch ideas by opening an issue, or to contribute with a pull request.


### PR DESCRIPTION
So, I've been testing what patches do/don't break with KSPCF and a de4dot cleaned dll (as the cleaned dll performs ever so slightly better than the obfuscated one).

I've pretty much made a patchset that can completely support all current patches with the cleaned dlls and no errors.  I use SHA256 hash checks against my own binary patches [here](https://github.com/R-T-B/KAC) as well as a size detection coupled with version check to do some heuristics to detect other homebuilt cleaned-dll builds.

I can keep it separate in my own repos of course, but wanted to make you aware in case you thought this worthy of mainlining.  Take a look and tell me what your thoughts are, no offense taken if you reject it.