### PR TITLE
New ksp bug fix patch : DebugConsoleDontStealInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Changelog
 
+##### 1.39.0
+**New/improved patches**
+- New KSP bugfix : **DebugConsoleDontStealInput**, fix the Alt+F12 console input field stealing input when a console entry is added.
+
 ##### 1.38.1
 **Bug fixes**
 - **ModuleColorChangerOptimization** : Fixed externally controlled ModuleColorChanger modules state being wrongly reset on startup, notably causing the stock heat shield to start in the charred / black state in the editor.

--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -233,6 +233,9 @@ KSP_COMMUNITY_FIXES
   // Fix exception spam when a radiator set to `parentCoolingOnly` is detached from the vessel
   ModuleActiveRadiatorNoParentException = true
 
+  // Fix the Alt+F12 console input field stealing input when a console entry is added
+  DebugConsoleDontStealInput = true
+
   // ##########################
   // Obsolete bugfixes
   // ##########################

--- a/KSPCommunityFixes/BugFixes/DebugConsoleDontStealInput.cs
+++ b/KSPCommunityFixes/BugFixes/DebugConsoleDontStealInput.cs
@@ -1,0 +1,45 @@
+﻿using HarmonyLib;
+using KSP.UI.Screens.DebugToolbar;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using UnityEngine.EventSystems;
+
+namespace KSPCommunityFixes.BugFixes
+{
+    internal class DebugConsoleDontStealInput : BasePatch
+    {
+        protected override void ApplyPatches()
+        {
+            AddPatch(PatchType.Transpiler, typeof(DebugScreenConsole), nameof(DebugScreenConsole.OnEnable), nameof(ScrollDownTranspiler));
+            AddPatch(PatchType.Transpiler, typeof(DebugScreenConsole), nameof(DebugScreenConsole.SubmitCommand), nameof(ScrollDownTranspiler));
+            AddPatch(PatchType.Transpiler, typeof(DebugScreenConsole), nameof(DebugScreenConsole.OnMemoryLogUpdated), nameof(ScrollDownTranspiler));
+        }
+
+        private static IEnumerable<CodeInstruction> ScrollDownTranspiler(IEnumerable<CodeInstruction> instructions)
+        {
+            MethodInfo mScrollDownOriginal = AccessTools.Method(typeof(DebugScreenConsole), nameof(DebugScreenConsole.ScrollDown));
+            MethodInfo mScrollDownPatched = AccessTools.Method(typeof(DebugConsoleDontStealInput), nameof(ScrollDownPatched));
+
+            foreach (CodeInstruction il in instructions)
+            {
+                if (il.opcode == OpCodes.Call && ReferenceEquals(il.operand, mScrollDownOriginal))
+                    il.operand = mScrollDownPatched;
+
+                yield return il;
+            }
+        }
+
+        private static IEnumerator ScrollDownPatched(DebugScreenConsole console)
+        {
+            yield return null;
+
+            if (console.scrollRect != null)
+                console.scrollRect.verticalNormalizedPosition = 0f;
+
+            EventSystem.current.SetSelectedGameObject(console.inputField.gameObject, null);
+            //console.inputField.OnPointerClick(new PointerEventData(EventSystem.current));
+        }
+    }
+}

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -126,6 +126,7 @@
     <Compile Include="BugFixes\AsteroidInfiniteMining.cs" />
     <Compile Include="BugFixes\ChutePhantomSymmetry.cs" />
     <Compile Include="BugFixes\CorrectDragForFlags.cs" />
+    <Compile Include="BugFixes\DebugConsoleDontStealInput.cs" />
     <Compile Include="BugFixes\DragCubeLoadException.cs" />
     <Compile Include="BugFixes\EVAConstructionMass.cs" />
     <Compile Include="BugFixes\InventoryPartMass.cs" />

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ User options are available from the "ESC" in-game settings menu :<br/><img src="
 - [**DragCubeLoadException**](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/232) [KSP 1.8.0 - 1.12.5]<br/>Fix loading of drag cubes without a name failing with an IndexOutOfRangeException
 - [**TimeWarpBodyCollision**](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/259) [KSP 1.12.0 - 1.12.5]<br/>Fix timewarp rate not always being limited on SOI transistions, sometimes resulting in failure to detect an encounter/collision with the body in the next SOI.
 - [**ModuleActiveRadiatorNoParentException**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/249) [KSP 1.12.3 - 1.12.5]<br/>Fix exception spam when a radiator set to `parentCoolingOnly` is detached from the vessel
+- **DebugConsoleDontStealInput** [KSP 1.12.3 - 1.12.5]<br/>Fix the Alt+F12 console input field stealing input when a console entry is added
 
 #### Quality of Life tweaks 
 


### PR DESCRIPTION
Fix the Alt+F12 console input field stealing input when a console entry is added