### PR TITLE
Emit onEditorShipModified when part animations complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - New KSP bugfix : [**SymmetryReferenceOnDelete**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/382) Fix deleting a part in the editor leaving stale (destroyed) references in the `symmetryCounterparts` list of surviving parts, which broke ship saving and the editor. Happens when removing symmetry from a parent part that still has children, then deleting it.
 - New KSP bugfix : [**EVAConstructionUninitializedInventory**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/378) Fixes a bug where stock will return parts that are not initialized yet when searching for parts with inventories, causing bugs in downstream mods.
 - New KSP bugfix : [**HarvesterECConsumption**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/358) Show accurate resource consumption info for `ModuleResourceHarvester`.
+- New KSP bugfix : [**EditorAnimatedPartsShipModified**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/388) Fix the Engineer's Report craft dimensions lagging one vessel modification behind when an animated part is actuated in the editor (deployable solar panels/radiators/antennas, `ModuleAnimateGeneric`, Breaking Ground robotic servos).
 
 **Bug Fixes**
 - **PartBoundsIgnoreDisabledTransforms** : This patch now ignores meshes on the TransparentFX layer when computing bounds. This should prevent waterfall effects or other effect-only meshes from affecting the part bounds.

--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -267,6 +267,13 @@ KSP_COMMUNITY_FIXES
   // Make the info panel for `ModuleResourceHarvester` show accurate rates for consumed resources.
   HarvesterECConsumption = true
 
+  // Fix the Engineer's Report (and other onEditorShipModified consumers) reporting craft
+  // dimensions one modification behind when an animated part is actuated in the editor: deployable
+  // parts (solar panels, radiators, antennas...), ModuleAnimateGeneric animations and Breaking Ground
+  // robotic servos. Re-fires onEditorShipModified once the animation has actually finished so the
+  // reported bounds reflect the settled geometry.
+  EditorAnimatedPartsShipModified = true
+
   // ##########################
   // Obsolete bugfixes
   // ##########################

--- a/KSPCommunityFixes/BugFixes/EditorAnimatedPartsShipModified.cs
+++ b/KSPCommunityFixes/BugFixes/EditorAnimatedPartsShipModified.cs
@@ -1,0 +1,99 @@
+// The Engineer's report (and anything else that listens to GameEvents.onEditorShipModified) only
+// run when it is fired. Deployable parts fire the event when their animation starts, but not when
+// it finishes. This makes it look like the editor's report is delayed by one modification.
+//
+// We fix this by firing an additional onEditorShipModified event when the animation completes.
+// This is done by adding an OnStop event handler to all IScalarModules during part Start. This
+// should work even for modded animation modules.
+
+using System;
+using System.Collections;
+using UnityEngine;
+
+namespace KSPCommunityFixes.BugFixes;
+
+class EditorAnimatedPartsShipModified : BasePatch
+{
+    protected override void ApplyPatches()
+    {
+        AddPatch(PatchType.Postfix, typeof(Part), nameof(Part.ModulesOnStartFinished));
+    }
+
+    static void Part_ModulesOnStartFinished_Postfix(Part __instance)
+    {
+        if (!HighLogic.LoadedSceneIsEditor)
+            return;
+
+        ScalarModuleStopListener listener = null;
+        foreach (var module in __instance.Modules)
+        {
+            if (module is not IScalarModule scalarModule)
+                continue;
+            if (scalarModule.OnStop is null)
+                continue;
+
+            listener ??= __instance.gameObject.AddComponent<ScalarModuleStopListener>();
+            scalarModule.OnStop.Add(listener.OnScalarModuleStop);
+        }
+    }
+
+    class ScalarModuleStopListener : MonoBehaviour
+    {
+        static Coroutine coroutine = null;
+        static ScalarModuleStopListener host = null;
+
+        public void OnScalarModuleStop(float position)
+        {
+            if (coroutine is not null)
+                return;
+
+            EditorLogic editor = EditorLogic.fetch;
+            if (editor.IsNullOrDestroyed() || editor.ship is null)
+                return;
+
+            // We only really want to fire this once per frame, so launch a coroutine if not already
+            // done. The coroutine will fire the event in the next Update.
+            coroutine = StartCoroutine(DelayEmit());
+            host = this;
+        }
+
+        // If we own the current coroutine and are being disabled or destroyed, then fire the event
+        // immediately.
+        void OnDisable()
+        {
+            if (coroutine is null || host != this)
+                return;
+
+            StopCoroutine(coroutine);
+            coroutine = null;
+            host = null;
+
+            var editor = EditorLogic.fetch;
+            if (editor.IsNullOrDestroyed() || editor.ship is null)
+                return;
+
+            GameEvents.onEditorShipModified.Fire(editor.ship);
+        }
+
+        IEnumerator DelayEmit()
+        {
+            using var guard = new ClearCoroutineGuard();
+            yield return null;
+
+            var editor = EditorLogic.fetch;
+            if (editor.IsNullOrDestroyed() || editor.ship is null)
+                yield break;
+
+            GameEvents.onEditorShipModified.Fire(editor.ship);
+        }
+
+        readonly struct ClearCoroutineGuard : IDisposable
+        {
+            public void Dispose()
+            {
+                coroutine = null;
+                host = null;
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ User options are available from the "ESC" in-game settings menu :<br/><img src="
 - [**WheelIntertialLimit**](https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/341) Reduces the minimum inertia limit for wheels from 0.01 to 0.00001. Several small wheels had inertia values below this limit, so this makes them behave more correctly.
 - [**MapTargetBodyWithEncounter**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/381) [KSP 1.12.0 - 1.12.5]<br/>Fix being unable to left-click or double-click a celestial body's icon in the map view (to set it as target) when a maneuver node produces an encounter with that body.
 - [**HarvesterECConsumption**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/358) [KSP 1.8.0 - 1.12.5]<br/>Make the info panel for `ModuleResourceHarvester` show accurate rates for consumed resources.
+- [**EditorAnimatedPartsShipModified**](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/388) [KSP 1.12.0 - 1.12.5]<br/>Fix the Engineer's Report craft dimensions (and other `onEditorShipModified` consumers) lagging one vessel modification behind when an animated part is actuated in the editor (deployable solar panels/radiators/antennas, `ModuleAnimateGeneric` animations, Breaking Ground robotic servos), by re-firing the modification event once the animation has actually finished.
 
 #### Quality of Life tweaks 
 


### PR DESCRIPTION
This gets fired when animations start, but not when they finish. This makes downstream consumers like the engineer's report lag behind the actual vessel state.

We fix this generically for any IScalarModule by adding a listener to OnStop that re-fires the event when the animation completes, along with a debounce check to ensure it is only fired once per frame.

Fixes #388