### PR TITLE
Avoid dependency on string internals

### DIFF
--- a/KSPCommunityFixes/KSPCommunityFixes.csproj
+++ b/KSPCommunityFixes/KSPCommunityFixes.csproj
@@ -115,7 +115,6 @@
     <Publicize Include="mscorlib:System.IO.MonoIOError" />
     <Publicize Include="mscorlib:System.IO.MonoIOStat" />
     <Publicize Include="mscorlib:System.Reflection.Assembly.GetTypes" />
-    <Publicize Include="mscorlib:System.String.m_firstChar" />
     <Publicize Include="0Harmony:MonoMod.Utils.Cil.ILGeneratorShimExt" />
     <Publicize Include="0Harmony:MonoMod.Utils.Cil.CecilILGenerator+LabelInfo" />
     <Publicize Include="0Harmony:MonoMod.Utils.Cil.CecilILGenerator+LabelledExceptionHandler" />

--- a/KSPCommunityFixes/Performance/LocalizerPerf.cs
+++ b/KSPCommunityFixes/Performance/LocalizerPerf.cs
@@ -192,7 +192,7 @@ namespace KSPCommunityFixes.Performance
             int length = formattedString.Length;
             int removed = 0;
 
-            fixed (char* charPtr = &formattedString.m_firstChar)
+            fixed (char* charPtr = formattedString)
             {
                 for (int i = 0; i < length; i++)
                 {


### PR DESCRIPTION
You can just use a fixed statement directly to get the internal pointer to the string, no need to publicize its internals.