### PR TITLE
Ignore TransparentFX renderers in PartBoundsIgnoreDisabledTransforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - New KSP bugfix : [**EVAConstructionUninitializedInventory**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/378) Fixes a bug where stock will return parts that are not initialized yet when searching for parts with inventories, causing bugs in downstream mods.
 - New KSP bugfix : [**HarvesterECConsumption**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/358) Show accurate resource consumption info for `ModuleResourceHarvester`.
 
+**Bug Fixes**
+- **PartBoundsIgnoreDisabledTransforms** : This patch now ignores meshes on the TransparentFX layer when computing bounds. This should prevent waterfall effects or other effect-only meshes from affecting the part bounds.
+
 ##### 1.40.1
 **Bug Fixes**
 - **PQSOnlyStartOnce** : This patch is now disabled by default as it appears to cause

--- a/KSPCommunityFixes/BugFixes/PartBoundsIgnoreDisabledTransforms.cs
+++ b/KSPCommunityFixes/BugFixes/PartBoundsIgnoreDisabledTransforms.cs
@@ -9,17 +9,17 @@ namespace KSPCommunityFixes
     {
         static PartBoundsIgnoreDisabledTransforms()
         {
-            PartGeometryUtil.disabledVariantGOs = new List<string>();
+            PartGeometryUtil.disabledVariantGOs = [];
         }
 
-        protected override Version VersionMin => new Version(1, 12, 3);
+        protected override Version VersionMin => new(1, 12, 3);
 
         protected override void ApplyPatches()
         {
             AddPatch(PatchType.Prefix, typeof(PartGeometryUtil), nameof(PartGeometryUtil.GetPartRendererBounds));
         }
 
-        static readonly List<Renderer> partRenderersBuffer = new List<Renderer>();
+        static readonly List<Renderer> partRenderersBuffer = [];
 
         static bool PartGeometryUtil_GetPartRendererBounds_Prefix(Part p, out Bounds[] __result)
         {
@@ -43,9 +43,20 @@ namespace KSPCommunityFixes
 
             Transform modelTransform = GetPartModelTransform(p);
 
-            try 
+            // Ignore renderers on the TransparentFX layer (layer 1).
+            //
+            // We can't do this unconditionally because when a part is detached in the editor KSP
+            // temporarily moves all its renderers to layer 1. If we were then we'd get 0-sized
+            // bounds. We instead take a cue from DragCubeGeneration and only filter out layer 1
+            // when the part is not frozen.
+            //
+            // This matches the same rule as done in https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/150
+            // which isn't really perfect, but is probably good enough for our purposes.
+            bool ignoreTransparentFX = !p.frozen;
+
+            try
             {
-                GetRenderersRecursive(modelTransform, partRenderersBuffer, PartGeometryUtil.disabledVariantGOs);
+                GetRenderersRecursive(modelTransform, partRenderersBuffer, PartGeometryUtil.disabledVariantGOs, ignoreTransparentFX);
 
                 __result = new Bounds[partRenderersBuffer.Count];
                 for (int i = __result.Length; i-- > 0;)
@@ -59,14 +70,17 @@ namespace KSPCommunityFixes
             return false;
         }
 
-        static readonly List<Renderer> rendererBuffer = new List<Renderer>();
+        static readonly List<Renderer> rendererBuffer = [];
 
-        static void GetRenderersRecursive(Transform parent, List<Renderer> renderers, List<string> excludedGOs)
+        static void GetRenderersRecursive(Transform parent, List<Renderer> renderers, List<string> excludedGOs, bool ignoreTransparentFX)
         {
             // note : this will result in a slight change in behavior vs stock
             // as this will exclude childs as well, wereas stock will still include them.
             // But stock behavior could be classified as a bug...
             if (excludedGOs.Contains(parent.name))
+                return;
+
+            if (ignoreTransparentFX && parent.gameObject.layer == 1)
                 return;
 
             try
@@ -89,7 +103,7 @@ namespace KSPCommunityFixes
             {
                 Transform child = parent.GetChild(i);
                 if (child.gameObject.activeSelf)
-                    GetRenderersRecursive(child, renderers, excludedGOs);
+                    GetRenderersRecursive(child, renderers, excludedGOs, ignoreTransparentFX);
             }
         }
 


### PR DESCRIPTION
Some effects add new renderer meshes to a part module for transparent effects (e.g. Waterfall). Without KSPCF these are not included in the renderer bounds because it is only calculated once before runtime additions happen, but with the PartBoundsIgnoreDisabledTransforms patch this is now calculated later on and picks up TransparentFX renderers.

This updates the patch to exclude said renderers. There are cases in the editor where everything is on the TransparentFX layer (detached parts) so we can't do this unconditionally, but it should work in all the cases that matter.

Fixes #386