### PR TITLE
Properly guard against vessel being null in ActiveRadiatorPerf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### Changelog
 
 ##### Unreleased
+**Bug Fixes**
+- **ActiveRadiatorPerf** : Fixed a `NullReferenceException` ([issue #397](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/397)) thrown from `ModuleActiveRadiator.Start` in the editor (where `part.vessel` is null), most visible as exception spam through SystemHeat's `ModuleSystemHeatRadiator`.
 
 ##### 1.41.0
 **New/Improved patches**

--- a/KSPCommunityFixes/Performance/ActiveRadiatorPerf.cs
+++ b/KSPCommunityFixes/Performance/ActiveRadiatorPerf.cs
@@ -285,6 +285,9 @@ internal class ActiveRadiatorPerf : BasePatch
 
     static void ModuleActiveRadiator_Start_Postfix(ModuleActiveRadiator __instance)
     {
+        if (!HighLogic.LoadedSceneIsFlight || __instance.vessel.IsNullOrDestroyed())
+            return;
+
         var data = (ExtraModuleData)__instance.adjusterCache;
         data.integrator = __instance.vessel.gameObject
             .AddOrGetComponent<KSPCFRadiatorHeatIntegrator>();


### PR DESCRIPTION
`ModuleActiveRadiator_Start_Postfix` dereferences `__instance.vessel`, but this is null in the editor. This isn't a problem in `FixedUpdate` because that properly guards against running in the editor.

This adds the appropriate check to the start prefix patch.

Fixes #397