### PR TITLE
Avoid duplicate call to PSystemSetup.SetActive in FlightDriver.setStartupNewVessel

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -340,6 +340,9 @@ KSP_COMMUNITY_FIXES
   // and on other occasions, wasting a ton of CPU processing time.
   PQSCoroutineLeak = true
 
+  /// Prevent KSP from restarting PQS for the current planet multiple times when launching a new ship.
+  PQSOnlyStartOnce = true
+
   // Remove unused ProgressTracking update handlers. Provides a very noticeable performance uplift in 
   // career games having a large amount of celestial bodies and/or vessels.
   ProgressTrackingSpeedBoost = true

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -221,6 +221,7 @@
     <Compile Include="Performance\ModuleDockingNodeFindOtherNodesFaster.cs" />
     <Compile Include="Performance\OptimizedModuleRaycasts.cs" />
     <Compile Include="Performance\PQSCoroutineLeak.cs" />
+    <Compile Include="Performance\PQSOnlyStartOnce.cs" />
     <Compile Include="Performance\PQSUpdateNoMemoryAlloc.cs" />
     <Compile Include="Performance\ProgressTrackingSpeedBoost.cs" />
     <Compile Include="QoL\AutostrutActions.cs" />

--- a/KSPCommunityFixes/Performance/PQSOnlyStartOnce.cs
+++ b/KSPCommunityFixes/Performance/PQSOnlyStartOnce.cs
@@ -1,0 +1,70 @@
+
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using HarmonyLib;
+
+namespace KSPCommunityFixes.Performance
+{
+    class PQSOnlyStartOnce : BasePatch
+    {
+
+        protected override void ApplyPatches()
+        {
+            AddPatch(PatchType.Transpiler, typeof(FlightDriver), nameof(FlightDriver.setStartupNewVessel));
+        }
+        
+
+        static IEnumerable<CodeInstruction> FlightDriver_setStartupNewVessel_Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator gen)
+        {
+            var method1 = SymbolExtensions.GetMethodInfo<PSystemSetup>(p => p.SetPQSActive(null));
+            var method2 = SymbolExtensions.GetMethodInfo<PSystemSetup>(p => p.SetPQSActive());
+
+            var matcher = new CodeMatcher(instructions);
+            var state = gen.DeclareLocal(typeof(State));
+
+            matcher
+                .MatchStartForward(new CodeMatch(OpCodes.Callvirt, method1))
+                .Repeat(
+                    matcher =>
+                    {
+                        matcher.RemoveInstruction();
+                        matcher.InsertAndAdvance(new CodeInstruction(OpCodes.Ldloca, state));
+                        matcher.InsertAndAdvance(CodeInstruction.Call<State>(s => SetPQSActive(null, null, ref s)));
+                    }
+                );
+
+            matcher.Start();
+            matcher
+                .MatchStartForward(new CodeMatch(OpCodes.Callvirt, method2))
+                .Repeat(
+                    matcher =>
+                    {
+                        matcher.RemoveInstruction();
+                        matcher.InsertAndAdvance(new CodeInstruction(OpCodes.Ldloca, state));
+                        matcher.InsertAndAdvance(CodeInstruction.Call<State>(s => SetPQSActive(null, ref s)));
+                    }
+                );
+
+            return matcher.Instructions();
+        }
+
+        struct State
+        {
+            public bool activated;
+        }
+
+        static void SetPQSActive(PSystemSetup psystem, PQS pqs, ref State state)
+        {
+            psystem.SetPQSActive(pqs);
+            state.activated = true;
+        }
+
+        static void SetPQSActive(PSystemSetup psystem, ref State state)
+        {
+            if (state.activated)
+                return;
+
+            psystem.SetPQSActive();
+        }
+    }
+}


### PR DESCRIPTION
When you launch out of the VAB, FlightDriver.setStartupNewVessel ends up starting all PQS instances twice. The initial start of PQS is very expensive, and all the work done on the first call is basically thrown away.

This patches `FlightDriver.setStartupNewVessel` to avoid calling `PSystemSetup.SetActive` a second time. This is just a matter of patching the 3 different calls to shims that track whether they have been called.

How much this actually ends up saving depends on the planet and mods installed. For stock I expect this to be about 2s, for the Sol install I'm testing (with a whole bunch of other patches to various mods) it is about 2.5s.

### Before
<img width="1743" height="934" alt="image" src="https://github.com/user-attachments/assets/3bf980e0-3038-4e54-be45-f8d52c25ee8e" />

### After
<img width="1717" height="979" alt="image" src="https://github.com/user-attachments/assets/c05b87d5-c6b7-4d94-be45-41c036e4d89b" />
