### PR TITLE
Fix projection mistake in Optimised Vector Lines

### DIFF
--- a/KSPCommunityFixes/Performance/OptimisedVectorLines.cs
+++ b/KSPCommunityFixes/Performance/OptimisedVectorLines.cs
@@ -91,12 +91,12 @@ namespace KSPCommunityFixes.Performance
             return ReplaceCall(instructions, Camera_ScreenToWorldPoint, VectorLineOptimisation_ScreenToWorldPoint, count);
         }
 
-        private static IEnumerable<CodeInstruction> ReplaceScreenToViewportPoint(IEnumerable<CodeInstruction> instructions, int count)
+        private static IEnumerable<CodeInstruction> ReplaceViewportToWorldPoint(IEnumerable<CodeInstruction> instructions, int count)
         {
-            MethodInfo Camera_ScreenToViewportPoint = AccessTools.Method(typeof(Camera), nameof(Camera.ScreenToViewportPoint), new Type[] { typeof(Vector3) });
-            MethodInfo VectorLineOptimisation_ScreenToViewportPoint = AccessTools.Method(typeof(VectorLineCameraProjection), nameof(VectorLineCameraProjection.ScreenToViewportPoint));
+            MethodInfo Camera_ViewportToWorldPoint = AccessTools.Method(typeof(Camera), nameof(Camera.ViewportToWorldPoint), new Type[] { typeof(Vector3) });
+            MethodInfo VectorLineOptimisation_ViewportToWorldPoint = AccessTools.Method(typeof(VectorLineCameraProjection), nameof(VectorLineCameraProjection.ViewportToWorldPoint));
 
-            return ReplaceCall(instructions, Camera_ScreenToViewportPoint, VectorLineOptimisation_ScreenToViewportPoint, count);
+            return ReplaceCall(instructions, Camera_ViewportToWorldPoint, VectorLineOptimisation_ViewportToWorldPoint, count);
         }
 
         #endregion
@@ -153,9 +153,10 @@ namespace KSPCommunityFixes.Performance
             projectionInv.m22 += projectionInv.m23;
 
             Matrix4x4 clipToWorld = worldToCameraInv * projectionInv;
-            VectorLineCameraProjection.clipToWorld = new TransformMatrix(clipToWorld.m00, clipToWorld.m01, clipToWorld.m02, camera.worldToCameraMatrix.inverse.m03,
-                                                clipToWorld.m10, clipToWorld.m11, clipToWorld.m12, camera.worldToCameraMatrix.inverse.m13,
-                                                clipToWorld.m20, clipToWorld.m21, clipToWorld.m22, camera.worldToCameraMatrix.inverse.m23);
+            VectorLineCameraProjection.clipToWorld = new TransformMatrix(
+                clipToWorld.m00, clipToWorld.m01, clipToWorld.m02, camera.worldToCameraMatrix.inverse.m03,
+                clipToWorld.m10, clipToWorld.m11, clipToWorld.m12, camera.worldToCameraMatrix.inverse.m13,
+                clipToWorld.m20, clipToWorld.m21, clipToWorld.m22, camera.worldToCameraMatrix.inverse.m23);
         }
 
         #region World to Clip
@@ -229,10 +230,10 @@ namespace KSPCommunityFixes.Performance
             return new Vector3((float)x, (float)y, (float)z);
         }
 
-        public static Vector3 ScreenToViewportPoint(Camera camera, Vector3 position)
+        public static Vector3 ViewportToWorldPoint(Camera camera, Vector3 position)
         {
             //if (!patchEnabled)
-            //    return camera.ScreenToViewportPoint(position);
+            //    return camera.ViewportToWorldPoint(position);
 
             //if (lastCachedFrame != KSPCommunityFixes.frameCount)
             //    UpdateCache();

--- a/KSPCommunityFixes/Performance/OptimisedVectorLines.cs
+++ b/KSPCommunityFixes/Performance/OptimisedVectorLines.cs
@@ -143,8 +143,16 @@ namespace KSPCommunityFixes.Performance
 
             viewport = new ViewportInfo(camera.pixelRect);
 
+            // WorldToClip. Use the fourth row in place of the third row.
+            // This is because users of WorldToScreen/Viewport expect world distance from the camera plane (w after projection) in the z component, not z in NDC.
+
             Matrix4x4 worldToClip = camera.projectionMatrix * camera.worldToCameraMatrix;
-            VectorLineCameraProjection.worldToClip = new TransformMatrix(ref worldToClip);
+            VectorLineCameraProjection.worldToClip = new TransformMatrix(
+                worldToClip.m00, worldToClip.m01, worldToClip.m02, worldToClip.m03,
+                worldToClip.m10, worldToClip.m11, worldToClip.m12, worldToClip.m13,
+                worldToClip.m30, worldToClip.m31, worldToClip.m32, worldToClip.m33);
+
+            // ClipToWorld
 
             Matrix4x4 worldToCameraInv = camera.worldToCameraMatrix.inverse;
             Matrix4x4 projectionInv = camera.projectionMatrix.inverse;
@@ -176,6 +184,7 @@ namespace KSPCommunityFixes.Performance
             double y = worldPosition.y;
             double z = worldPosition.z;
 
+            // z becomes w after this projection with our funny matrix. True z is discarded.
             worldToClip.MutateMultiplyPoint3x4(ref x, ref y, ref z);
 
             double num = 0.5 / z;
@@ -197,6 +206,7 @@ namespace KSPCommunityFixes.Performance
             double y = worldPosition.y;
             double z = worldPosition.z;
 
+            // z becomes w after this projection with our funny matrix. True z is discarded.
             worldToClip.MutateMultiplyPoint3x4(ref x, ref y, ref z);
 
             double num = 0.5 / z;

--- a/KSPCommunityFixes/Performance/OptimisedVectorLines.cs
+++ b/KSPCommunityFixes/Performance/OptimisedVectorLines.cs
@@ -143,8 +143,9 @@ namespace KSPCommunityFixes.Performance
 
             viewport = new ViewportInfo(camera.pixelRect);
 
-            // WorldToClip. Use the fourth row in place of the third row.
-            // This is because users of WorldToScreen/Viewport expect world distance from the camera plane (w after projection) in the z component, not z in NDC.
+            // WorldToClip. Normally this would be a 4x4 matrix, but we omit the third row.
+            // This is because users of WorldToScreen/Viewport expect world distance from the camera plane (which is w after projection) in the z component, not z in NDC.
+            // Therefore we never need to calculate the z component, only x, y and w.
 
             Matrix4x4 worldToClip = camera.projectionMatrix * camera.worldToCameraMatrix;
             VectorLineCameraProjection.worldToClip = new TransformMatrix(

--- a/KSPCommunityFixes/Performance/OptimisedVectorLines.cs
+++ b/KSPCommunityFixes/Performance/OptimisedVectorLines.cs
@@ -185,7 +185,7 @@ namespace KSPCommunityFixes.Performance
             double y = worldPosition.y;
             double z = worldPosition.z;
 
-            // z becomes w after this projection with our funny matrix. True z is never calculated.
+            // z becomes w after this projection with our xyw matrix. True z is never calculated.
             worldToClip.MutateMultiplyPoint3x4(ref x, ref y, ref z);
 
             double num = 0.5 / z;
@@ -207,7 +207,7 @@ namespace KSPCommunityFixes.Performance
             double y = worldPosition.y;
             double z = worldPosition.z;
 
-            // z becomes w after this projection with our funny matrix. True z is never calculated.
+            // z becomes w after this projection with our xyw matrix. True z is never calculated.
             worldToClip.MutateMultiplyPoint3x4(ref x, ref y, ref z);
 
             double num = 0.5 / z;

--- a/KSPCommunityFixes/Performance/OptimisedVectorLines.cs
+++ b/KSPCommunityFixes/Performance/OptimisedVectorLines.cs
@@ -185,7 +185,7 @@ namespace KSPCommunityFixes.Performance
             double y = worldPosition.y;
             double z = worldPosition.z;
 
-            // z becomes w after this projection with our funny matrix. True z is discarded.
+            // z becomes w after this projection with our funny matrix. True z is never calculated.
             worldToClip.MutateMultiplyPoint3x4(ref x, ref y, ref z);
 
             double num = 0.5 / z;
@@ -207,7 +207,7 @@ namespace KSPCommunityFixes.Performance
             double y = worldPosition.y;
             double z = worldPosition.z;
 
-            // z becomes w after this projection with our funny matrix. True z is discarded.
+            // z becomes w after this projection with our funny matrix. True z is never calculated.
             worldToClip.MutateMultiplyPoint3x4(ref x, ref y, ref z);
 
             double num = 0.5 / z;


### PR DESCRIPTION
While we were optimising our WorldToScreen/Viewport functions, we lost the [intended behaviour](https://docs.unity3d.com/6000.1/Documentation/ScriptReference/Camera.ScreenToViewportPoint.html#:~:text=right%20is%20(1%2C1).-,The%20z%20position%20is%20in%20world%20units%20from%20the%20camera.,-using%20UnityEngine%3B) of returning the signed (negative is behind the camera) world distance from the camera plane in the z component, and introduced a discrepancy between our functions and Unity's functions where the world position is projected as though it were `nearClipPlane` units closer to the camera plane than it actually is. 

It's hard to see in-game given the size of orbits in scaled space relative to `nearClipPlane`, but I would have noticed this if I'd written those tests like @gotmachine suggested in the PR.

The issue with the z component leads to a noticeable bug where placing the camera close to a 2D orbit line, which is possible for the orbit lines of planets, causes the final line segment before the near clip plane to point somewhere off-screen in the wrong direction.

I don't see any issues related to the ScreenToWorld function so I've left that as is.


https://github.com/user-attachments/assets/f477d531-ea0c-43c1-8ca5-c3ff0155bd45


https://github.com/user-attachments/assets/50a37dfc-0ba3-4609-ad00-e7ad32774f6e


