### PR TITLE
Remove constant overhead from `ModuleColorChanger.Update()`

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -478,6 +478,9 @@ KSP_COMMUNITY_FIXES
   // Significantly reduces the time it takes to open the craft browser and to search by name. Most noticeable with lots of craft.
   CraftBrowserOptimisations = true
 
+  // Reduce the constant overhead from ModuleColorChanger
+  ModuleColorChangerOptimization = true
+
   // ##########################
   // Modding
   // ##########################

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -166,6 +166,7 @@
     <Compile Include="BugFixes\DoubleCurvePreserveTangents.cs" />
     <Compile Include="BugFixes\RestoreMaxPhysicsDT.cs" />
     <Compile Include="Performance\FloatingOriginPerf.cs" />
+    <Compile Include="Performance\ModuleColorChangerOptimization.cs" />
     <Compile Include="Performance\OptimisedVectorLines.cs" />
     <Compile Include="Performance\GameDatabasePerf.cs" />
     <Compile Include="Performance\PartSystemsFastUpdate.cs" />

--- a/KSPCommunityFixes/Performance/ModuleColorChangerOptimization.cs
+++ b/KSPCommunityFixes/Performance/ModuleColorChangerOptimization.cs
@@ -1,0 +1,54 @@
+﻿namespace KSPCommunityFixes.Performance
+{
+    internal class ModuleColorChangerOptimization : BasePatch
+    {
+        protected override void ApplyPatches()
+        {
+            AddPatch(PatchType.Postfix, typeof(ModuleColorChanger), nameof(ModuleColorChanger.Start));
+            AddPatch(PatchType.Override, typeof(ModuleColorChanger), nameof(ModuleColorChanger.FixedUpdate));
+            AddPatch(PatchType.Override, typeof(ModuleColorChanger), nameof(ModuleColorChanger.Update));
+        }
+
+        static void ModuleColorChanger_Start_Postfix(ModuleColorChanger __instance)
+        {
+            __instance.SetState(__instance.currentRateState); // ensure initial state is correct
+        }
+
+        static void ModuleColorChanger_FixedUpdate_Override(ModuleColorChanger mcc)
+        {
+            return; // state checking moved to Update()
+        }
+
+        static void ModuleColorChanger_Update_Override(ModuleColorChanger mcc)
+        {
+            if (!mcc.useRate || !mcc.isValid)
+                return;
+
+            if (HighLogic.LoadedSceneIsEditor && mcc.part.frozen)
+                return;
+
+            if (mcc.animState)
+            {
+                if (mcc.currentRateState < 1f)
+                {
+                    mcc.currentRateState += mcc.animRate * TimeWarp.deltaTime;
+                    if (mcc.currentRateState > 1f)
+                        mcc.currentRateState = 1f;
+
+                    mcc.SetState(mcc.currentRateState);
+                }
+            }
+            else
+            {
+                if (mcc.currentRateState > 0f)
+                {
+                    mcc.currentRateState -= mcc.animRate * TimeWarp.deltaTime;
+                    if (mcc.currentRateState < 0f)
+                        mcc.currentRateState = 0f;
+
+                    mcc.SetState(mcc.currentRateState);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
See issue #302 

Mostly eliminate the constant overhead from `ModuleColorChanger.Update()` by avoiding re-setting the shader property when the state hasn't changed.