### PR TITLE
Reuse first UrlDir tree for FastLoader second pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ### Changelog
 
 ##### Unreleased
+**New/Improved patches**
+- Improved the **FastLoader** patch to reuse the initial GameDatabase directory tree during the second config pass while refreshing files and directories created or modified by `Startup.Instantly` addons. Avoids reparsing unchanged configs and saves several seconds in heavily modded installs.
+
 **Bug Fixes**
 - **EditorAnimatedPartsShipModified** : Fixed a memory leak ([issue #396](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/396)) where listeners were not properly cleaned up.
 - **EditorAnimatedPartsShipModified** : This patch is now disabled if DMagic Orbital Science is installed because DMagic Orbital Science has a bug that causes a stack overflow crash if you ever call `DMSoilMoisture.OnStop`, which this patch does.

--- a/KSPCommunityFixes/Performance/FastLoader.cs
+++ b/KSPCommunityFixes/Performance/FastLoader.cs
@@ -769,7 +769,7 @@ namespace KSPCommunityFixes.Performance
                 }
             }
 
-            DateTime recentConfigCutoffUtc = DateTime.UtcNow.AddSeconds(-4.0);
+            DateTime recentConfigCutoffUtc = DateTime.UtcNow.AddSeconds(-Time.realtimeSinceStartup);
             for (int i = 0; i < root.children.Count; i++)
                 RefreshDirectoryRecursive(root.children[i], fileConfig, recentConfigCutoffUtc);
 

--- a/KSPCommunityFixes/Performance/FastLoader.cs
+++ b/KSPCommunityFixes/Performance/FastLoader.cs
@@ -428,15 +428,11 @@ namespace KSPCommunityFixes.Performance
             gdb.progressTitle = "Loading configs...";
             gdb.progressFraction = 0f;
 
-            // note : rebuilding the whole database here can be very long in a modde dinstall and
-            // is quite silly since it was already built just before.
-            // The intent is just to mark assets files with their type (UrlFile.fileType) according to
-            // the registered type in configFileTypes.
-            // However, the full reload means mods can take the opportunity to generate configs/assets on
-            // the fly from Awake() in a Startup.Instantly KSPAddon and have it being loaded. I've found
-            // at least 2 mods doing that, so unfortunately this can't really be optimized...
             KSPCFFastLoaderReport.wSecondConfigLoad.Restart();
-            gdb._root = new UrlDir(gdb.urlConfig.ToArray(), configFileTypes.ToArray());
+            ConfigDirectory[] configDirectories = gdb.urlConfig.ToArray();
+            ConfigFileType[] fileConfig = configFileTypes.ToArray();
+            if (!TryRefreshRoot(gdb._root, configDirectories, fileConfig))
+                gdb._root = new UrlDir(configDirectories, fileConfig);
             KSPCFFastLoaderReport.wSecondConfigLoad.Stop();
 
             // Optimized version of GameDatabase.translateLoadedNodes()
@@ -747,6 +743,133 @@ namespace KSPCommunityFixes.Performance
             KSPCFFastLoaderReport.wModelLoading.Stop();
             KSPCFFastLoaderReport.wAssetsLoading.Stop();
         }
+
+        #region Second config load
+
+        /// <summary>
+        /// Depending on number of mods can shave off up to a few seconds. Around 8 seconds with 5k .cfg files in a modded install.
+        /// </summary>
+        private static bool TryRefreshRoot(UrlDir root, ConfigDirectory[] configDirectories, ConfigFileType[] fileConfig)
+        {
+            if (root == null || root.children.Count != configDirectories.Length)
+                return false;
+
+            for (int i = 0; i < root.children.Count; i++)
+            {
+                UrlDir child = root.children[i];
+                ConfigDirectory configDirectory = configDirectories[i];
+                string configuredPath = new DirectoryInfo(CreateApplicationPath(configDirectory.directory)).FullName;
+
+                if (child.name != configDirectory.urlRoot
+                    || child.type != configDirectory.type
+                    || !string.Equals(child.path, configuredPath, StringComparison.Ordinal)
+                    || !Directory.Exists(child.path))
+                {
+                    return false;
+                }
+            }
+
+            DateTime recentConfigCutoffUtc = DateTime.UtcNow.AddSeconds(-4.0);
+            for (int i = 0; i < root.children.Count; i++)
+                RefreshDirectoryRecursive(root.children[i], fileConfig, recentConfigCutoffUtc);
+
+            return true;
+        }
+
+        private static void RefreshDirectoryRecursive(UrlDir dir, ConfigFileType[] fileConfig, DateTime recentConfigCutoffUtc)
+        {
+            var directoryInfo = new DirectoryInfo(dir.path);
+            var existingFiles = new Dictionary<string, UrlFile>(dir.files.Count, StringComparer.Ordinal);
+            for (int i = 0; i < dir.files.Count; i++)
+                existingFiles[dir.files[i].fullPath] = dir.files[i];
+
+            var refreshedFiles = new List<UrlFile>(dir.files.Count);
+            foreach (FileInfo file in directoryInfo.GetFiles())
+            {
+                // Files changed by Startup.Instantly need a new UrlFile so config contents and
+                // metadata such as fileTime match the second stock directory scan.
+                if (!existingFiles.Remove(file.FullName, out UrlFile urlFile)
+                    || !CanReuseFile(urlFile, file, recentConfigCutoffUtc))
+                {
+                    urlFile = new UrlFile(dir, file);
+                }
+
+                urlFile.ConfigureFile(fileConfig);
+                refreshedFiles.Add(urlFile);
+            }
+
+            dir.files.Clear();
+            dir.files.AddRange(refreshedFiles);
+
+            var existingChildren = new Dictionary<string, UrlDir>(dir.children.Count, StringComparer.Ordinal);
+            for (int i = 0; i < dir.children.Count; i++)
+                existingChildren[dir.children[i].path] = dir.children[i];
+
+            var refreshedChildren = new List<UrlDir>(dir.children.Count);
+            foreach (DirectoryInfo directory in directoryInfo.GetDirectories())
+            {
+                if (ShouldSkipStockDirectory(directory.Name))
+                    continue;
+
+                if (!existingChildren.Remove(directory.FullName, out UrlDir childDir))
+                {
+                    childDir = new UrlDir(dir, directory);
+                    foreach (UrlFile file in childDir.files)
+                        file.ConfigureFile(fileConfig);
+                    foreach (UrlFile file in childDir.AllFiles)
+                        file.ConfigureFile(fileConfig);
+                }
+                else
+                {
+                    RefreshDirectoryRecursive(childDir, fileConfig, recentConfigCutoffUtc);
+                }
+
+                refreshedChildren.Add(childDir);
+            }
+
+            dir.children.Clear();
+            dir.children.AddRange(refreshedChildren);
+        }
+
+        private static bool CanReuseFile(UrlFile urlFile, FileInfo file, DateTime recentConfigCutoffUtc)
+        {
+            if (urlFile.fileTime != GetLastWriteTime(file))
+                return false;
+
+            if (urlFile.fileType != FileType.Config)
+                return true;
+
+            try
+            {
+                return file.LastWriteTimeUtc < recentConfigCutoffUtc
+                    && file.CreationTimeUtc < recentConfigCutoffUtc;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static DateTime GetLastWriteTime(FileInfo file)
+        {
+            try
+            {
+                return file.LastWriteTime;
+            }
+            catch
+            {
+                return DateTime.MinValue;
+            }
+        }
+
+        private static bool ShouldSkipStockDirectory(string directoryName)
+        {
+            return directoryName == ".svn"
+                || directoryName == "PluginData"
+                || directoryName == "zDeprecated";
+        }
+
+        #endregion
 
         /// <summary>
         /// ~100 times faster replacement for the stock GameDatabase.translateLoadedNodes() method (RP1 install 12500 ms -> 80 ms)


### PR DESCRIPTION
This pr makes makes reuse of the initial UrlDir tree during FastLoader’s second config pass instead of rebuilding the entire GameDatabase, shaving off seconds from load in modded installs.

The refresh detects added, removed, and modified files and directories, preserving support for configs and assets generated by Startup.Instantly addons. If the configured roots have changed, it falls back to a full rebuild.
This reduces the second pass by several seconds in heavily modded installs, around 5-8 seconds in my case.

If this approach is ok this https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/346 might not be needed.

### Modded profiles
<details>
<summary>Mods used when profiling</summary>
<pre>
KSP version: 1.12.5.3190

Installed modules:

\- ALCOR 1.0.1
\+ ASETAgency v2.0.2
\- ASETAvionics v3.0.1
\+ ASETProps v2.0.7
\- Astrogator v1.0.2
A Atmosphere (unmanaged)
\- AvalanchePlumes v1.0.5.1
\+ B9PartSwitch v2.21.0.4
\- BackgroundResourceProcessing 0.3.2
A BreakingGround-DLC 1.7.1 (unmanaged)
A BuildManager (unmanaged)
\- BurstPQS 0.1.24
A CelestialShadows (unmanaged)
\- Chatterer 0.9.99
\- ChattererExtended 0.6.2
A CityLights (unmanaged)
\- ClickThroughBlocker 1:2.1.10.23
\- CommunityCategoryKit v112.0.1
\+ CommunityResourcePack v112.0.1
\+ CommunityTechTree 1:3.4.5
\- ContractConfigurator v2.13.3.0
\- DE-IVAExtension v1.3.0
\- Deferred 1.3.5.0
\- DistantObject v2.2.1.7
\+ DistantObject-default v2.2.1.7
\- DockingPortAlignmentIndicator 6.13.1.0
\- EasyVesselSwitch 2.3
\- EditorExtensionsRedux 3.4.7
A EVEManager (unmanaged)
\+ FilterExtensions 3.2.9.1
\- FilterExtensionsDefaultConfig 3.2.9.1
\- Firefly 1.0.6
\+ FireflyAPI 1.0.0.0
\- Firespitter v7.17
\+ FirespitterCore v7.17
\+ FirespitterResourcesConfig v7.17
\- FreeIva 0.2.20.2
\+ Harmony2 2.2.1.0
\- HullcamVDSContinued 0.2.2.4
\- JanitorsCloset 0.4.1.3
\- KAS 1.12
\- KerbalChangelog v1.4.2
\- KerbalEngineerRedux 1.1.9.5
\- KerbalFX-AeroFX 0.8.1
\- KerbalFX-BlastFX 0.8.1
\+ KerbalFX-Core 0.8.1
\- KerbalFX-ImpactPuffs 0.8.1
\- KerbalFX-RoverDust 0.8.1
\- KIS 1.29
\+ Konstruction v112.0.1
\+ Kopernicus 2:release-1.12.1-247
\- kOS 1:1.6.0.1
\- kOS-Astrogator v0.2.2
\- kOS-Career 0.3.0.0
\- kOS-EVA 0.2.0.0
\- kOS-KerbalEngineer v0.1.1
\- kOS-MechJeb2 0.0.4
\- kOS-SCANSat 1.2.0.0
\- kOS-StockCamera 0.2.0.0
\- kOSforAll 0.0.5
\- kOSPropMonitor 1.7.3
\- KSAIVAUpgrade v1.6.7
\+ KSPBurst v1.7.4.11
\+ KSPBurst-Lite v1.7.4.11
\^ KSPCommunityFixes 1:1.41.1
\+ KSPTextureLoader 1.0.35
A MakingHistory-DLC 1.12.1 (unmanaged)
\- MechJeb2 2.15.3.0
\- MK12PodIVAReplacementbyASET 1:v2.0.1
\- Mk1LanderCanIVAReplbyASET v2.0.1
\- MoarFEConfigs 1.0.5.2
\+ ModularFlightIntegrator 1.2.10.0
\+ ModuleManager 4.2.3
\- NavUtilitiesUpdated 0.8.1.1
\+ NearFutureProps 1:0.7.2
\- ParallaxContinued 1.0.4
\- ParallaxContinued-Lifeless-Eve-Patch 1.0.0
\- ParallaxContinued-Planet-Textures 1.0.3
\- ParallaxContinued-Scatter-Textures 1.0.3
\- ParallaxContinued-Terrain-Textures 1.0.3
A PartFX (unmanaged)
\- PlanetShine 0.2.6.6
\+ PlanetShine-Config-Default 0.2.6.6
A PQSManager (unmanaged)
\- ProbeControlRoomRecontrolled 1.4.0
\- ProbesBeforeCrew 3.3.2
\- QuickIVA 1:1.3.0.11
\- QuickStart 1:2.2.1.5
\- RasterPropMonitor 1:v1.1.0.1
\+ RasterPropMonitor-Core 1:v1.1.0.1
\- ReStock 1.5.1
\- ReStockPlus 1.5.1
\- RestockWaterfallExpansion 0.2.0
\- Reviva 1.0.2
\- RocketSoundEnhancement 0.9.13
\+ RocketSoundEnhancement-Config-Default 1.3.1
\- SCANsat v21.1
A Scatterer (unmanaged)
\- ScienceAlert 1.9.20.5
\+ Shabby 0.4.2
A ShaderLoader (unmanaged)
\+ SmokeScreen 2.8.14.0
\+ SpaceTuxLibrary 0.0.9
\- StationPartsExpansionRedux 2.0.11
\- StationPartsExpansionRedux-IVAs 2.0.11
\- StockWaterfallEffects 0.8.0
A Terrain (unmanaged)
A TextureConfig (unmanaged)
\- Toolbar 1:1.8.1.2
\- ToolbarController 1:0.1.9.14
\- TrackingStationEvolved 2:1.0.9.1
\- Trajectories v2.4.5.4
\- TransferWindowPlannerFork v1.9.1.1
\- TriggerAu-Flags v2.11.0.0
\- TUFX 1.1.1
\- UKS 1:v112.0.1
\+ USI-Core v112.0.1
\+ USITools v112.0.1
A Utils (unmanaged)
\- VaporCones 1.2.0
\- VesselView 2:0.8.9
\+ VesselView-UI-RasterPropMonitor 1:0.8.9
\- VolumetricVaporCones 1.0.1
\- Waterfall 0.11.0
\- WaterfallRestock 0.2.3
\- WaypointManager 2.8.4.7
\- xScienceContinued 6.0.3.1
</pre>
</details>
Before:
<pre>
[LOG 22:17:58.038] [KSPCF:FastLoader] AMD Ryzen 9 5900X 12-Core Processor  | 32693 MB | NVIDIA GeForce RTX 5080 (15979 MB)
Total loading time to main menu : 72.249s
- Configs and assemblies loaded in 8.948s
- <b>Configs reload done in 5.532s</b>
- Configs translated in 0.076s
- 8713 assets loaded in 8.680s :
  - 1393 audio assets (312.77 MiB) in 6.800s, 45.996 MiB/s
  - 4428 texture assets (2.46 GiB) in 0.532s, 4.628 GiB/s
  - 2874 model assets (437.884 MiB) in 1.341s, 326.606 MiB/s
- Asset bundles loaded in 0.315s
- GameDatabase (configs, resources, traits, upgrades...) loaded in 0.253s
- Built-in parts copied in 0.019s
- Part and internal configs extracted in 0.005s
- 1096 parts and 11617 modules compiled in 17.405s
  - 10.6 modules/part, 15.881 ms/part, 1.498 ms/module
  - PartIcon compilation : 2.448s
- 199 internal spaces and 1632 props compiled in 4.842s
- 2 DLC (Making History, Breaking Ground) loaded in 0.444s
- Planetary system loaded in 7.186s
</pre>

After:
<pre>
[LOG 22:13:12.684] [KSPCF:FastLoader] AMD Ryzen 9 5900X 12-Core Processor  | 32693 MB | NVIDIA GeForce RTX 5080 (15979 MB)
Total loading time to main menu : 68.729s
- Configs and assemblies loaded in 9.528s
- <b>Configs reload done in 0.988s</b>
- Configs translated in 0.091s
- 8713 assets loaded in 8.543s :
  - 1393 audio assets (312.77 MiB) in 6.807s, 45.946 MiB/s
  - 4428 texture assets (2.46 GiB) in 0.513s, 4.795 GiB/s
  - 2874 model assets (437.884 MiB) in 1.216s, 360.182 MiB/s
- Asset bundles loaded in 0.339s
- GameDatabase (configs, resources, traits, upgrades...) loaded in 0.273s
- Built-in parts copied in 0.021s
- Part and internal configs extracted in 0.006s
- 1096 parts and 11617 modules compiled in 17.076s
  - 10.6 modules/part, 15.580 ms/part, 1.470 ms/module
  - PartIcon compilation : 2.392s
- 199 internal spaces and 1632 props compiled in 4.774s
- 2 DLC (Making History, Breaking Ground) loaded in 0.449s
- Planetary system loaded in 7.755s
</pre>

