### PR TITLE
perf: Cache some expensive operations in stock drill modules

### DIFF
--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -512,6 +512,10 @@ KSP_COMMUNITY_FIXES
   // Load the expansion bundles in the background while performing part compilation.
   ExpansionBundlePreload = true
 
+  // Cache some expensive computations in stock resource converter and drill modules.
+  // This has a fairly significant impact on ships with lots of drills.
+  ResourceConverterPerf = true
+
   // ##########################
   // Modding
   // ##########################

--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -168,6 +168,7 @@
     <Compile Include="Library\ObjectPool.cs" />
     <Compile Include="Library\MuParser.cs" />
     <Compile Include="Library\ShaderHelpers.cs" />
+    <Compile Include="Library\HashCode.cs" />
     <Compile Include="Modding\KSPFieldEnumDesc.cs" />
     <Compile Include="Modding\ModUpgradePipeline.cs" />
     <Compile Include="Performance\CraftBrowserOptimisations.cs" />
@@ -198,6 +199,7 @@
     <Compile Include="Performance\LocalizerPerf.cs" />
     <Compile Include="Performance\LowerMinPhysicsDTPerFrame.cs" />
     <Compile Include="Performance\MemoryLeaks.cs" />
+    <Compile Include="Performance\ResourceConverterPerf.cs" />
     <Compile Include="BugFixes\RescaledRoboticParts.cs" />
     <Compile Include="Modding\DepartmentHeadImage.cs" />
     <Compile Include="BugFixes\StickySplashedFixer.cs" />

--- a/KSPCommunityFixes/Library/HashCode.cs
+++ b/KSPCommunityFixes/Library/HashCode.cs
@@ -1,0 +1,14 @@
+namespace KSPCommunityFixes.Library
+{
+    internal static class HashCode
+    {
+        // Source: https://github.com/dotnet/coreclr/blob/456afea9fbe721e57986a21eb3b4bb1c9c7e4c56/src/System.Private.CoreLib/shared/System/Numerics/Hashing/HashHelpers.cs#L11-L17
+        internal static int Combine(int h1, int h2)
+        {
+            uint rol5 = ((uint)h1 << 5) | ((uint)h1 >> 27);
+            return ((int)rol5 + h1) ^ h2;
+        }
+
+        internal static int Combine(int h1, int h2, int h3) => Combine(Combine(h1, h2), h3);
+    }
+}

--- a/KSPCommunityFixes/Performance/ResourceConverterPerf.cs
+++ b/KSPCommunityFixes/Performance/ResourceConverterPerf.cs
@@ -14,6 +14,11 @@
 // * ResourceConverter.ProcessRecipe repeatedly ends up formatting a few different
 //   strings using the resource displayName. This is expensive and there are a limited
 //   number of resource display names so we cache the resulting localized strings.
+//
+// In addition, we also fix some other bugs that cause performance issues in stock:
+// * ResourceConverter.GetDeltaTime has a check to tell whether it should be
+//   operating in catchup mode. However, this is always off by ~5e-10 so it never
+//   actually exits catchup mode. We fix that by allowing a 1% margin of error.
 
 using HarmonyLib;
 using KSP.Localization;
@@ -36,6 +41,7 @@ namespace KSPCommunityFixes.Performance
             AddPatch(PatchType.Override, typeof(ModuleAsteroidDrill), nameof(ModuleAsteroidDrill.CheckForImpact));
             AddPatch(PatchType.Override, typeof(ModuleCometDrill), nameof(ModuleCometDrill.CheckForImpact));
             AddPatch(PatchType.Transpiler, typeof(ResourceConverter), nameof(ResourceConverter.ProcessRecipe));
+            AddPatch(PatchType.Override, typeof(BaseConverter), nameof(BaseConverter.GetDeltaTime));
         }
 
         #region Abundance Cache
@@ -281,6 +287,49 @@ namespace KSPCommunityFixes.Performance
                 .Repeat(matcher => matcher.SetOperandAndAdvance(cachedMethod));
 
             return matcher.Instructions();
+        }
+        #endregion
+
+        #region Fix GetDeltaTime Comparison Check
+        static double BaseConverter_GetDeltaTime_Override(BaseConverter converter)
+        {
+            if (Time.timeSinceLevelLoad < 1f || !FlightGlobals.ready)
+                return -1d;
+            if (Math.Abs(converter.lastUpdateTime) < 1e-9)
+            {
+                converter.lastUpdateTime = Planetarium.GetUniversalTime();
+                return -1.0;
+            }
+
+            try
+            {
+                double deltaT = Math.Min(
+                    Planetarium.GetUniversalTime() - converter.lastUpdateTime,
+                    ResourceUtilities.GetMaxDeltaTime());
+                double fixedDeltaT = Math.Min(TimeWarp.fixedDeltaTime, 0.02);
+
+                // We multiply fixedDeltaT by 1.01 because otherwise it tends to be
+                // smaller than deltaT by ~5e-10, which makes it so that in stock
+                // GetBestDeltaTime is almost always called.
+                if (deltaT > fixedDeltaT * 1.01 && converter.catchupRetries < 10)
+                {
+                    double bestDeltaT = converter.GetBestDeltaTime(deltaT);
+                    if (bestDeltaT < deltaT)
+                    {
+                        converter.catchupRetries++;
+                        deltaT = Math.Max(fixedDeltaT, bestDeltaT);
+                    }
+                }
+
+                converter.lastUpdateTime += deltaT;
+                return deltaT;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError("[RESOURCES] Error in BaseConverter.GetDeltaTime");
+                Debug.LogException(ex);
+                return 0.0;
+            }
         }
         #endregion
     }

--- a/KSPCommunityFixes/Performance/ResourceConverterPerf.cs
+++ b/KSPCommunityFixes/Performance/ResourceConverterPerf.cs
@@ -3,7 +3,7 @@
 // while FixedUpdate is running, so we can save quite a bit of time by caching
 // them.
 //
-// The two main thing we cache are:
+// The things we cache are:
 // * Each and every ModuleResourceHarvester makes two calls to ResourceMap.GetAbundance
 //   every FixedUpdate. The result of this only really depends on the vessel, resource
 //   name, and harvester type, so we cache it so that it only gets done once per
@@ -11,8 +11,12 @@
 // * All 3 drill modules do two raycasts per FixedUpdate to check if they are touching
 //   the target/ground. This doesn't change while they are running so we add a cache
 //   that avoids the duplicate.
+// * ResourceConverter.ProcessRecipe repeatedly ends up formatting a few different
+//   strings using the resource displayName. This is expensive and there are a limited
+//   number of resource display names so we cache the resulting localized strings.
 
 using HarmonyLib;
+using KSP.Localization;
 using KSPCommunityFixes.Library;
 using System;
 using System.Collections.Generic;
@@ -31,6 +35,7 @@ namespace KSPCommunityFixes.Performance
             AddPatch(PatchType.Override, typeof(ModuleResourceHarvester), nameof(ModuleResourceHarvester.CheckForImpact));
             AddPatch(PatchType.Override, typeof(ModuleAsteroidDrill), nameof(ModuleAsteroidDrill.CheckForImpact));
             AddPatch(PatchType.Override, typeof(ModuleCometDrill), nameof(ModuleCometDrill.CheckForImpact));
+            AddPatch(PatchType.Transpiler, typeof(ResourceConverter), nameof(ResourceConverter.ProcessRecipe));
         }
 
         #region Abundance Cache
@@ -218,6 +223,64 @@ namespace KSPCommunityFixes.Performance
                 module.impactHitInfo = default;
                 return false;
             }
+        }
+        #endregion
+
+        #region ResourceConverter Format Cache
+        struct FormatCacheKey : IEquatable<FormatCacheKey>
+        {
+            public string template;
+            public string name;
+
+            public readonly bool Equals(FormatCacheKey other)
+                => template == other.template
+                && name == other.name;
+            public readonly override bool Equals(object obj) => obj is FormatCacheKey key && Equals(key);
+            public readonly override int GetHashCode() =>
+                HashCode.Combine(template.GetHashCode(), name.GetHashCode());
+        }
+
+        static readonly Dictionary<FormatCacheKey, string> FormatCache = new Dictionary<FormatCacheKey, string>();
+
+        static string LocalizerFormatCached(string template, string[] list)
+        {
+            switch (template)
+            {
+                case "#autoLOC_261332":
+                    goto default;
+
+                case "#autoLOC_261304":
+                case "#autoLOC_261334":
+                case "#autoLOC_261263":
+                    var key = new FormatCacheKey
+                    {
+                        template = template,
+                        name = list[0]
+                    };
+
+                    if (FormatCache.TryGetValue(key, out var value))
+                        return value;
+
+                    value = Localizer.Format(template, list);
+                    FormatCache.Add(key, value);
+                    return value;
+
+                default:
+                    return Localizer.Format(template, list);
+            }
+        }
+
+        static IEnumerable<CodeInstruction> ResourceConverter_ProcessRecipe_Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            var formatMethod = SymbolExtensions.GetMethodInfo(() => Localizer.Format("", new string[] { }));
+            var cachedMethod = SymbolExtensions.GetMethodInfo(() => LocalizerFormatCached("", new string[] { }));
+
+            var matcher = new CodeMatcher(instructions);
+            matcher
+                .MatchStartForward(new CodeMatch(OpCodes.Call, formatMethod))
+                .Repeat(matcher => matcher.SetOperandAndAdvance(cachedMethod));
+
+            return matcher.Instructions();
         }
         #endregion
     }

--- a/KSPCommunityFixes/Performance/ResourceConverterPerf.cs
+++ b/KSPCommunityFixes/Performance/ResourceConverterPerf.cs
@@ -1,0 +1,225 @@
+// The stock ModuleAsteroidDrill, ModuleCometDrill, and ModuleResourceHarvester
+// each do a couple expensive operations twice per FixedUpdate. These don't change
+// while FixedUpdate is running, so we can save quite a bit of time by caching
+// them.
+//
+// The two main thing we cache are:
+// * Each and every ModuleResourceHarvester makes two calls to ResourceMap.GetAbundance
+//   every FixedUpdate. The result of this only really depends on the vessel, resource
+//   name, and harvester type, so we cache it so that it only gets done once per
+//   frame (for a given cache key) instead of redoing it for every single module.
+// * All 3 drill modules do two raycasts per FixedUpdate to check if they are touching
+//   the target/ground. This doesn't change while they are running so we add a cache
+//   that avoids the duplicate.
+
+using HarmonyLib;
+using KSPCommunityFixes.Library;
+using System;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using UnityEngine;
+
+namespace KSPCommunityFixes.Performance
+{
+    internal class ResourceConverterPerf : BasePatch
+    {
+        protected override Version VersionMin => new Version(1, 12, 3);
+
+        protected override void ApplyPatches()
+        {
+            AddPatch(PatchType.Transpiler, typeof(ModuleResourceHarvester), nameof(ModuleResourceHarvester.PrepareRecipe));
+            AddPatch(PatchType.Override, typeof(ModuleResourceHarvester), nameof(ModuleResourceHarvester.CheckForImpact));
+            AddPatch(PatchType.Override, typeof(ModuleAsteroidDrill), nameof(ModuleAsteroidDrill.CheckForImpact));
+            AddPatch(PatchType.Override, typeof(ModuleCometDrill), nameof(ModuleCometDrill.CheckForImpact));
+        }
+
+        #region Abundance Cache
+        struct AbundanceCacheKey : IEquatable<AbundanceCacheKey>
+        {
+            public int VesselID;
+            public HarvestTypes ResourceType;
+            public string ResourceName;
+
+            public readonly bool Equals(AbundanceCacheKey other)
+                => VesselID == other.VesselID
+                && ResourceType == other.ResourceType
+                && ResourceName == other.ResourceName;
+            public readonly override bool Equals(object obj) => obj is AbundanceCacheKey key && Equals(key);
+            public readonly override int GetHashCode()
+                => HashCode.Combine(VesselID, (int)ResourceType, ResourceName.GetHashCode());
+        }
+
+        private static int AbundanceCacheFrame = -1;
+        private static readonly Dictionary<AbundanceCacheKey, float> AbundanceCache = new Dictionary<AbundanceCacheKey, float>();
+
+        static float GetAbundanceCached(
+            ResourceMap map,
+            AbundanceRequest request,
+            PartModule module)
+        {
+            var vessel = module.vessel;
+            var cacheKey = new AbundanceCacheKey
+            {
+                VesselID = vessel.GetInstanceID(),
+                ResourceType = request.ResourceType,
+                ResourceName = request.ResourceName
+            };
+
+            var frameCount = Time.frameCount;
+            if (AbundanceCacheFrame != frameCount)
+            {
+                AbundanceCache.Clear();
+                AbundanceCacheFrame = frameCount;
+            }
+            else if (AbundanceCache.TryGetValue(cacheKey, out var cached))
+            {
+                return cached;
+            }
+
+            var abundance = map.GetAbundance(request);
+            AbundanceCache.Add(cacheKey, abundance);
+            return abundance;
+        }
+
+        static IEnumerable<CodeInstruction> ModuleResourceHarvester_PrepareRecipe_Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            var getAbundanceMethod = SymbolExtensions.GetMethodInfo<ResourceMap>(map => map.GetAbundance(default));
+            var checkForImpactMethod = SymbolExtensions.GetMethodInfo<ModuleResourceHarvester>(module => module.CheckForImpact());
+            var getAbundanceCached = SymbolExtensions.GetMethodInfo(() => GetAbundanceCached(null, default, null));
+
+            var matcher = new CodeMatcher(instructions);
+
+            // Replace GetAbundance with our own cached version
+            matcher
+                .MatchStartForward(new CodeMatch(OpCodes.Callvirt, getAbundanceMethod))
+                .ThrowIfInvalid("Unable to find call to ResourceMap.GetAbundance")
+                .RemoveInstruction()
+                .Insert(
+                    new CodeInstruction(OpCodes.Ldarg_0),
+                    new CodeInstruction(OpCodes.Call, getAbundanceCached)
+                );
+
+            return matcher.Instructions();
+        }
+        #endregion
+
+        #region Drill Impact Cache
+        static float ImpactCacheTime = float.NaN;
+        static Vector3 ImpactPosition = new Vector3(float.NaN, float.NaN, float.NaN);
+        static Vector3 ImpactDirection = new Vector3(float.NaN, float.NaN, float.NaN);
+        static float ImpactRange = float.NaN;
+        static int ImpactLayerMask = 0;
+
+        static RaycastHit? ImpactCacheValue = null;
+
+        static RaycastHit? CheckForImpactCached(Transform transform, float range, int layerMask = -5)
+        {
+            if (transform.IsNullOrDestroyed())
+                return null;
+
+            var position = transform.position;
+            var direction = transform.forward;
+            var fixedTime = Time.fixedTime;
+            
+            if (ImpactCacheTime == fixedTime
+                && ImpactPosition == position
+                && ImpactDirection == direction
+                && ImpactRange == range
+                && ImpactLayerMask == layerMask)
+            {
+                return ImpactCacheValue;
+            }
+
+            var result = Physics.Raycast(
+                new Ray(position, direction),
+                out var hitInfo,
+                range,
+                layerMask);
+
+            ImpactCacheTime = fixedTime;
+            ImpactPosition = position;
+            ImpactDirection = direction;
+            ImpactRange = range;
+            ImpactLayerMask = layerMask;
+
+            if (result)
+                ImpactCacheValue = hitInfo;
+            else
+                ImpactCacheValue = null;
+
+            return ImpactCacheValue;
+        }
+
+        static bool ModuleResourceHarvester_CheckForImpact_Override(ModuleResourceHarvester module)
+        {
+            if (string.IsNullOrEmpty(module.ImpactTransform))
+                return true;
+            if (module.impactTransformCache.IsNullOrDestroyed())
+                return true;
+
+            var hitInfo = CheckForImpactCached(
+                module.impactTransformCache,
+                module.ImpactRange,
+                1 << 15);
+
+            if (hitInfo is RaycastHit hit)
+            {
+                module.impactHitInfo = hit;
+                return true;
+            }
+            else
+            {
+                module.impactHitInfo = default;
+                return false;
+            }
+        }
+
+        static bool ModuleAsteroidDrill_CheckForImpact_Override(ModuleAsteroidDrill module)
+        {
+            if (string.IsNullOrEmpty(module.ImpactTransform))
+                return true;
+            if (module.impactTransformCache.IsNullOrDestroyed())
+                return true;
+
+            var hitInfo = CheckForImpactCached(
+                module.impactTransformCache,
+                module.ImpactRange);
+
+            if (hitInfo is RaycastHit hit)
+            {
+                module.impactHitInfo = hit;
+                return hit.collider.gameObject.GetComponentUpwards<ModuleAsteroid>() != null;
+            }
+            else
+            {
+                module.impactHitInfo = default;
+                return false;
+            }
+        }
+
+        static bool ModuleCometDrill_CheckForImpact_Override(ModuleCometDrill module)
+        {
+            if (string.IsNullOrEmpty(module.ImpactTransform))
+                return true;
+            if (module.impactTransformCache.IsNullOrDestroyed())
+                return true;
+
+            var hitInfo = CheckForImpactCached(
+                module.impactTransformCache,
+                module.ImpactRange);
+
+            if (hitInfo is RaycastHit hit)
+            {
+                module.impactHitInfo = hit;
+                return hit.collider.gameObject.GetComponentUpwards<ModuleComet>() != null;
+            }
+            else
+            {
+                module.impactHitInfo = default;
+                return false;
+            }
+        }
+        #endregion
+    }
+}
+

--- a/KSPCommunityFixes/Performance/ResourceConverterPerf.cs
+++ b/KSPCommunityFixes/Performance/ResourceConverterPerf.cs
@@ -37,9 +37,6 @@ namespace KSPCommunityFixes.Performance
         protected override void ApplyPatches()
         {
             AddPatch(PatchType.Transpiler, typeof(ModuleResourceHarvester), nameof(ModuleResourceHarvester.PrepareRecipe));
-            AddPatch(PatchType.Override, typeof(ModuleResourceHarvester), nameof(ModuleResourceHarvester.CheckForImpact));
-            AddPatch(PatchType.Override, typeof(ModuleAsteroidDrill), nameof(ModuleAsteroidDrill.CheckForImpact));
-            AddPatch(PatchType.Override, typeof(ModuleCometDrill), nameof(ModuleCometDrill.CheckForImpact));
             AddPatch(PatchType.Transpiler, typeof(ResourceConverter), nameof(ResourceConverter.ProcessRecipe));
             AddPatch(PatchType.Override, typeof(BaseConverter), nameof(BaseConverter.GetDeltaTime));
         }
@@ -111,124 +108,6 @@ namespace KSPCommunityFixes.Performance
                 );
 
             return matcher.Instructions();
-        }
-        #endregion
-
-        #region Drill Impact Cache
-        static float ImpactCacheTime = float.NaN;
-        static Vector3 ImpactPosition = new Vector3(float.NaN, float.NaN, float.NaN);
-        static Vector3 ImpactDirection = new Vector3(float.NaN, float.NaN, float.NaN);
-        static float ImpactRange = float.NaN;
-        static int ImpactLayerMask = 0;
-
-        static RaycastHit? ImpactCacheValue = null;
-
-        static RaycastHit? CheckForImpactCached(Transform transform, float range, int layerMask = -5)
-        {
-            if (transform.IsNullOrDestroyed())
-                return null;
-
-            var position = transform.position;
-            var direction = transform.forward;
-            var fixedTime = Time.fixedTime;
-            
-            if (ImpactCacheTime == fixedTime
-                && ImpactPosition == position
-                && ImpactDirection == direction
-                && ImpactRange == range
-                && ImpactLayerMask == layerMask)
-            {
-                return ImpactCacheValue;
-            }
-
-            var result = Physics.Raycast(
-                new Ray(position, direction),
-                out var hitInfo,
-                range,
-                layerMask);
-
-            ImpactCacheTime = fixedTime;
-            ImpactPosition = position;
-            ImpactDirection = direction;
-            ImpactRange = range;
-            ImpactLayerMask = layerMask;
-
-            if (result)
-                ImpactCacheValue = hitInfo;
-            else
-                ImpactCacheValue = null;
-
-            return ImpactCacheValue;
-        }
-
-        static bool ModuleResourceHarvester_CheckForImpact_Override(ModuleResourceHarvester module)
-        {
-            if (string.IsNullOrEmpty(module.ImpactTransform))
-                return true;
-            if (module.impactTransformCache.IsNullOrDestroyed())
-                return true;
-
-            var hitInfo = CheckForImpactCached(
-                module.impactTransformCache,
-                module.ImpactRange,
-                1 << 15);
-
-            if (hitInfo is RaycastHit hit)
-            {
-                module.impactHitInfo = hit;
-                return true;
-            }
-            else
-            {
-                module.impactHitInfo = default;
-                return false;
-            }
-        }
-
-        static bool ModuleAsteroidDrill_CheckForImpact_Override(ModuleAsteroidDrill module)
-        {
-            if (string.IsNullOrEmpty(module.ImpactTransform))
-                return true;
-            if (module.impactTransformCache.IsNullOrDestroyed())
-                return true;
-
-            var hitInfo = CheckForImpactCached(
-                module.impactTransformCache,
-                module.ImpactRange);
-
-            if (hitInfo is RaycastHit hit)
-            {
-                module.impactHitInfo = hit;
-                return hit.collider.gameObject.GetComponentUpwards<ModuleAsteroid>() != null;
-            }
-            else
-            {
-                module.impactHitInfo = default;
-                return false;
-            }
-        }
-
-        static bool ModuleCometDrill_CheckForImpact_Override(ModuleCometDrill module)
-        {
-            if (string.IsNullOrEmpty(module.ImpactTransform))
-                return true;
-            if (module.impactTransformCache.IsNullOrDestroyed())
-                return true;
-
-            var hitInfo = CheckForImpactCached(
-                module.impactTransformCache,
-                module.ImpactRange);
-
-            if (hitInfo is RaycastHit hit)
-            {
-                module.impactHitInfo = hit;
-                return hit.collider.gameObject.GetComponentUpwards<ModuleComet>() != null;
-            }
-            else
-            {
-                module.impactHitInfo = default;
-                return false;
-            }
         }
         #endregion
 


### PR DESCRIPTION
All 3 of these spend a significant amount of time performing operations that could be shared. This introduces caches for those operations where applicable.

The two things cached here are:
* ResourceMap.GetAbundance calls - these are expensive but also do not change for the same (vessel, harvester type, resource name) key. We can do them once per frame and then keep reusing the result.
* CheckForImpact - this does an expensive raycast and gets called twice per FixedUpdate. We cache this so it only gets called once.

On net this seems to make things about 50% faster for `ModuleResourceHarvester`. I expect the other two to have a fairly minor improvement, though I haven't profiled them.

Before:
<img width="1688" height="594" alt="image" src="https://github.com/user-attachments/assets/30ab7983-1ca2-45f6-8b16-51aea9fdd258" />

After:
<img width="1734" height="805" alt="image" src="https://github.com/user-attachments/assets/44e5a263-bb1f-4b09-84ec-f114dc5b0cd2" />
