### PR TITLE
Fix a memory leak in EditorAnimatedPartsShipModified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### Changelog
 
 ##### Unreleased
+**Bug Fixes**
+- **EditorAnimatedPartsShipModified** : Fixed a memory leak ([issue #396](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/396)) where listeners were not properly cleaned up.
 
 ##### 1.41.1
 **Bug Fixes**

--- a/KSPCommunityFixes/BugFixes/EditorAnimatedPartsShipModified.cs
+++ b/KSPCommunityFixes/BugFixes/EditorAnimatedPartsShipModified.cs
@@ -32,7 +32,12 @@ class EditorAnimatedPartsShipModified : BasePatch
             if (scalarModule.OnStop is null)
                 continue;
 
-            listener ??= __instance.gameObject.AddComponent<ScalarModuleStopListener>();
+            if (listener == null)
+            {
+                listener = __instance.gameObject.AddComponent<ScalarModuleStopListener>();
+                listener.part = __instance;
+            }
+
             scalarModule.OnStop.Add(listener.OnScalarModuleStop);
         }
     }
@@ -41,6 +46,9 @@ class EditorAnimatedPartsShipModified : BasePatch
     {
         static Coroutine coroutine = null;
         static ScalarModuleStopListener host = null;
+
+        // The part we are attached to.
+        public Part part;
 
         public void OnScalarModuleStop(float position)
         {
@@ -73,6 +81,16 @@ class EditorAnimatedPartsShipModified : BasePatch
                 return;
 
             GameEvents.onEditorShipModified.Fire(editor.ship);
+        }
+
+        void OnDestroy()
+        {
+            // Make sure to unsubscribe ourselves from the OnStop events.
+            foreach (var module in part.Modules)
+            {
+                if (module is IScalarModule scalarModule)
+                    scalarModule.OnStop?.Remove(OnScalarModuleStop);
+            }
         }
 
         IEnumerator DelayEmit()


### PR DESCRIPTION
We were registering to IScalarModule.OnStop, assuming that the event handler was cleaned up when the part is destroyed. As it turns out, these are recycled so registering and leaving it causes a memory leak.

This modfies ScalarModuleStopListener to unsubscribe appropriately when it gets destroyed.

Fixes #399