### PR TITLE
Fix lower limit for wheel moment of inertia

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -240,6 +240,11 @@ KSP_COMMUNITY_FIXES
   // Fix the Alt+F12 console input field stealing input when a console entry is added
   DebugConsoleDontStealInput = true
 
+  // Fix the hard-coded lower limit for the moment of inertia of wheels being too large (0.01 t*m^2) and
+  // causing incorrectly large forces on small aircraft during touchdown. This fix should prevent your craft from
+  // pitching up or down unexpectedly when touching down.
+  WheelInertiaLimit = true
+
   // ##########################
   // Obsolete bugfixes
   // ##########################

--- a/KSPCommunityFixes/BugFixes/WheelInertiaLimit.cs
+++ b/KSPCommunityFixes/BugFixes/WheelInertiaLimit.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using HarmonyLib;
+using VehiclePhysics;
+using UnityEngine;
+
+namespace KSPCommunityFixes
+{
+    public class WheelInertiaLimit : BasePatch
+    {
+        protected override Version VersionMin => new Version(1, 12, 0);
+
+        protected override void ApplyPatches()
+        {
+            AddPatch(PatchType.Postfix, typeof(VehiclePhysics.Wheel), nameof(VehiclePhysics.Wheel.RecalculateConstants));
+        }
+
+        static void Wheel_RecalculateConstants_Postfix(VehiclePhysics.Wheel __instance)
+        {
+            __instance.I = __instance.mass * __instance.radius * __instance.radius * 0.5f;
+
+            if (__instance.I < 0.00001f)
+            {
+                __instance.I = 0.00001f;
+            }
+
+            __instance.invI = 1f / __instance.I;
+        }
+    }
+}

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -128,6 +128,7 @@
     <Compile Include="BugFixes\ChutePhantomSymmetry.cs" />
     <Compile Include="BugFixes\CorrectDragForFlags.cs" />
     <Compile Include="BugFixes\DebugConsoleDontStealInput.cs" />
+    <Compile Include="BugFixes\WheelInertiaLimit.cs" />
     <Compile Include="BugFixes\DragCubeLoadException.cs" />
     <Compile Include="BugFixes\EVAConstructionMass.cs" />
     <Compile Include="BugFixes\FastAndFixedEnumExtensions.cs" />


### PR DESCRIPTION
When the game calculates the moment of inertia for wheels, it sets a hard-coded lower limit of `0.01`. This is much larger than the calculated moment of inertia of most landing gear wheels (e.g. the LY-10 Small Landing Gear has a moment of inertia of `0.000648`).

This causes significant forces on small aircraft (~10t) during touchdown as the wheels spin up. As a result, the craft pitches down if the wheels are not spinning and pitches up if the wheels are still spinning. This is correct in principle but very exaggerated in small aircraft due to the inappropriately large moment of inertia.

This patch changes the lower limit to `0.00001` which is lower than the correct moment of inertia of the stock landing gears.

The chosen lower limit is kind of arbitrary (I just added three zeroes) and I am completely open to lowering it even further or removing it entirely.