### PR TITLE
Fix #321 :  Fix exceptions when calling `EnumExtensions.displayDescription()`

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -233,6 +233,10 @@ KSP_COMMUNITY_FIXES
   // Fix exception spam when a radiator set to `parentCoolingOnly` is detached from the vessel
   ModuleActiveRadiatorNoParentException = true
 
+  // Fix exceptions when calling the `EnumExtensions.*Description()` methods with a non-defined
+  // enum value, and implement a cache for faster and less allocating execution of those methods.
+  FastAndFixedEnumExtensions = true
+
   // ##########################
   // Obsolete bugfixes
   // ##########################

--- a/KSPCommunityFixes/BugFixes/FastAndFixedEnumExtensions.cs
+++ b/KSPCommunityFixes/BugFixes/FastAndFixedEnumExtensions.cs
@@ -1,0 +1,75 @@
+﻿using KSP.Localization;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Reflection;
+
+namespace KSPCommunityFixes
+{
+    internal class FastAndFixedEnumExtensions : BasePatch
+    {
+        internal static Dictionary<Type, Dictionary<long, EnumMemberDescription>> enumMemberDescriptionCache = new Dictionary<Type, Dictionary<long, EnumMemberDescription>>();
+
+        internal class EnumMemberDescription
+        {
+            public string description;
+            public string localizedDescription;
+
+            public EnumMemberDescription(string memberName, DescriptionAttribute descriptionAttribute = null)
+            {
+                description = descriptionAttribute?.Description ?? memberName;
+                localizedDescription = Localizer.Format(description);
+            }
+        }
+
+        protected override void ApplyPatches()
+        {
+            AddPatch(PatchType.Override, typeof(EnumExtensions), nameof(EnumExtensions.Description));
+            AddPatch(PatchType.Override, typeof(EnumExtensions), nameof(EnumExtensions.displayDescription));
+        }
+
+        internal static bool TryGetEnumMemberDescription(Enum enumValue, out EnumMemberDescription enumMemberDescription)
+        {
+            Type enumType = enumValue.GetType();
+            if (!enumMemberDescriptionCache.TryGetValue(enumType, out Dictionary<long, EnumMemberDescription> enumDescriptions))
+            {
+                enumDescriptions = new Dictionary<long, EnumMemberDescription>();
+                string[] names = enumType.GetEnumNames();
+
+                foreach (string enumMemberName in names)
+                {
+                    MemberInfo[] enumMembers = enumType.GetMember(enumMemberName);
+                    if (enumMembers.Length == 0)
+                        continue;
+
+                    DescriptionAttribute descriptionAttribute = enumMembers[0].GetCustomAttribute<DescriptionAttribute>();
+                    Enum enumMember = (Enum)Enum.Parse(enumType, enumMemberName);
+                    enumDescriptions.Add(enumMember.GetSignedBoxedEnumValue(), new EnumMemberDescription(enumMemberName, descriptionAttribute));
+                }
+
+                enumMemberDescriptionCache.Add(enumType, enumDescriptions);
+            }
+
+            if (enumDescriptions.TryGetValue(enumValue.GetSignedBoxedEnumValue(), out enumMemberDescription))
+                return true;
+
+            return false;
+        }
+
+        internal static string EnumExtensions_Description_Override(Enum e)
+        {
+            if (!TryGetEnumMemberDescription(e, out EnumMemberDescription enumMemberDescription))
+                return e.ToString();
+
+            return enumMemberDescription.description;
+        }
+
+        internal static string EnumExtensions_displayDescription_Override(Enum e)
+        {
+            if (!TryGetEnumMemberDescription(e, out EnumMemberDescription enumMemberDescription))
+                return Localizer.Format(e.ToString());
+
+            return enumMemberDescription.localizedDescription;
+        }
+    }
+}

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -99,6 +99,7 @@
     <Publicize Include="UnityEngine.CoreModule:UnityEngine.Object.GetOffsetOfInstanceIDInCPlusPlusObject" />
     <Publicize Include="UnityEngine.IMGUIModule" />
     <Publicize Include="UnityEngine.CoreModule:Unity.Collections.NativeArray`1.m_Buffer" />
+    <Publicize Include="mscorlib:System.Runtime.CompilerServices.Unsafe" />
     <Publicize Include="mscorlib:System.IO.MonoIO" />
     <Publicize Include="mscorlib:System.IO.MonoIOError" />
     <Publicize Include="mscorlib:System.IO.MonoIOStat" />
@@ -128,6 +129,7 @@
     <Compile Include="BugFixes\CorrectDragForFlags.cs" />
     <Compile Include="BugFixes\DragCubeLoadException.cs" />
     <Compile Include="BugFixes\EVAConstructionMass.cs" />
+    <Compile Include="BugFixes\FastAndFixedEnumExtensions.cs" />
     <Compile Include="BugFixes\InventoryPartMass.cs" />
     <Compile Include="BugFixes\ModuleActiveRadiatorNoParentException.cs" />
     <Compile Include="BugFixes\ModulePartVariantsNodePersistence.cs" />

--- a/KSPCommunityFixes/Library/Extensions.cs
+++ b/KSPCommunityFixes/Library/Extensions.cs
@@ -29,6 +29,35 @@ namespace KSPCommunityFixes
         {
             return part.PartActionWindow.IsNotNullOrDestroyed() && part.PartActionWindow.isActiveAndEnabled;
         }
+
+        /// <summary>
+        /// Get the value of a boxed enum, as a 64 bit signed integer. 
+        /// If the enum underlying type is an unsigned 64 bit integer and the value is greater than long.MaxValue, 
+        /// the result will overflow and be negative.
+        /// </summary>
+        public static long GetSignedBoxedEnumValue(this Enum enumInstance)
+        {
+            Type underlyingType = enumInstance.GetType().GetEnumUnderlyingType();
+
+            if (underlyingType == typeof(int))
+                return (int)(object)enumInstance;
+            else if (underlyingType == typeof(sbyte))
+                return (sbyte)(object)enumInstance;
+            else if (underlyingType == typeof(short))
+                return (short)(object)enumInstance;
+            else if (underlyingType == typeof(long))
+                return (long)(object)enumInstance;
+            else if (underlyingType == typeof(uint))
+                return (uint)(object)enumInstance;
+            else if (underlyingType == typeof(byte))
+                return (byte)(object)enumInstance;
+            else if (underlyingType == typeof(ushort))
+                return (ushort)(object)enumInstance;
+            else if (underlyingType == typeof(ulong))
+                return (long)(ulong)(object)enumInstance;
+
+            throw new Exception($"Enum {enumInstance.GetType()} is of unknown size");
+        }
     }
 
     static class ParticleBuffer

--- a/KSPCommunityFixes/Modding/KSPFieldEnumDesc.cs
+++ b/KSPCommunityFixes/Modding/KSPFieldEnumDesc.cs
@@ -18,8 +18,8 @@ namespace KSPCommunityFixes.Modding
             Type fieldType = __instance.FieldInfo.FieldType;
             if (fieldType.IsEnum)
             {
-                var val = (Enum)__instance.GetValue(host);
-                __result = val.displayDescription();
+                Enum val = (Enum)__instance.GetValue(host);
+                __result = FastAndFixedEnumExtensions.EnumExtensions_displayDescription_Override(val);
                 return false;
             }
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ User options are available from the "ESC" in-game settings menu :<br/><img src="
 - [**DragCubeLoadException**](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/232) [KSP 1.8.0 - 1.12.5]<br/>Fix loading of drag cubes without a name failing with an IndexOutOfRangeException
 - [**TimeWarpBodyCollision**](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/259) [KSP 1.12.0 - 1.12.5]<br/>Fix timewarp rate not always being limited on SOI transistions, sometimes resulting in failure to detect an encounter/collision with the body in the next SOI.
 - [**ModuleActiveRadiatorNoParentException**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/249) [KSP 1.12.3 - 1.12.5]<br/>Fix exception spam when a radiator set to `parentCoolingOnly` is detached from the vessel
+- [**FastAndFixedEnumExtensions**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/321) [KSP 1.12.3 - 1.12.5]<br/>Fix exceptions when calling the `EnumExtensions.*Description()` methods with a non-defined enum value, and implement a cache for faster and less allocating execution of those methods.
 
 #### Quality of Life tweaks 
 


### PR DESCRIPTION
Fix exceptions when calling `EnumExtensions.displayDescription()` with an enum value that isn't defined, a stock bug occuring more consistently when the KSPCF KSPFieldEnumDesc patch is enabled. As part of this new FastAndFixedEnumExtensions patch, also implement a cache for the enum descriptions.