### PR TITLE
perf: Reparse the game database in parallel

### DIFF
--- a/KSPCommunityFixes/Performance/ConfigNodePerf.cs
+++ b/KSPCommunityFixes/Performance/ConfigNodePerf.cs
@@ -27,10 +27,12 @@ namespace KSPCommunityFixes.Performance
 
         const int _SaveBufferSize = 64 * 1024;
         const int _ReadBufferSize = 1024 * 1024;
-        private static readonly char[] _charBuf = new char[_ReadBufferSize];
+        [ThreadStatic]
+        private static char[] _charBuf;
         static readonly UTF8Encoding _UTF8NoBOM = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
         static readonly string _Newline = Environment.NewLine;
-        static readonly Stack<ConfigNode> _nodeStack = new Stack<ConfigNode>(128);
+        [ThreadStatic]
+        static Stack<ConfigNode> _nodeStack;
         public static bool _doClean = true; // so it is accessible from ModUpgradePipeline
         public static bool _AllowSkipIndent = false; // so it is accessible from other things if needed
         // This large-size stringbuilder is used for writing ConfigNodes to string.
@@ -738,7 +740,7 @@ namespace KSPCommunityFixes.Performance
                 if (fLength > _ReadBufferSize)
                     chars = new char[fLength];
                 else
-                    chars = _charBuf;
+                    chars = _charBuf ??= new char[_ReadBufferSize];
 
                 numChars = reader.Read(chars, 0, chars.Length);
             }
@@ -776,6 +778,7 @@ namespace KSPCommunityFixes.Performance
             int pos = 0;
             string savedName = string.Empty;
             ParseMode mode = ParseMode.SkipToKey;
+            _nodeStack ??= new Stack<ConfigNode>(128);
             _nodeStack.Push(node);
 
 


### PR DESCRIPTION
This PR has two linked changes:
- It makes config file parsing thread-safe, and,
- It parallelizes the game database rebuild at the start of the fast loader.

I have tuned the parallelism to go 3 levels deep from the root (e.g. each `GameData/Mod/SubFolder` will be done in parallel). This is enough to get some benefit on stock KSP. In my tests it takes about 900ms to process the `Squad/Parts` folder which is likely to be a lower bound on how much improvement there will be.

As it turns out, this is blocked from getting better performance with a modded folder by what looks to be contention on allocations when creating a modified stream reader, so the improvements seem to only really be about 0.5s in either case. I have a patch lying around that _should_ address this, but I haven't tested it yet.

### Stock Profiles
Before:
```
[KSPCF:FastLoader] 11th Gen Intel(R) Core(TM) i7-11700K @ 3.60GHz | 65371 MB | NVIDIA GeForce RTX 3060 (12110 MB)
Total loading time to main menu : 45.638s
- Configs and assemblies loaded in 6.663s
- Configs reload done in 1.502s
- Configs translated in 0.024s
- 2979 assets loaded in 3.383s :
  - 86 audio assets (79.689 MiB) in 0.499s, 159.719 MiB/s
  - 2238 texture assets (1.357 GiB) in 2.102s, 661.7 MiB/s
  - 654 model assets (67.207 MiB) in 0.780s, 86.209 MiB/s
- Asset bundles loaded in 0.611s
- GameDatabase (configs, resources, traits, upgrades...) loaded in 0.233s
- Built-in parts copied in 0.039s
- Part and internal configs extracted in 0.004s
- 509 parts and 2066 modules compiled in 8.721s
  - 4.1 modules/part, 17.134 ms/part, 4.221 ms/module
  - PartIcon compilation : 1.496s
- 27 internal spaces and 56 props compiled in 0.292s
- 2 DLC (Making History, Breaking Ground) loaded in 6.676s
- Planetary system loaded in 10.772s
```

After:
```
[KSPCF:FastLoader] 11th Gen Intel(R) Core(TM) i7-11700K @ 3.60GHz | 65371 MB | NVIDIA GeForce RTX 3060 (12110 MB)
Total loading time to main menu : 45.154s
- Configs and assemblies loaded in 6.525s
- Configs reload done in 1.108s
- Configs translated in 0.031s
- 2979 assets loaded in 3.443s :
  - 86 audio assets (79.689 MiB) in 0.365s, 218.481 MiB/s
  - 2238 texture assets (1.357 GiB) in 2.268s, 613.036 MiB/s
  - 654 model assets (67.207 MiB) in 0.807s, 83.317 MiB/s
- Asset bundles loaded in 0.578s
- GameDatabase (configs, resources, traits, upgrades...) loaded in 0.230s
- Built-in parts copied in 0.029s
- Part and internal configs extracted in 0.003s
- 509 parts and 2066 modules compiled in 8.616s
  - 4.1 modules/part, 16.928 ms/part, 4.171 ms/module
  - PartIcon compilation : 1.443s
- 27 internal spaces and 56 props compiled in 0.290s
- 2 DLC (Making History, Breaking Ground) loaded in 6.722s
- Planetary system loaded in 11.151s
```

And here's what the breakdown looks like internally
<img width="1632" height="897" alt="image" src="https://github.com/user-attachments/assets/d2e9b045-285d-4dfa-9fdd-fc21159b8ab3" />
