### PR TITLE
Disable EditorAnimatedPartsShipModified if DMagicOrbitalScience is installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ##### Unreleased
 **Bug Fixes**
 - **EditorAnimatedPartsShipModified** : Fixed a memory leak ([issue #396](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/396)) where listeners were not properly cleaned up.
+- **EditorAnimatedPartsShipModified** : This patch is now disabled if DMagic Orbital Science is installed because DMagic Orbital Science has a bug that causes a stack overflow crash if you ever call `DMSoilMoisture.OnStop`, which this patch does.
 
 ##### 1.41.1
 **Bug Fixes**

--- a/GameData/KSPCommunityFixes/MMPatches/ModSupport/DMagicOrbitalScience.cfg
+++ b/GameData/KSPCommunityFixes/MMPatches/ModSupport/DMagicOrbitalScience.cfg
@@ -1,0 +1,12 @@
+// DMSoilMoisture.OnStop causes a stack overflow when called. The
+// EditorAnimatedPartsShipModified patch calls OnStop on all IScalarModules on
+// the ship. It ends up triggering the stack overflow which then crashes KSP.
+//
+// We disable the patch if DMagicOrbitalScience is installed to avoid this.
+//
+// See https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/409
+
+@KSP_COMMUNITY_FIXES:NEEDS[DMagicOrbitalScience]
+{
+    @EditorAnimatedPartsShipModified = false
+}


### PR DESCRIPTION
DMSoilMoisture.OnStop infinitely recurses and causes KSP to crash whenever it is called. The EditorAnimatedPartsShipModified patch ends up calling OnStop on pretty much every IScalarModule, so it ends up running into this crash where nothing else did before.

Fixes #409