### PR TITLE
Disable PQSOnlyStartOnce patch

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -345,8 +345,10 @@ KSP_COMMUNITY_FIXES
   // and on other occasions, wasting a ton of CPU processing time.
   PQSCoroutineLeak = true
 
-  /// Prevent KSP from restarting PQS for the current planet multiple times when launching a new ship.
-  PQSOnlyStartOnce = true
+  // Prevent KSP from restarting PQS for the current planet multiple times when launching a new ship.
+  //
+  // Disabled by default due to issue #351
+  PQSOnlyStartOnce = false
 
   // Remove unused ProgressTracking update handlers. Provides a very noticeable performance uplift in 
   // career games having a large amount of celestial bodies and/or vessels.


### PR DESCRIPTION
This seems to be causing issues when used with sigma dimensions as reported in #351. I haven't been able to reproduce the issue but the user reported that disabling the patch seems to fix it.

As such, this commit disables the patch entirely.