### PR TITLE
Include kspedia bundles placed directly in GameData

### DIFF
--- a/KSPCommunityFixes/Performance/FastLoader.cs
+++ b/KSPCommunityFixes/Performance/FastLoader.cs
@@ -3222,11 +3222,18 @@ namespace KSPCommunityFixes.Performance
                 .AsParallel()
                 .AsOrdered()
                 .SelectMany(dir => dir.GetFiles(glob, SearchOption.AllDirectories))
+                .Concat(
+                    // Make sure to also grab bundles in the root directory
+                    assetDir
+                        .GetFiles(glob, SearchOption.TopDirectoryOnly)
+                        .AsParallel()
+                        .AsOrdered()
+                )
                 .Where(file => !assetBlacklist.Contains(file.Name))
                 .AsSequential();
 
-            loader.allFilesList = new List<FileInfo>();
-            AssetBundleRequestCache = new List<AssetBundleCreateRequest>();
+            loader.allFilesList = [];
+            AssetBundleRequestCache = [];
 
             var seen = new HashSet<string>();
             var requestCache = AssetBundleRequestCache;


### PR DESCRIPTION
The parallel walk over all the directories missed this, so we need to explicitly add any bundles in the root.

Fixes #407