### PR TITLE
Small simplification of FlightIntergratorPerf.SetDragCubeDrag

### DIFF
--- a/KSPCommunityFixes/Performance/FlightIntegratorPerf.cs
+++ b/KSPCommunityFixes/Performance/FlightIntegratorPerf.cs
@@ -757,13 +757,12 @@ namespace KSPCommunityFixes.Performance
                 double weightedDrag = dragCubes.weightedDrag[i];
 
                 double dot = Vector3.Dot(direction, faceDir);
-                double dotNormalized = (dot + 1.0) * 0.5;
                 double drag; // = PhysicsGlobals.DragCurveValue(__instance.SurfaceCurves, dotNormalized, machNumber);
 
-                if (dotNormalized <= 0.5)
-                    drag = Numerics.Lerp(fiData.dragTail, fiData.dragSurf, dotNormalized * 2.0) * fiData.dragMult;
+                if (dot <= 0.0)
+                    drag = Numerics.Lerp(fiData.dragSurf, fiData.dragTail, -dot) * fiData.dragMult;
                 else
-                    drag = Numerics.Lerp(fiData.dragSurf, fiData.dragTip, (dotNormalized - 0.5) * 2.0) * fiData.dragMult;
+                    drag = Numerics.Lerp(fiData.dragSurf, fiData.dragTip, dot) * fiData.dragMult;
 
                 double areaOccludedByDrag = areaOccluded * drag;
                 area += areaOccludedByDrag;


### PR DESCRIPTION
This probably shaves a few cycles, and if nothing else makes the code easier to understand.

I found this while working on a [mod that attempts to fix some odd drag cube behaviour](https://github.com/CensoredUsername/BodyDragFix). Not sure if that is a qualifier for KSPCommunityFixes, it does change the stock behaviour quite a bit. Basically what it does is, instead of lerping on `dot` it lerps on `dot*dot`.

Unfortunately this does also result in a compatibility issue between KSPCommunityFixes and my mod right now. Would anyone have some advice on how to deal with this? 