### PR TITLE
Fix method signature for ExpansionBundlePreload StartLoad override

### DIFF
--- a/KSPCommunityFixes/Performance/ExpansionBundlePreload.cs
+++ b/KSPCommunityFixes/Performance/ExpansionBundlePreload.cs
@@ -53,7 +53,7 @@ namespace KSPCommunityFixes.Performance
             instance.StartCoroutine(LoadExpansionsV2(instance));
         }
 
-        static void ExpansionsLoader_StartLoad_Override()
+        static void ExpansionsLoader_StartLoad_Override(ExpansionsLoader _)
         {
             ExpansionsLoaderStarted = true;
         }


### PR DESCRIPTION
I have noticed `ExpansionBundlePreload` failing to apply in some cases. Now that I've looked at it I'm not entirely sure how it ever worked in the first place. This fixes the method signature for the override to match that of the method it is overriding.