### PR TITLE
Fix an accidental material instantiation in Highlighter.UpdateRenderers

### DIFF
--- a/KSPCommunityFixes/Performance/PartSystemsFastUpdate.cs
+++ b/KSPCommunityFixes/Performance/PartSystemsFastUpdate.cs
@@ -258,7 +258,7 @@ namespace KSPCommunityFixes.Performance
                 for (int i = partRenderers.Count; i-- > 0;)
                 {
                     Renderer renderer = partRenderers[i];
-                    if (renderer.gameObject.layer != 1 && !renderer.material.name.Contains("KSP/Alpha/Translucent Additive"))
+                    if (renderer.gameObject.layer != 1 && !renderer.sharedMaterial.name.Contains("KSP/Alpha/Translucent Additive"))
                     {
                         RendererCache rendererCache = new RendererCache(renderer, hl.opaqueMaterial, hl.zTestFloat, hl.stencilRefFloat);
                         hl.highlightableRenderers.Add(rendererCache);


### PR DESCRIPTION
This loop is just trying to find a material with the appropriate name. However, because it is using `.material` it unshares all the materials in any game object that happens to have a highlighter component on it. (i.e. every single part in the editor).