### PR TITLE
Remove constant overhead from `ModuleSurfaceFX.Update()`

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -441,7 +441,8 @@ KSP_COMMUNITY_FIXES
   LowerMinPhysicsDTPerFrame = true
 
   // Improve engine exhaust damage and solar panel line of sight raycasts performance by avoiding extra physics
-  // state synchronization and caching solar panels scaled space raycasts results.
+  // state synchronization and caching solar panels scaled space raycasts results. Also prevent useless raycasts
+  // from exhaust ground effects (ModuleSurfaceFX).
   OptimizedModuleRaycasts = true
 
   // Faster and minimal GC allocation replacements for Part FindModelTransform*() and FindHeirarchyTransform*()

--- a/KSPCommunityFixes/Performance/OptimizedModuleRaycasts.cs
+++ b/KSPCommunityFixes/Performance/OptimizedModuleRaycasts.cs
@@ -1,5 +1,6 @@
-﻿using System;
-using HarmonyLib;
+﻿using HarmonyLib;
+using KSPCommunityFixes.Library;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
@@ -16,11 +17,13 @@ namespace KSPCommunityFixes.Performance
 
         protected override void ApplyPatches()
         {
+            KSPCommunityFixes.Instance.StartCoroutine(ResetSyncOnFixedEnd());
+
             AddPatch(PatchType.Transpiler, typeof(ModuleEngines), nameof(ModuleEngines.EngineExhaustDamage));
 
             AddPatch(PatchType.Prefix, typeof(ModuleDeployableSolarPanel), nameof(ModuleDeployableSolarPanel.CalculateTrackingLOS));
 
-            KSPCommunityFixes.Instance.StartCoroutine(ResetSyncOnFixedEnd());
+            AddPatch(PatchType.Override, typeof(ModuleSurfaceFX), nameof(ModuleSurfaceFX.Update));
         }
 
         static IEnumerator ResetSyncOnFixedEnd()
@@ -141,6 +144,110 @@ namespace KSPCommunityFixes.Performance
             bool result = Physics.defaultPhysicsScene.Raycast(origin, direction, out hitInfo, maxDistance, layerMask);
             Physics.autoSyncTransforms = true;
             return result;
+        }
+
+        static void ModuleSurfaceFX_Update_Override(ModuleSurfaceFX msFX)
+        {
+            if (!HighLogic.LoadedSceneIsFlight || !GameSettings.SURFACE_FX)
+                return;
+
+            if (msFX.engineModule != null)
+                msFX.fxScale = msFX.engineModule.GetCurrentThrust() / msFX.engineModule.GetMaxThrust() * msFX.fxMax;
+            else
+                msFX.fxScale = 0f;
+
+            if (msFX.fxScale <= 0f)
+            {
+                ModuleSurfaceFX_ResetSrfFX(msFX);
+                return;
+            }
+
+            if (msFX.vessel.radarAltitude > (msFX.vessel.vesselSize.magnitude + msFX.maxDistance) * 2.5f)
+            {
+                ModuleSurfaceFX_ResetSrfFX(msFX);
+                return;
+            }
+
+            float transformAltitude = 0f;
+
+            if (msFX.vessel.mainBody.ocean)
+            {
+                transformAltitude = FlightGlobals.getAltitudeAtPos(msFX.trf.position, msFX.vessel.mainBody);
+                if (transformAltitude < 0f)
+                {
+                    ModuleSurfaceFX_ResetSrfFX(msFX);
+                    return;
+                }
+            }
+
+            msFX.raycastHit = Physics.Raycast(msFX.trf.position, msFX.trf.forward, out msFX.hitInfo, msFX.maxDistance, 1073774592);
+
+            // added the ocean condition here, fixing the bug where the effect wouldn't show up on non-ocean bodies at negative altitudes
+            if (msFX.raycastHit && (!msFX.vessel.mainBody.ocean || FlightGlobals.GetSqrAltitude(msFX.hitInfo.point, msFX.vessel.mainBody) >= 0.0))
+            {
+                if (msFX.hitInfo.collider.CompareTag("LaunchpadFX"))
+                {
+                    msFX.hit = ModuleSurfaceFX.SurfaceType.Launchpad;
+                }
+                else if (msFX.hitInfo.collider.CompareTag("Wheel_Piston_Collider"))
+                {
+                    ModuleSurfaceFX_ResetSrfFX(msFX);
+                    return;
+                }
+                else
+                {
+                    msFX.hit = ModuleSurfaceFX.SurfaceType.Terrain;
+                }
+                msFX.point = msFX.hitInfo.point;
+                msFX.normal = msFX.hitInfo.normal;
+                msFX.distance = msFX.hitInfo.distance;
+            }
+            else if (msFX.vessel.mainBody.ocean)
+            {
+                if (transformAltitude > msFX.maxDistance)
+                {
+                    ModuleSurfaceFX_ResetSrfFX(msFX);
+                    return;
+                }
+
+                float downDot = Vector3.Dot(msFX.trf.forward, -msFX.vessel.upAxis);
+                if (downDot <= 0f)
+                {
+                    ModuleSurfaceFX_ResetSrfFX(msFX);
+                    return;
+                }
+
+                msFX.normal = msFX.vessel.upAxis;
+                msFX.distance = transformAltitude / downDot;
+                msFX.point = msFX.trf.position + msFX.trf.forward * msFX.distance;
+                msFX.hit = ModuleSurfaceFX.SurfaceType.Water;
+            }
+            else
+            {
+                ModuleSurfaceFX_ResetSrfFX(msFX);
+                return;
+            }
+
+            msFX.scaledDistance = Mathf.Pow(1f - msFX.distance / msFX.maxDistance, msFX.falloff);
+            msFX.ScaledFX = msFX.fxScale * msFX.scaledDistance;
+            msFX.rDir = msFX.point - msFX.trf.position;
+            msFX.Vsrf = Vector3.ProjectOnPlane(msFX.rDir, msFX.normal).normalized * msFX.fxScale;
+
+            msFX.UpdateSrfFX(msFX.hitInfo);
+        }
+
+        static void ModuleSurfaceFX_ResetSrfFX(ModuleSurfaceFX msFX)
+        {
+            msFX.hit = ModuleSurfaceFX.SurfaceType.None;
+            msFX.Vsrf.MutateZero();
+            msFX.ScaledFX = 0f;
+            msFX.srfFXnext = null;
+            msFX.padFX = null;
+            if (msFX.srfFX.IsNotNullRef())
+            {
+                msFX.srfFX.RemoveSource(msFX);
+                msFX.srfFX = null;
+            }
         }
     }
 }


### PR DESCRIPTION
See issue #301 

As a part of the `OptimizedModuleRaycasts` patch, fix `ModuleSurfaceFX.Update()` performing raycasts (and PhysX-Transform syncs) and other useless computations even when the effects have no chance of appearing. Also fix a bug with the effects not appearing at negative altitudes on ocean-less bodies.