### PR TITLE
Fix mouse double clicks passing through to parts on vessel while the the map view is open

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -245,6 +245,10 @@ KSP_COMMUNITY_FIXES
   // pitching up or down unexpectedly when touching down.
   WheelInertiaLimit = true
 
+  // Fix mouse double clicks passing through to parts on vessel while the the map view is open.
+  // This causes current target vessel or CB getting unselected.
+  BlockMapViewPartClick = true
+
   // ##########################
   // Obsolete bugfixes
   // ##########################

--- a/KSPCommunityFixes/BugFixes/BlockMapViewPartClick.cs
+++ b/KSPCommunityFixes/BugFixes/BlockMapViewPartClick.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace KSPCommunityFixes
+{
+    public class BlockMapViewPartClick : BasePatch
+    {
+        protected override Version VersionMin => new Version(1, 12, 0);
+
+        protected override void ApplyPatches()
+        {
+            AddPatch(PatchType.Prefix, typeof(Part), "UpdateMouseOver");
+        }
+
+        static bool Part_UpdateMouseOver_Prefix()
+        {
+            return !HighLogic.LoadedSceneIsFlight || CameraManager.Instance.currentCameraMode != CameraManager.CameraMode.Map;
+        }
+    }
+}

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -130,6 +130,7 @@
   <ItemGroup>
     <Compile Include="BasePatch.cs" />
     <Compile Include="BugFixes\AsteroidInfiniteMining.cs" />
+    <Compile Include="BugFixes\BlockMapViewPartClick.cs" />
     <Compile Include="BugFixes\ChutePhantomSymmetry.cs" />
     <Compile Include="BugFixes\CorrectDragForFlags.cs" />
     <Compile Include="BugFixes\DebugConsoleDontStealInput.cs" />


### PR DESCRIPTION
This causes current target vessel or CB getting unselected.
Why this is a rather annoying issue? Many mods have UIs that can be open in map view and clickthrough blocking does nothing of use here. So with something like MJ maneuver editor you need to be careful not to click on buttons fast enough that those get registered as double clicks.