### PR TITLE
Avoid scaling ModuleResourceHarvester inputs by Efficiency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Improved the **ExtendedDeployableParts** patch to fix a `NullReferenceException` ([issue #380](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/380)) thrown when a static (non-animated) solar panel is placed on a part that has other, unrelated animations.
 - New KSP bugfix : [**SymmetryReferenceOnDelete**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/382) Fix deleting a part in the editor leaving stale (destroyed) references in the `symmetryCounterparts` list of surviving parts, which broke ship saving and the editor. Happens when removing symmetry from a parent part that still has children, then deleting it.
 - New KSP bugfix : [**EVAConstructionUninitializedInventory**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/378) Fixes a bug where stock will return parts that are not initialized yet when searching for parts with inventories, causing bugs in downstream mods.
+- New KSP bugfix : [**HarvesterECConsumption**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/358) Show accurate resource consumption info for `ModuleResourceHarvester`.
 
 ##### 1.40.1
 **Bug Fixes**

--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -264,6 +264,9 @@ KSP_COMMUNITY_FIXES
   // Fix a bug where a disabling symmetry on a part then deleting it breaks the editor.
   SymmetryReferenceOnDelete = true
 
+  // Make the info panel for `ModuleResourceHarvester` show accurate rates for consumed resources.
+  HarvesterECConsumption = true
+
   // ##########################
   // Obsolete bugfixes
   // ##########################

--- a/KSPCommunityFixes/BugFixes/HarvesterECConsumption.cs
+++ b/KSPCommunityFixes/BugFixes/HarvesterECConsumption.cs
@@ -1,0 +1,70 @@
+// ModuleResourceHarvester.GetInfo() multiplies the harvester's INPUT_RESOURCE
+// rates by Efficiency before displaying them. However, ModuleResourceHarvester
+// itself does not actually multiply input resources by Efficiency when figuring
+// out how much to consume, so that figures displayed in the editor are wrong.
+//
+// This patch overrides GetInfo so that it returns the correct values.
+//
+// See https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/358
+
+using System;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using HarmonyLib;
+
+namespace KSPCommunityFixes.BugFixes;
+
+internal class HarvesterECConsumption : BasePatch
+{
+    protected override Version VersionMin => new(1, 8, 0);
+
+    protected override void ApplyPatches()
+    {
+        AddPatch(PatchType.Transpiler, typeof(ModuleResourceHarvester), nameof(ModuleResourceHarvester.GetInfo));
+    }
+
+    static IEnumerable<CodeInstruction> ModuleResourceHarvester_GetInfo_Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        var efficiency = AccessTools.Field(typeof(BaseDrill), nameof(BaseDrill.Efficiency));
+        var matcher = new CodeMatcher(instructions);
+
+        // End fence: the "Outputs:" header. Efficiency uses at or after this point belong
+        // to the output loop and must be left scaled.
+        matcher
+            .MatchStartForward(new CodeMatch(OpCodes.Ldstr, "#autoLOC_259698"))
+            .ThrowIfInvalid("Unable to find the outputs section header (#autoLOC_259698)");
+        int outputsHeader = matcher.Pos;
+
+        // Start fence: the "Inputs:" header. This skips the `Efficiency * 100f` use in the
+        // part header, which has a different shape and isn't part of the inputs loop.
+        matcher
+            .Start()
+            .MatchStartForward(new CodeMatch(OpCodes.Ldstr, "#autoLOC_259676"))
+            .ThrowIfInvalid("Unable to find the inputs section header (#autoLOC_259676)");
+
+        int replaced = 0;
+        while (true)
+        {
+            matcher.MatchStartForward(
+                new CodeMatch(OpCodes.Ldarg_0),
+                new CodeMatch(OpCodes.Ldfld, efficiency),
+                new CodeMatch(OpCodes.Conv_R8),
+                new CodeMatch(OpCodes.Mul));
+
+            if (!matcher.IsValid || matcher.Pos >= outputsHeader)
+                break;
+
+            // Replace this.Efficiency with 1.0f.
+            // ldarg.0 -> nop, ldfld Efficiency -> ldc.r4 1 (conv.r8 then makes it 1.0).
+            matcher
+                .SetAndAdvance(OpCodes.Nop, null)
+                .SetAndAdvance(OpCodes.Ldc_R4, 1f);
+            replaced++;
+        }
+
+        if (replaced != 5)
+            throw new Exception($"[HarvesterECConsumption] Expected 5 Efficiency factors in the inputs loop, found {replaced}");
+
+        return matcher.Instructions();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ User options are available from the "ESC" in-game settings menu :<br/><img src="
 - [**DebugConsoleDontStealInput**](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/329) [KSP 1.12.3 - 1.12.5]<br/>Fix the Alt+F12 console input field stealing input when a console entry is added
 - [**WheelIntertialLimit**](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/341) Reduces the minimum inertia limit for wheels from 0.01 to 0.00001. Several small wheels had inertia values below this limit, so this makes them behave more correctly.
 - [**MapTargetBodyWithEncounter**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/381) [KSP 1.12.0 - 1.12.5]<br/>Fix being unable to left-click or double-click a celestial body's icon in the map view (to set it as target) when a maneuver node produces an encounter with that body.
+- [**HarvesterECConsumption**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/358) [KSP 1.8.0 - 1.12.5]<br/>Make the info panel for `ModuleResourceHarvester` show accurate rates for consumed resources.
 
 #### Quality of Life tweaks 
 


### PR DESCRIPTION
The actual implementation of ModuleResourceHarvester does not do this, so its GetInfo ends up not matching what is actually being consumed in-game.

This just patches GetInfo to avoid multiplying input rates by Efficiency.

Fixes #358