### PR TITLE
Fix radiation flux being inconsistent during timewarp

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -323,6 +323,9 @@ KSP_COMMUNITY_FIXES
   // Allow targeting the parent body of the current craft, or any body in the parent hierarchy
   TargetParentBody = true
 
+  // Fix radiation flux being inconsistent for timewarp rates 1<x≤100.
+  FIUpdateRadiation = true
+
   // ##########################
   // Performance tweaks
   // ##########################

--- a/KSPCommunityFixes/BugFixes/FIUpdateRadiation.cs
+++ b/KSPCommunityFixes/BugFixes/FIUpdateRadiation.cs
@@ -8,7 +8,7 @@ namespace KSPCommunityFixes
 
         protected override void ApplyPatches()
         {
-            AddPatch(PatchType.Prefix, typeof(FlightIntegrator), "UpdateRadiation");
+            AddPatch(PatchType.Override, typeof(FlightIntegrator), "UpdateRadiation");
         }
 
         /// <summary>
@@ -17,8 +17,7 @@ namespace KSPCommunityFixes
         /// </summary>
         /// <param name="__instance"></param>
         /// <param name="ptd"></param>
-        /// <returns></returns>
-        static bool FlightIntegrator_UpdateRadiation_Prefix(FlightIntegrator __instance, PartThermalData ptd)
+        static void FlightIntegrator_UpdateRadiation_Override(FlightIntegrator __instance, PartThermalData ptd)
         {
             double cacheStefanBoltzmanConstant = __instance.cacheStefanBoltzmanConstant;
 
@@ -52,8 +51,6 @@ namespace KSPCommunityFixes
                     ptd.radiationFlux += ptd.expFlux - (skinTemperature - brtExposed) * cacheStefanBoltzmanConstant * ptd.emissScalar * exposedArea;
                 }
             }
-
-            return false;
         }
     }
 }

--- a/KSPCommunityFixes/BugFixes/FIUpdateRadiation.cs
+++ b/KSPCommunityFixes/BugFixes/FIUpdateRadiation.cs
@@ -1,0 +1,59 @@
+﻿using System;
+
+namespace KSPCommunityFixes
+{
+    public class FIUpdateRadiation : BasePatch
+    {
+        protected override Version VersionMin => new Version(1, 12, 0);
+
+        protected override void ApplyPatches()
+        {
+            AddPatch(PatchType.Prefix, typeof(FlightIntegrator), "UpdateRadiation");
+        }
+
+        /// <summary>
+        /// UpdateRadiation method applies incoming radiation fluxes and outgoing black body radiation.
+        /// The problem with original code is that ptd.expFlux and ptd.unexpFlux get mutated during every thermal integration pass.
+        /// </summary>
+        /// <param name="__instance"></param>
+        /// <param name="ptd"></param>
+        /// <returns></returns>
+        static bool FlightIntegrator_UpdateRadiation_Prefix(FlightIntegrator __instance, PartThermalData ptd)
+        {
+            double cacheStefanBoltzmanConstant = __instance.cacheStefanBoltzmanConstant;
+
+            Part part = ptd.part;
+            if (!part.ShieldedFromAirstream)
+            {
+                double skinTemperature = part.skinTemperature;
+                double skinUnexposedTemperature = part.skinUnexposedTemperature;
+                double exposedArea = part.radiativeArea * part.skinExposedAreaFrac;             // Exposed is the fraction of radiative area subject to convection
+                double unexposedArea = part.radiativeArea * (1.0 - part.skinExposedAreaFrac);   // Unexposed is the remainder
+
+                // ptd.expFlux and ptd.unexpFlux are precalculated incoming fluxes, summed together from sun and body fluxes.
+                // ptd.brtExposed and ptd.brtUnexposed signify incoming background radiation flux.
+
+                if (skinUnexposedTemperature > 0.0 && unexposedArea > 0.0)
+                {
+                    double brtUnexposed = ptd.brtUnexposed;
+                    brtUnexposed *= brtUnexposed;
+                    brtUnexposed *= brtUnexposed;
+                    skinUnexposedTemperature *= skinUnexposedTemperature;
+                    skinUnexposedTemperature *= skinUnexposedTemperature;
+                    ptd.unexpRadiationFlux += ptd.unexpFlux - (skinUnexposedTemperature - brtUnexposed) * cacheStefanBoltzmanConstant * ptd.emissScalar * unexposedArea;
+                }
+                if (skinTemperature > 0.0 && exposedArea > 0.0)
+                {
+                    double brtExposed = ptd.brtExposed;
+                    brtExposed *= brtExposed;
+                    brtExposed *= brtExposed;
+                    skinTemperature *= skinTemperature;
+                    skinTemperature *= skinTemperature;
+                    ptd.radiationFlux += ptd.expFlux - (skinTemperature - brtExposed) * cacheStefanBoltzmanConstant * ptd.emissScalar * exposedArea;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -130,6 +130,7 @@
   <ItemGroup>
     <Compile Include="BasePatch.cs" />
     <Compile Include="BugFixes\AsteroidInfiniteMining.cs" />
+    <Compile Include="BugFixes\FIUpdateRadiation.cs" />
     <Compile Include="BugFixes\ChutePhantomSymmetry.cs" />
     <Compile Include="BugFixes\CorrectDragForFlags.cs" />
     <Compile Include="BugFixes\DebugConsoleDontStealInput.cs" />


### PR DESCRIPTION
The problem with original code is that ptd.expFlux and ptd.unexpFlux get mutated during every thermal integration pass. This will cause the magnitude of the flux to increase with every timewarp step. 1x speed and analytic mode (>100x) behaved correctly before and are thus unchanged.