### PR TITLE
Patch GameDatabase.ExistsModel similarly to other methods

### DIFF
--- a/KSPCommunityFixes/Performance/GameDatabasePerf.cs
+++ b/KSPCommunityFixes/Performance/GameDatabasePerf.cs
@@ -21,6 +21,7 @@ namespace KSPCommunityFixes.Performance
             AddPatch(PatchType.Override, typeof(GameDatabase), nameof(GameDatabase.GetModel));
             AddPatch(PatchType.Override, typeof(GameDatabase), nameof(GameDatabase.GetModelIn));
             AddPatch(PatchType.Override, typeof(GameDatabase), nameof(GameDatabase.GetModelFile), new[] { typeof(GameObject) });
+            AddPatch(PatchType.Override, typeof(GameDatabase), nameof(GameDatabase.ExistsModel));
             // we don't patch the GetModelFile(string) variant as it would require an additional dictionary,
             // is unused in stock and very unlikely to ever be used by anyone.
 
@@ -120,6 +121,11 @@ namespace KSPCommunityFixes.Performance
             }
 
             return result;
+        }
+
+        static bool GameDatabase_ExistsModel_Override(GameDatabase gdb, string url)
+        {
+            return GameDatabase_GetModelPrefab_Override(gdb, url).IsNotNullRef();
         }
 
         internal static int txcallCount;


### PR DESCRIPTION
This one method call takes up ~80% of ModuleWaterfallFX.Start, which can account for a pretty significant amount of time during scene switches. This is especially true on more heavily modded games where the list of models can be much larger. The added patch is basically trivial since all the hard parts have been implemented already.

For some numbers, here's a break down of how long it takes for `ModuleWaterfallFX` on one of my test saves
<img width="1719" height="801" alt="image" src="https://github.com/user-attachments/assets/f832cd36-cdfa-4f72-b5a9-f270c39941e1" />