### PR TITLE
On-demand part and model textures via unity mipmap streaming

### DIFF
--- a/GameData/KSPCommunityFixes/Localization/en-us.cfg
+++ b/GameData/KSPCommunityFixes/Localization/en-us.cfg
@@ -39,6 +39,14 @@ Localization
     #KSPCF_KSPCFFastLoader_PopupL4 = You can change this setting later in the in-game settings menu
     #KSPCF_KSPCFFastLoader_PopupL5 = Do you want to enable this optimization ?
 
+    // TextureStreaming
+
+    #KSPCF_TextureStreaming_StreamingEnabledTitle = Texture streaming
+    #KSPCF_TextureStreaming_StreamingEnabledTooltip = Stream part textures from files on disk as they are needed. Ensures VRAM usage for part and IVA textures stays within the budget that you set.
+    #KSPCF_TextureStreaming_StreamingBudgetTitle = Streaming memory budget (MB)
+    #KSPCF_TextureStreaming_StreamingBudgetTooltip = The amount of memory that is allocated to store streaming textures. Unity will automatically load and unload parts of textures to stay under this limit.
+    #KSPCF_TextureStreaming_F_StreamingBudgetValue = <<1>> MB
+
     // LowerMinPhysicsDTPerFrame
 
     #KSPCF_LowerMinPhysicsDTPerFrame_SettingsTooltip = How the game handle lag in CPU bound situations.\nMostly relevant with large part count vessels.\n\nLower value :\nHigher and smoother FPS, but game time might advance slower than real time.\n\nHigher value :\nLower and choppier FPS, but game time will advance closer to real time.

--- a/GameData/KSPCommunityFixes/Settings.cfg
+++ b/GameData/KSPCommunityFixes/Settings.cfg
@@ -558,6 +558,10 @@ KSP_COMMUNITY_FIXES
   // completes. Significantly reduces stutter when a ship with cargo bays crashes.
   CargoBayPerf = true
 
+  // Stream part and IVA textures from disk on demand using Unity's mipmap streaming, keeping their
+  // VRAM footprint within a configurable budget. Can be toggled and tuned from the KSPCF in-game settings.
+  TextureStreaming = true
+
   // ##########################
   // Modding
   // ##########################

--- a/KSPCommunityFixes/Internal/PatchSettings.cs
+++ b/KSPCommunityFixes/Internal/PatchSettings.cs
@@ -57,7 +57,7 @@ namespace KSPCommunityFixes
             // +1 for the KSPCF title box; entryCount already accounts for every added row (the streaming
             // patch contributes 2, see ApplyPatches).
             DialogGUIBase[] modifiedResult = new DialogGUIBase[count + entryCount + 1];
-            
+
             for (int i = 0; i < count; i++)
                 modifiedResult[i] = __result[i];
 
@@ -83,7 +83,7 @@ namespace KSPCommunityFixes
             if (maneuverToolPatch != null)
             {
                 DialogGUIToggle toggle = new DialogGUIToggle(DisableManeuverTool.enableManeuverTool,
-                    () => (!DisableManeuverTool.enableManeuverTool) 
+                    () => (!DisableManeuverTool.enableManeuverTool)
                         ? Localizer.Format("#autoLOC_6001071") //"Disabled"
                         : Localizer.Format("#autoLOC_6001072"), //"Enabled"
                     DisableManeuverTool.OnToggleApp, 150f);
@@ -98,7 +98,7 @@ namespace KSPCommunityFixes
 
             if (altimeterPatch != null)
             {
-                DialogGUISlider slider = new DialogGUISlider(() => AltimeterHorizontalPosition.altimeterPosition, 0f, 1f, wholeNumbers: false, 200f, 20f, delegate(float f)
+                DialogGUISlider slider = new DialogGUISlider(() => AltimeterHorizontalPosition.altimeterPosition, 0f, 1f, wholeNumbers: false, 200f, 20f, delegate (float f)
                 {
                     AltimeterHorizontalPosition.altimeterPosition = f;
                     AltimeterHorizontalPosition.SetTopFramePosition();
@@ -187,11 +187,13 @@ namespace KSPCommunityFixes
 
             NoIVA.SaveSettings();
 
-            ConfigNode streamingNode = new();
-            streamingNode.AddValue(nameof(TextureStreaming.MipmapStreamingEnabled), TextureStreaming.MipmapStreamingEnabled);
-            streamingNode.AddValue(nameof(TextureStreaming.MipmapStreamingBudgetMb), TextureStreaming.MipmapStreamingBudgetMb);
-            SaveData<TextureStreaming>(streamingNode);
-            
+            if (textureStreamingPatch != null)
+            {
+                ConfigNode streamingNode = new();
+                streamingNode.AddValue(nameof(TextureStreaming.MipmapStreamingEnabled), TextureStreaming.MipmapStreamingEnabled);
+                streamingNode.AddValue(nameof(TextureStreaming.MipmapStreamingBudgetMb), TextureStreaming.MipmapStreamingBudgetMb);
+                SaveData<TextureStreaming>(streamingNode);
+            }
         }
     }
 }

--- a/KSPCommunityFixes/Internal/PatchSettings.cs
+++ b/KSPCommunityFixes/Internal/PatchSettings.cs
@@ -19,6 +19,7 @@ namespace KSPCommunityFixes
         private static AltimeterHorizontalPosition altimeterPatch;
         private static DisableManeuverTool maneuverToolPatch;
         private static OptionalMakingHistoryDLCFeatures disableMHPatch;
+        private static TextureStreaming textureStreamingPatch;
 
         protected override void ApplyPatches()
         {
@@ -38,6 +39,10 @@ namespace KSPCommunityFixes
             if (disableMHPatch != null)
                 entryCount++;
 
+            textureStreamingPatch = KSPCommunityFixes.GetPatchInstance<TextureStreaming>();
+            if (textureStreamingPatch != null)
+                entryCount += 2;
+
             // NoIVA is always enabled
             entryCount++;
         }
@@ -49,6 +54,8 @@ namespace KSPCommunityFixes
 
             int count = __result.Length;
 
+            // +1 for the KSPCF title box; entryCount already accounts for every added row (the streaming
+            // patch contributes 2, see ApplyPatches).
             DialogGUIBase[] modifiedResult = new DialogGUIBase[count + entryCount + 1];
             
             for (int i = 0; i < count; i++)
@@ -112,6 +119,46 @@ namespace KSPCommunityFixes
                 new DialogGUILabel(NoIVA.LOC_SettingsTitle, 150f), noIVAslider, valueLabel, new DialogGUIFlexibleSpace());
             count++;
 
+            if (textureStreamingPatch != null)
+            {
+                DialogGUIToggle streamingToggle = new(
+                    TextureStreaming.MipmapStreamingEnabled,
+                    () => (!TextureStreaming.MipmapStreamingEnabled)
+                        ? Localizer.Format("#autoLOC_6001071")  //"Disabled"
+                        : Localizer.Format("#autoLOC_6001072"), //"Enabled"
+                    b => TextureStreaming.MipmapStreamingEnabled = b, 150f);
+                streamingToggle.tooltipText = TextureStreaming.LOC_StreamingEnabledTooltip;
+
+                modifiedResult[count] = new DialogGUIHorizontalLayout(
+                    TextAnchor.MiddleLeft,
+                    new DialogGUILabel(TextureStreaming.LOC_StreamingEnabledTitle, 150f),
+                    streamingToggle,
+                    new DialogGUIFlexibleSpace());
+                count++;
+
+                // Streaming memory budget, in MB (0 .. total VRAM). Only interactable while streaming is on.
+                float budgetMax = Math.Max(1024, SystemInfo.graphicsMemorySize);
+                DialogGUISlider budgetSlider = new(
+                    () => TextureStreaming.MipmapStreamingBudgetMb,
+                    0f,
+                    budgetMax,
+                    wholeNumbers: true,
+                    128f,
+                    20f,
+                    budget => TextureStreaming.MipmapStreamingBudgetMb = (int)budget);
+                budgetSlider.tooltipText = TextureStreaming.LOC_StreamingBudgetTooltip;
+                budgetSlider.OptionInteractableCondition = () => TextureStreaming.MipmapStreamingEnabled;
+                DialogGUILabel budgetValue = new(() => Localizer.Format(TextureStreaming.LOC_F_StreamingBudgetValue, TextureStreaming.MipmapStreamingBudgetMb));
+
+                modifiedResult[count] = new DialogGUIHorizontalLayout(
+                    TextAnchor.MiddleLeft,
+                    new DialogGUILabel(TextureStreaming.LOC_StreamingBudgetTitle, 150f),
+                    budgetSlider,
+                    budgetValue,
+                    new DialogGUIFlexibleSpace());
+                count++;
+            }
+
             __result = modifiedResult;
         }
 
@@ -133,12 +180,18 @@ namespace KSPCommunityFixes
 
             if (altimeterPatch != null)
             {
-                ConfigNode node = new ConfigNode();
+                ConfigNode node = new();
                 node.AddValue(nameof(AltimeterHorizontalPosition.altimeterPosition), AltimeterHorizontalPosition.altimeterPosition);
                 SaveData<AltimeterHorizontalPosition>(node);
             }
 
             NoIVA.SaveSettings();
+
+            ConfigNode streamingNode = new();
+            streamingNode.AddValue(nameof(TextureStreaming.MipmapStreamingEnabled), TextureStreaming.MipmapStreamingEnabled);
+            streamingNode.AddValue(nameof(TextureStreaming.MipmapStreamingBudgetMb), TextureStreaming.MipmapStreamingBudgetMb);
+            SaveData<TextureStreaming>(streamingNode);
+            
         }
     }
 }

--- a/KSPCommunityFixes/Library/Model/ModelInstructions.cs
+++ b/KSPCommunityFixes/Library/Model/ModelInstructions.cs
@@ -170,8 +170,6 @@ namespace KSPCommunityFixes.Library.Model
                         else
                         {
                             mat.SetTexture(t.Name, tex);
-                            // This texture is used by rendered geometry: release it from the load-time full-res
-                            // pin so Unity's mipmap streaming can manage its residency (no-op when disabled).
                             KSPCFFastLoader.ReleaseToStreaming(tex);
                         }
                     }

--- a/KSPCommunityFixes/Library/Model/ModelInstructions.cs
+++ b/KSPCommunityFixes/Library/Model/ModelInstructions.cs
@@ -1,5 +1,6 @@
 using System;
 using KSPCommunityFixes.Library;
+using KSPCommunityFixes.Performance;
 using PartToolsLib;
 using UnityEngine;
 using UnityEngine.Rendering;
@@ -167,7 +168,12 @@ namespace KSPCommunityFixes.Library.Model
                         if (tex.IsNullOrDestroyed())
                             Debug.LogError($"Texture '{t.Url}' not found!");
                         else
+                        {
                             mat.SetTexture(t.Name, tex);
+                            // This texture is used by rendered geometry: release it from the load-time full-res
+                            // pin so Unity's mipmap streaming can manage its residency (no-op when disabled).
+                            KSPCFFastLoader.ReleaseToStreaming(tex);
+                        }
                     }
                 }
             }

--- a/KSPCommunityFixes/Library/TextureBundle/TextureBundleBuilder.cs
+++ b/KSPCommunityFixes/Library/TextureBundle/TextureBundleBuilder.cs
@@ -67,6 +67,11 @@ namespace KSPCommunityFixes.Library.TextureBundle
 
             /// <summary>Whether Unity should keep a CPU-side copy of the pixels.</summary>
             public bool Readable;
+
+            /// <summary>Serialized <c>m_StreamingMipmaps</c>. When true, the texture joins Unity's
+            /// mipmap streaming system. The caller decides eligibility (only set it when the mip
+            /// levels stay block aligned under the deepest streaming reduction).</summary>
+            public bool StreamingMipmaps;
         }
 
         /// <summary>The built bundle prefix plus the name to request from it.</summary>
@@ -104,6 +109,10 @@ namespace KSPCommunityFixes.Library.TextureBundle
 
             public readonly bool Readable;
 
+            /// <summary>Serialized <c>m_StreamingMipmaps</c>: whether this texture joins Unity's
+            /// mipmap streaming system.</summary>
+            public readonly bool StreamingMipmaps;
+
             /// <summary>Absolute path of the DDS file the pixels are streamed from.</summary>
             public readonly string ExternalPath;
 
@@ -121,6 +130,7 @@ namespace KSPCommunityFixes.Library.TextureBundle
                 int format,
                 int colorSpace,
                 bool readable,
+                bool streamingMipmaps,
                 string externalPath,
                 long externalOffset,
                 long pixelsLength)
@@ -132,6 +142,7 @@ namespace KSPCommunityFixes.Library.TextureBundle
                 Format = format;
                 ColorSpace = colorSpace;
                 Readable = readable;
+                StreamingMipmaps = streamingMipmaps;
                 ExternalPath = externalPath;
                 ExternalOffset = externalOffset;
                 PixelsLength = pixelsLength;
@@ -271,6 +282,7 @@ namespace KSPCommunityFixes.Library.TextureBundle
                     Format = e.Format,
                     ColorSpace = e.ColorSpace,
                     Readable = e.Readable,
+                    StreamingMipmaps = e.StreamingMipmaps,
                 };
 
                 file.BeginObject(w, ref slots[i + 1]);
@@ -331,7 +343,12 @@ namespace KSPCommunityFixes.Library.TextureBundle
             w.WriteBool(req.Readable); // m_IsReadable
             w.WriteBool(false); // m_IgnoreMasterTextureLimit
             w.WriteBool(false); // m_IsPreProcessed
-            w.WriteBool(false); // m_StreamingMipmaps
+            // Opt this texture into Unity's mipmap streaming manager only when the caller marked it
+            // eligible (its mip levels stay block aligned under the deepest streaming reduction, so the
+            // reduced base mip can still be uploaded). The feature is also gated globally by
+            // QualitySettings.streamingMipmapsActive (see KSPCFFastLoader.ApplyStreamingQualitySettings),
+            // and each realized streaming texture is pinned full-res until a model/part binds it.
+            w.WriteBool(req.StreamingMipmaps); // m_StreamingMipmaps
             w.Align(4);
             w.WriteInt32(0); // m_StreamingMipmapsPriority
             w.Align(4);

--- a/KSPCommunityFixes/Library/TextureBundle/TextureBundleBuilder.cs
+++ b/KSPCommunityFixes/Library/TextureBundle/TextureBundleBuilder.cs
@@ -346,7 +346,7 @@ namespace KSPCommunityFixes.Library.TextureBundle
             // Opt this texture into Unity's mipmap streaming manager only when the caller marked it
             // eligible (its mip levels stay block aligned under the deepest streaming reduction, so the
             // reduced base mip can still be uploaded). The feature is also gated globally by
-            // QualitySettings.streamingMipmapsActive (see KSPCFFastLoader.ApplyStreamingQualitySettings),
+            // QualitySettings.streamingMipmapsActive (see TextureStreaming.ApplyStreamingQualitySettings),
             // and each realized streaming texture is pinned full-res until a model/part binds it.
             w.WriteBool(req.StreamingMipmaps); // m_StreamingMipmaps
             w.Align(4);

--- a/KSPCommunityFixes/Library/TextureBundle/TextureBundleBuilder.cs
+++ b/KSPCommunityFixes/Library/TextureBundle/TextureBundleBuilder.cs
@@ -1,27 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using UnityEngine;
 
 namespace KSPCommunityFixes.Library.TextureBundle
 {
     /// <summary>
-    /// Builds a minimal UnityFS bundle wrapping a single streamed <c>Texture2D</c> and the
-    /// <c>AssetBundle</c> that references it, where the texture's pixel data lives in an existing
-    /// DDS file on disk. The generated bundle carries only ~1&#160;KB of metadata: the texture's
-    /// <c>m_StreamData.path</c> is the absolute path of the DDS file and <c>m_StreamData.offset</c>
-    /// is its data offset, so Unity opens the file and streams the compressed pixels itself. Pure
-    /// CPU work; safe to call from a background thread.
-    /// </summary>
-    /// <remarks>
-    /// The whole prefix is written into a single <see cref="BundleBufferWriter"/>: the UnityFS
-    /// framing (<see cref="BundleWriter"/>), the serialized-file framing
-    /// (<see cref="SerializedFileWriter"/>) and the two object bodies written here by hand. The
-    /// bodies reproduce the exact field order, sizes and alignment padding of Unity 2019.4's own
-    /// layout — the same layout the embedded type tree encodes.
-    ///
-    /// <para>Borrowed from KSPTextureLoader
-    /// (../KSPTextureLoader/src/KSPTextureLoader/Format/Bundle/TextureBundleBuilder.cs), stripped
-    /// to the classic Texture2D + external-file path.</para>
+    /// A builder for UnityFS bundles that contain <see cref="Texture2D" />s.
+    /// The special bit is that these bundles refer to the actual contents of
+    /// the dds files on disk instead of storing them directly.
     /// </remarks>
     internal static class TextureBundleBuilder
     {
@@ -68,9 +55,6 @@ namespace KSPCommunityFixes.Library.TextureBundle
             /// <summary>Whether Unity should keep a CPU-side copy of the pixels.</summary>
             public bool Readable;
 
-            /// <summary>Serialized <c>m_StreamingMipmaps</c>. When true, the texture joins Unity's
-            /// mipmap streaming system. The caller decides eligibility (only set it when the mip
-            /// levels stay block aligned under the deepest streaming reduction).</summary>
             public bool StreamingMipmaps;
         }
 
@@ -109,8 +93,6 @@ namespace KSPCommunityFixes.Library.TextureBundle
 
             public readonly bool Readable;
 
-            /// <summary>Serialized <c>m_StreamingMipmaps</c>: whether this texture joins Unity's
-            /// mipmap streaming system.</summary>
             public readonly bool StreamingMipmaps;
 
             /// <summary>Absolute path of the DDS file the pixels are streamed from.</summary>
@@ -343,11 +325,6 @@ namespace KSPCommunityFixes.Library.TextureBundle
             w.WriteBool(req.Readable); // m_IsReadable
             w.WriteBool(false); // m_IgnoreMasterTextureLimit
             w.WriteBool(false); // m_IsPreProcessed
-            // Opt this texture into Unity's mipmap streaming manager only when the caller marked it
-            // eligible (its mip levels stay block aligned under the deepest streaming reduction, so the
-            // reduced base mip can still be uploaded). The feature is also gated globally by
-            // QualitySettings.streamingMipmapsActive (see TextureStreaming.ApplyStreamingQualitySettings),
-            // and each realized streaming texture is pinned full-res until a model/part binds it.
             w.WriteBool(req.StreamingMipmaps); // m_StreamingMipmaps
             w.Align(4);
             w.WriteInt32(0); // m_StreamingMipmapsPriority

--- a/KSPCommunityFixes/Performance/FastLoader.cs
+++ b/KSPCommunityFixes/Performance/FastLoader.cs
@@ -276,12 +276,6 @@ namespace KSPCommunityFixes.Performance
                 if (!config.TryGetValue(nameof(textureCacheEnabled), ref textureCacheEnabled))
                     userOptInChoiceDone = false;
             }
-
-            // TEMPORARY: force the texture cache on and skip the opt-in popup while iterating on the
-            // mipmap-streaming work (DeployToKSP wipes the cfg each build, so the popup blocks unattended
-            // loads). Revert to the config-driven / popup behavior before shipping.
-            userOptInChoiceDone = true;
-            textureCacheEnabled = true;
         }
 
         /// <summary>

--- a/KSPCommunityFixes/Performance/FastLoader.cs
+++ b/KSPCommunityFixes/Performance/FastLoader.cs
@@ -176,15 +176,9 @@ namespace KSPCommunityFixes.Performance
         // Vestigial: kept so the popup can persist its choice across launches once it is repurposed.
         private static bool textureCacheEnabled;
 
-        // Mipmap streaming for part/mesh textures. Bundle textures are baked with m_StreamingMipmaps=true
-        // (see TextureBundleBuilder), pinned full-res on load, then released to the streaming manager at
-        // the point a model material or a part texture-replacement binds them. Gated globally by this
-        // toggle (read early from PluginData config in Awake, before KSPCommunityFixes.SettingsNode exists).
-        internal static bool mipmapStreamingEnabled = true;
-
-        // Fraction of total VRAM handed to the streaming memory budget. Leaves headroom for framebuffers
-        // and other VRAM consumers (Deferred, Scatterer, EVE) so streaming only drops mips under real pressure.
-        private const float StreamingBudgetFraction = 0.8f;
+        // Mipmap streaming for part/mesh textures. The load-time plumbing lives here (bake eligibility, the
+        // full-res pin, and the two PartLoader release postfixes registered in Awake); the runtime settings and
+        // QualitySettings application live in TextureStreaming.
 
         private static string ModPath => Path.GetDirectoryName(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
         private static string ConfigPath => Path.Combine(ModPath, "PluginData", "PNGTextureCache.cfg");
@@ -246,8 +240,7 @@ namespace KSPCommunityFixes.Performance
             PatchStartCoroutineInCoroutine(AccessTools.Method(typeof(PartLoader), nameof(PartLoader.CompileParts)));
 
             // Release part-compilation texture replacements to the mipmap streaming manager at their bind
-            // sites (gated at call time on mipmapStreamingEnabled). These are the only two texture-assignment
-            // points in stock part compilation.
+            // sites. These are the only two texture-assignment points in stock part compilation.
             MethodInfo m_PartLoader_ReplaceTextures = AccessTools.Method(typeof(PartLoader), "ReplaceTextures");
             MethodInfo po_PartLoader_ReplaceTextures = AccessTools.Method(typeof(KSPCFFastLoader), nameof(PartLoader_ReplaceTextures_Postfix));
             assetAndPartLoaderHarmony.Patch(m_PartLoader_ReplaceTextures, null, new HarmonyMethod(po_PartLoader_ReplaceTextures));
@@ -282,10 +275,6 @@ namespace KSPCommunityFixes.Performance
 
                 if (!config.TryGetValue(nameof(textureCacheEnabled), ref textureCacheEnabled))
                     userOptInChoiceDone = false;
-
-                // Optional opt-out for mipmap streaming (default ON). Read here — the load-phase streaming
-                // setup runs long before KSPCommunityFixes.SettingsNode is populated.
-                config.TryGetValue(nameof(mipmapStreamingEnabled), ref mipmapStreamingEnabled);
             }
 
             // TEMPORARY: force the texture cache on and skip the opt-in popup while iterating on the
@@ -595,11 +584,6 @@ namespace KSPCommunityFixes.Performance
             // Tune the AUP for much better throughput
             QualitySettings.asyncUploadTimeSlice = 25;
             QualitySettings.asyncUploadBufferSize = 256;
-            QualitySettings.streamingMipmapsMaxLevelReduction = MaxStreamingMipReduction;
-
-            // Enable mipmap streaming before the bundle textures are realized so they register with the
-            // streaming manager on load.
-            ApplyStreamingQualitySettings();
 
             int textureCount = bundleRequests.Count + textureQueue.Count;
 
@@ -1310,8 +1294,9 @@ namespace KSPCommunityFixes.Performance
 
                     // Pin every streaming texture full-res on load. It stays pinned (never streamed down)
                     // until a model material or a part texture-replacement releases it via ReleaseToStreaming;
-                    // textures with no owning mesh (UI, icons, ...) therefore never blur.
-                    if (mipmapStreamingEnabled && tex.streamingMipmaps)
+                    // textures with no owning mesh (UI, icons, ...) therefore never blur. The pin is latent
+                    // until streamingMipmapsActive is turned on (after MM patching, see PatchSettings).
+                    if (tex.streamingMipmaps)
                         tex.requestedMipmapLevel = 0;
                 }
                 else
@@ -1332,27 +1317,13 @@ namespace KSPCommunityFixes.Performance
 
         #region Mipmap streaming
 
-        // Enable Unity's mipmap streaming and size its budget to a fraction of total VRAM. These setters
-        // write to the currently-active quality level (GameSettings.QUALITY_PRESET). Called once, early in
-        // the asset-load phase, before the bundle textures are realized. If in-game testing shows KSP's
-        // SetQualityLevel wipes these, a fallback postfix on GameSettings.ApplySettings would re-apply them.
-        internal static void ApplyStreamingQualitySettings()
-        {
-            if (!mipmapStreamingEnabled)
-                return;
-
-            QualitySettings.streamingMipmapsActive = true;
-            QualitySettings.streamingMipmapsAddAllCameras = true;
-            QualitySettings.streamingMipmapsMemoryBudget = SystemInfo.graphicsMemorySize * StreamingBudgetFraction;
-        }
-
         // Release a just-bound mesh/part texture back to automatic streaming, undoing the load-time full-res
         // pin from InsertBundledTextures. Idempotent (ClearRequestedMipmapLevel is a no-op the second time and
         // on non-streaming textures), so the shared database Texture2D can be released by whichever model or
         // part binds it first, with no dedup bookkeeping.
         internal static void ReleaseToStreaming(Texture tex)
         {
-            if (mipmapStreamingEnabled && tex is Texture2D t2d && t2d.streamingMipmaps)
+            if (tex is Texture2D t2d && t2d.streamingMipmaps)
                 t2d.ClearRequestedMipmapLevel();
         }
 
@@ -1361,7 +1332,7 @@ namespace KSPCommunityFixes.Performance
         // + a texture with no owning renderer would only stream down when it is genuinely unused).
         private static void PartLoader_ReplaceTextures_Postfix(List<TextureInfo> newTextures)
         {
-            if (!mipmapStreamingEnabled || newTextures == null)
+            if (newTextures == null)
                 return;
 
             for (int i = 0; i < newTextures.Count; i++)
@@ -1379,9 +1350,6 @@ namespace KSPCommunityFixes.Performance
         // release the shared database texture (GetTexture is a dictionary lookup, fast-pathed by KSPCF).
         private static void PartLoader_ReplacePartTexture_Postfix(UrlConfig urlConfig, string textureName, bool normalMap)
         {
-            if (!mipmapStreamingEnabled)
-                return;
-
             string url = urlConfig.parent.parent.url + "/textures/" + Path.GetFileNameWithoutExtension(textureName);
             ReleaseToStreaming(GameDatabase.Instance.GetTexture(url, normalMap));
         }
@@ -2508,25 +2476,21 @@ namespace KSPCommunityFixes.Performance
             return width % blockWidth == 0 && height % blockHeight == 0;
         }
 
-        // Mipmap streaming reduces a texture's resident base mip by up to
-        // QualitySettings.streamingMipmapsMaxLevelReduction levels (we set that to this value; Unity's
-        // default is 2). The reduced mip becomes the texture's uploaded base level, and a block-compressed
-        // upload only works when that base is a whole number of blocks. So a texture may only join the
-        // streaming system when its mip level MaxStreamingMipReduction is still block aligned; otherwise the
-        // deepest reduction would upload a fractional-block base and corrupt. Uncompressed formats have
-        // a 1x1 block and always qualify.
-        private const int MaxStreamingMipReduction = 3;
-
         // Textures smaller than this (whole mip chain) aren't worth streaming: the VRAM they could
         // free is negligible next to the per-texture bookkeeping the streaming manager keeps for them.
         private const long MinStreamingBytes = 4 * 1024;
 
+        // A texture is baked into the streaming system (m_StreamingMipmaps) only if it's large enough to bother
+        // with and still block aligned at TextureStreaming.MaxStreamingMipReduction: streaming reduces the
+        // resident base mip by up to that many levels and re-uploads the reduced mip as the new base, and a
+        // block-compressed base upload only works when its dims are a whole number of blocks. Uncompressed
+        // formats have a 1x1 block and always qualify.
         private static bool EligibleForStreaming(in DDSPreparedHeader hdr) =>
             hdr.StreamedSize >= MinStreamingBytes
             && IsBlockAligned(
                 hdr.Format,
-                Math.Max(1, hdr.Width >> MaxStreamingMipReduction),
-                Math.Max(1, hdr.Height >> MaxStreamingMipReduction));
+                Math.Max(1, hdr.Width >> TextureStreaming.MaxStreamingMipReduction),
+                Math.Max(1, hdr.Height >> TextureStreaming.MaxStreamingMipReduction));
 
         // The number of mip levels Unity allocates for a full mip chain.
         private static int ComputeMipCount(int width, int height)
@@ -3842,10 +3806,17 @@ namespace KSPCommunityFixes.Performance
             loader.userOptInChoiceDone = true;
             textureCacheEnabled = optIn;
             choosed = true;
+            SaveConfig();
+        }
 
+        // Rewrite the fast-loader PluginData config from current in-memory state. This file holds only the
+        // opt-in choice (the mipmap-streaming settings live in KSPCF's own settings, see PatchSettings), so a
+        // full rewrite is safe.
+        private static void SaveConfig()
+        {
             ConfigNode config = new ConfigNode();
-            config.AddValue(nameof(userOptInChoiceDone), true);
-            config.AddValue(nameof(textureCacheEnabled), optIn);
+            config.AddValue(nameof(userOptInChoiceDone), loader.IsNotNullOrDestroyed() && loader.userOptInChoiceDone);
+            config.AddValue(nameof(textureCacheEnabled), textureCacheEnabled);
 
             string pluginDataPath = Path.Combine(ModPath, "PluginData");
             if (!Directory.Exists(pluginDataPath))

--- a/KSPCommunityFixes/Performance/FastLoader.cs
+++ b/KSPCommunityFixes/Performance/FastLoader.cs
@@ -176,10 +176,6 @@ namespace KSPCommunityFixes.Performance
         // Vestigial: kept so the popup can persist its choice across launches once it is repurposed.
         private static bool textureCacheEnabled;
 
-        // Mipmap streaming for part/mesh textures. The load-time plumbing lives here (bake eligibility, the
-        // full-res pin, and the two PartLoader release postfixes registered in Awake); the runtime settings and
-        // QualitySettings application live in TextureStreaming.
-
         private static string ModPath => Path.GetDirectoryName(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
         private static string ConfigPath => Path.Combine(ModPath, "PluginData", "PNGTextureCache.cfg");
 
@@ -239,8 +235,8 @@ namespace KSPCommunityFixes.Performance
 
             PatchStartCoroutineInCoroutine(AccessTools.Method(typeof(PartLoader), nameof(PartLoader.CompileParts)));
 
-            // Release part-compilation texture replacements to the mipmap streaming manager at their bind
-            // sites. These are the only two texture-assignment points in stock part compilation.
+            // These enable texture streaming for any texture used in a model,
+            // for a part, or for an IVA.
             MethodInfo m_PartLoader_ReplaceTextures = AccessTools.Method(typeof(PartLoader), "ReplaceTextures");
             MethodInfo po_PartLoader_ReplaceTextures = AccessTools.Method(typeof(KSPCFFastLoader), nameof(PartLoader_ReplaceTextures_Postfix));
             assetAndPartLoaderHarmony.Patch(m_PartLoader_ReplaceTextures, null, new HarmonyMethod(po_PartLoader_ReplaceTextures));
@@ -1286,10 +1282,8 @@ namespace KSPCommunityFixes.Performance
                     req.Result = new TextureInfo(req.File, tex, item.IsNormalMap, isReadable: false, isCompressed: true);
                     req.Status = TextureLoadRequest.State.Ready;
 
-                    // Pin every streaming texture full-res on load. It stays pinned (never streamed down)
-                    // until a model material or a part texture-replacement releases it via ReleaseToStreaming;
-                    // textures with no owning mesh (UI, icons, ...) therefore never blur. The pin is latent
-                    // until streamingMipmapsActive is turned on (after MM patching, see PatchSettings).
+                    // Disable mipmap streaming if enabled. We'll re-enable it on a case-by-case
+                    // basis when textures are used in parts or models.
                     if (tex.streamingMipmaps)
                         tex.requestedMipmapLevel = 0;
                 }
@@ -1311,19 +1305,16 @@ namespace KSPCommunityFixes.Performance
 
         #region Mipmap streaming
 
-        // Release a just-bound mesh/part texture back to automatic streaming, undoing the load-time full-res
-        // pin from InsertBundledTextures. Idempotent (ClearRequestedMipmapLevel is a no-op the second time and
-        // on non-streaming textures), so the shared database Texture2D can be released by whichever model or
-        // part binds it first, with no dedup bookkeeping.
+        /// <summary>
+        /// Enable mipmpa streaming for <paramref name="tex"/>.
+        /// </summary>
+        /// <param name="tex"></param>
         internal static void ReleaseToStreaming(Texture tex)
         {
             if (tex is Texture2D t2d && t2d.streamingMipmaps)
                 t2d.ClearRequestedMipmapLevel();
         }
 
-        // Postfix on PartLoader.ReplaceTextures (MODEL-node "texture = orig, new" swaps): release each
-        // config-declared replacement texture. Releasing a declared-but-unmatched entry is harmless (idempotent
-        // + a texture with no owning renderer would only stream down when it is genuinely unused).
         private static void PartLoader_ReplaceTextures_Postfix(List<TextureInfo> newTextures)
         {
             if (newTextures == null)
@@ -1339,9 +1330,6 @@ namespace KSPCommunityFixes.Performance
             }
         }
 
-        // Postfix on PartLoader.ReplacePartTexture (part-level "texture"/"bump" field): the resolved texture is
-        // a local in the stock method, so recompute the URL from the parameters exactly as the method does and
-        // release the shared database texture (GetTexture is a dictionary lookup, fast-pathed by KSPCF).
         private static void PartLoader_ReplacePartTexture_Postfix(UrlConfig urlConfig, string textureName, bool normalMap)
         {
             string url = urlConfig.parent.parent.url + "/textures/" + Path.GetFileNameWithoutExtension(textureName);
@@ -2470,15 +2458,12 @@ namespace KSPCommunityFixes.Performance
             return width % blockWidth == 0 && height % blockHeight == 0;
         }
 
-        // Textures smaller than this (whole mip chain) aren't worth streaming: the VRAM they could
-        // free is negligible next to the per-texture bookkeeping the streaming manager keeps for them.
+        // Textures smaller than 4KB are too small to be worth streaming.
         private const long MinStreamingBytes = 4 * 1024;
 
-        // A texture is baked into the streaming system (m_StreamingMipmaps) only if it's large enough to bother
-        // with and still block aligned at TextureStreaming.MaxStreamingMipReduction: streaming reduces the
-        // resident base mip by up to that many levels and re-uploads the reduced mip as the new base, and a
-        // block-compressed base upload only works when its dims are a whole number of blocks. Uncompressed
-        // formats have a 1x1 block and always qualify.
+        // Attempting to load a compressed mipmap whose size is not a multiple of the
+        // DDS block size (4x4) causes unity to crash. To avoid this we need to
+        // only include textures whose mipmaps are the correct size.
         private static bool EligibleForStreaming(in DDSPreparedHeader hdr) =>
             hdr.StreamedSize >= MinStreamingBytes
             && IsBlockAligned(
@@ -3803,9 +3788,6 @@ namespace KSPCommunityFixes.Performance
             SaveConfig();
         }
 
-        // Rewrite the fast-loader PluginData config from current in-memory state. This file holds only the
-        // opt-in choice (the mipmap-streaming settings live in KSPCF's own settings, see PatchSettings), so a
-        // full rewrite is safe.
         private static void SaveConfig()
         {
             ConfigNode config = new ConfigNode();

--- a/KSPCommunityFixes/Performance/FastLoader.cs
+++ b/KSPCommunityFixes/Performance/FastLoader.cs
@@ -176,6 +176,16 @@ namespace KSPCommunityFixes.Performance
         // Vestigial: kept so the popup can persist its choice across launches once it is repurposed.
         private static bool textureCacheEnabled;
 
+        // Mipmap streaming for part/mesh textures. Bundle textures are baked with m_StreamingMipmaps=true
+        // (see TextureBundleBuilder), pinned full-res on load, then released to the streaming manager at
+        // the point a model material or a part texture-replacement binds them. Gated globally by this
+        // toggle (read early from PluginData config in Awake, before KSPCommunityFixes.SettingsNode exists).
+        internal static bool mipmapStreamingEnabled = true;
+
+        // Fraction of total VRAM handed to the streaming memory budget. Leaves headroom for framebuffers
+        // and other VRAM consumers (Deferred, Scatterer, EVE) so streaming only drops mips under real pressure.
+        private const float StreamingBudgetFraction = 0.8f;
+
         private static string ModPath => Path.GetDirectoryName(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
         private static string ConfigPath => Path.Combine(ModPath, "PluginData", "PNGTextureCache.cfg");
 
@@ -234,6 +244,18 @@ namespace KSPCommunityFixes.Performance
             assetAndPartLoaderHarmony.Patch(m_PartLoader_StartLoad, null, null, new HarmonyMethod(t_PartLoader_StartLoad));
 
             PatchStartCoroutineInCoroutine(AccessTools.Method(typeof(PartLoader), nameof(PartLoader.CompileParts)));
+
+            // Release part-compilation texture replacements to the mipmap streaming manager at their bind
+            // sites (gated at call time on mipmapStreamingEnabled). These are the only two texture-assignment
+            // points in stock part compilation.
+            MethodInfo m_PartLoader_ReplaceTextures = AccessTools.Method(typeof(PartLoader), "ReplaceTextures");
+            MethodInfo po_PartLoader_ReplaceTextures = AccessTools.Method(typeof(KSPCFFastLoader), nameof(PartLoader_ReplaceTextures_Postfix));
+            assetAndPartLoaderHarmony.Patch(m_PartLoader_ReplaceTextures, null, new HarmonyMethod(po_PartLoader_ReplaceTextures));
+
+            MethodInfo m_PartLoader_ReplacePartTexture = AccessTools.Method(typeof(PartLoader), "ReplacePartTexture");
+            MethodInfo po_PartLoader_ReplacePartTexture = AccessTools.Method(typeof(KSPCFFastLoader), nameof(PartLoader_ReplacePartTexture_Postfix));
+            assetAndPartLoaderHarmony.Patch(m_PartLoader_ReplacePartTexture, null, new HarmonyMethod(po_PartLoader_ReplacePartTexture));
+
             PatchStartCoroutineInCoroutine(AccessTools.Method(typeof(DragCubeSystem), nameof(DragCubeSystem.SetupDragCubeCoroutine), new[] { typeof(Part) }));
             PatchStartCoroutineInCoroutine(AccessTools.Method(typeof(DragCubeSystem), nameof(DragCubeSystem.RenderDragCubesCoroutine)));
 
@@ -260,7 +282,17 @@ namespace KSPCommunityFixes.Performance
 
                 if (!config.TryGetValue(nameof(textureCacheEnabled), ref textureCacheEnabled))
                     userOptInChoiceDone = false;
+
+                // Optional opt-out for mipmap streaming (default ON). Read here — the load-phase streaming
+                // setup runs long before KSPCommunityFixes.SettingsNode is populated.
+                config.TryGetValue(nameof(mipmapStreamingEnabled), ref mipmapStreamingEnabled);
             }
+
+            // TEMPORARY: force the texture cache on and skip the opt-in popup while iterating on the
+            // mipmap-streaming work (DeployToKSP wipes the cfg each build, so the popup blocks unattended
+            // loads). Revert to the config-driven / popup behavior before shipping.
+            userOptInChoiceDone = true;
+            textureCacheEnabled = true;
         }
 
         /// <summary>
@@ -563,6 +595,11 @@ namespace KSPCommunityFixes.Performance
             // Tune the AUP for much better throughput
             QualitySettings.asyncUploadTimeSlice = 25;
             QualitySettings.asyncUploadBufferSize = 256;
+            QualitySettings.streamingMipmapsMaxLevelReduction = MaxStreamingMipReduction;
+
+            // Enable mipmap streaming before the bundle textures are realized so they register with the
+            // streaming manager on load.
+            ApplyStreamingQualitySettings();
 
             int textureCount = bundleRequests.Count + textureQueue.Count;
 
@@ -1149,6 +1186,7 @@ namespace KSPCommunityFixes.Performance
                     req.File.url,
                     hdr.Width, hdr.Height, hdr.MipCount,
                     hdr.ClassicTextureFormat, hdr.ColorSpace, readable: false,
+                    EligibleForStreaming(hdr),
                     sourcePath, hdr.DataOffset, hdr.StreamedSize);
                 return new BundleClassification(entry, new BundleItem { Request = req, IsNormalMap = isNormalMap });
             }
@@ -1269,6 +1307,12 @@ namespace KSPCommunityFixes.Performance
                 {
                     req.Result = new TextureInfo(req.File, tex, item.IsNormalMap, isReadable: false, isCompressed: true);
                     req.Status = TextureLoadRequest.State.Ready;
+
+                    // Pin every streaming texture full-res on load. It stays pinned (never streamed down)
+                    // until a model material or a part texture-replacement releases it via ReleaseToStreaming;
+                    // textures with no owning mesh (UI, icons, ...) therefore never blur.
+                    if (mipmapStreamingEnabled && tex.streamingMipmaps)
+                        tex.requestedMipmapLevel = 0;
                 }
                 else
                 {
@@ -1284,6 +1328,64 @@ namespace KSPCommunityFixes.Performance
                     yield return null;
             }
         }
+        #endregion
+
+        #region Mipmap streaming
+
+        // Enable Unity's mipmap streaming and size its budget to a fraction of total VRAM. These setters
+        // write to the currently-active quality level (GameSettings.QUALITY_PRESET). Called once, early in
+        // the asset-load phase, before the bundle textures are realized. If in-game testing shows KSP's
+        // SetQualityLevel wipes these, a fallback postfix on GameSettings.ApplySettings would re-apply them.
+        internal static void ApplyStreamingQualitySettings()
+        {
+            if (!mipmapStreamingEnabled)
+                return;
+
+            QualitySettings.streamingMipmapsActive = true;
+            QualitySettings.streamingMipmapsAddAllCameras = true;
+            QualitySettings.streamingMipmapsMemoryBudget = SystemInfo.graphicsMemorySize * StreamingBudgetFraction;
+        }
+
+        // Release a just-bound mesh/part texture back to automatic streaming, undoing the load-time full-res
+        // pin from InsertBundledTextures. Idempotent (ClearRequestedMipmapLevel is a no-op the second time and
+        // on non-streaming textures), so the shared database Texture2D can be released by whichever model or
+        // part binds it first, with no dedup bookkeeping.
+        internal static void ReleaseToStreaming(Texture tex)
+        {
+            if (mipmapStreamingEnabled && tex is Texture2D t2d && t2d.streamingMipmaps)
+                t2d.ClearRequestedMipmapLevel();
+        }
+
+        // Postfix on PartLoader.ReplaceTextures (MODEL-node "texture = orig, new" swaps): release each
+        // config-declared replacement texture. Releasing a declared-but-unmatched entry is harmless (idempotent
+        // + a texture with no owning renderer would only stream down when it is genuinely unused).
+        private static void PartLoader_ReplaceTextures_Postfix(List<TextureInfo> newTextures)
+        {
+            if (!mipmapStreamingEnabled || newTextures == null)
+                return;
+
+            for (int i = 0; i < newTextures.Count; i++)
+            {
+                TextureInfo ti = newTextures[i];
+                if (ti == null)
+                    continue;
+                ReleaseToStreaming(ti.texture);
+                ReleaseToStreaming(ti.normalMap);
+            }
+        }
+
+        // Postfix on PartLoader.ReplacePartTexture (part-level "texture"/"bump" field): the resolved texture is
+        // a local in the stock method, so recompute the URL from the parameters exactly as the method does and
+        // release the shared database texture (GetTexture is a dictionary lookup, fast-pathed by KSPCF).
+        private static void PartLoader_ReplacePartTexture_Postfix(UrlConfig urlConfig, string textureName, bool normalMap)
+        {
+            if (!mipmapStreamingEnabled)
+                return;
+
+            string url = urlConfig.parent.parent.url + "/textures/" + Path.GetFileNameWithoutExtension(textureName);
+            ReleaseToStreaming(GameDatabase.Instance.GetTexture(url, normalMap));
+        }
+
         #endregion
 
         #region Model bundle loader
@@ -1471,6 +1573,8 @@ namespace KSPCommunityFixes.Performance
                 tcs.SetException(new Exception("asset bundle failed to load"));
                 yield break;
             }
+
+            group.Bundle = bundle;
 
             var request = bundle.LoadAllAssetsAsync();
             request.priority = -100;
@@ -2403,6 +2507,26 @@ namespace KSPCommunityFixes.Performance
             int blockHeight = (int)GraphicsFormatUtility.GetBlockHeight(format);
             return width % blockWidth == 0 && height % blockHeight == 0;
         }
+
+        // Mipmap streaming reduces a texture's resident base mip by up to
+        // QualitySettings.streamingMipmapsMaxLevelReduction levels (we set that to this value; Unity's
+        // default is 2). The reduced mip becomes the texture's uploaded base level, and a block-compressed
+        // upload only works when that base is a whole number of blocks. So a texture may only join the
+        // streaming system when its mip level MaxStreamingMipReduction is still block aligned; otherwise the
+        // deepest reduction would upload a fractional-block base and corrupt. Uncompressed formats have
+        // a 1x1 block and always qualify.
+        private const int MaxStreamingMipReduction = 3;
+
+        // Textures smaller than this (whole mip chain) aren't worth streaming: the VRAM they could
+        // free is negligible next to the per-texture bookkeeping the streaming manager keeps for them.
+        private const long MinStreamingBytes = 4 * 1024;
+
+        private static bool EligibleForStreaming(in DDSPreparedHeader hdr) =>
+            hdr.StreamedSize >= MinStreamingBytes
+            && IsBlockAligned(
+                hdr.Format,
+                Math.Max(1, hdr.Width >> MaxStreamingMipReduction),
+                Math.Max(1, hdr.Height >> MaxStreamingMipReduction));
 
         // The number of mip levels Unity allocates for a full mip chain.
         private static int ComputeMipCount(int width, int height)

--- a/KSPCommunityFixes/Performance/TextureStreaming.cs
+++ b/KSPCommunityFixes/Performance/TextureStreaming.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections;
+using UnityEngine;
+
+namespace KSPCommunityFixes.Performance;
+
+internal class TextureStreaming : BasePatch
+{
+    /// <summary>
+    /// Whether mipmap streaming is enabled.
+    /// </summary>
+    internal static bool MipmapStreamingEnabled = false;
+
+    // The minimum amount of memory reserved for streaming, in megabytes.
+    internal static int MipmapStreamingBudgetMb = 1024;
+
+    // The maximum number of mipmap levels that we allow streaing to unload.
+    //
+    // Note that this also affects which textures are eligible for mipmap streaming.
+    // Unity will crash if it attempts to load a compressed texture whose size is
+    // not a multiple of the block size, so the texture loader will disable streaming
+    // for any texture whose mipmaps match that.
+    //
+    // The value of 3 is meant to be a balance between memory improvements (64x less
+    // memory for a fully streamed out texture) and allowing more textures to be
+    // streamed.
+    internal const int MaxStreamingMipReduction = 3;
+
+    internal static string LOC_StreamingEnabledTitle = "Texture streaming";
+    internal static string LOC_StreamingEnabledTooltip =
+        "Stream part textures from files on disk as they are needed. "
+        + "Ensures VRAM usage for part and IVA textures stays within the "
+        + "budget that you set.";
+    internal static string LOC_StreamingBudgetTitle = "Streaming memory budget (MB)";
+    internal static string LOC_StreamingBudgetTooltip =
+        "The amount of memory that is allocated to store streaming textures. "
+        + "Unity will automatically load and unload parts of textures to stay "
+        + "under this limit.";
+    // Format string for the budget slider's value readout; <<1>> is the megabyte value.
+    internal static string LOC_F_StreamingBudgetValue = "<<1>> MB";
+
+    protected override Version VersionMin => new(1, 12, 3);
+
+    protected override void ApplyPatches() { }
+
+    protected override void OnLoadData(ConfigNode node)
+    {
+        node.TryGetValue(nameof(MipmapStreamingEnabled), ref MipmapStreamingEnabled);
+        node.TryGetValue(nameof(MipmapStreamingBudgetMb), ref MipmapStreamingBudgetMb);
+    }
+
+    protected override void OnPatchApplied()
+    {
+        if (!KSPCFFastLoader.IsPatchEnabled)
+            return;
+
+        var go = new GameObject();
+        go.AddComponent<TextureStreamingController>();
+
+        QualitySettings.streamingMipmapsActive = MipmapStreamingEnabled;
+    }
+
+    internal void OnSettingsUpdated()
+    {
+        QualitySettings.streamingMipmapsActive = MipmapStreamingEnabled;
+    }
+}
+
+internal class TextureStreamingController : MonoBehaviour
+{
+    void Awake()
+    {
+        DontDestroyOnLoad(this);
+
+        QualitySettings.streamingMipmapsAddAllCameras = true;
+        QualitySettings.streamingMipmapsMaxLevelReduction = TextureStreaming.MaxStreamingMipReduction;
+    }
+
+    void Start()
+    {
+        StartCoroutine(UpdateMemoryLimitCoroutine());
+    }
+
+    static readonly WaitForSecondsRealtime WaitForHalfSecond = new(0.5f);
+    static readonly WaitForEndOfFrame WaitForEndOfFrame = new();
+
+    IEnumerator UpdateMemoryLimitCoroutine()
+    {
+        const ulong MB = 1024 * 1024;
+
+        while (true)
+        {
+            yield return WaitForHalfSecond;
+            yield return WaitForEndOfFrame;
+
+            if (QualitySettings.streamingMipmapsActive)
+            {
+                ulong totalGraphicsMemory = (ulong)SystemInfo.graphicsMemorySize * 4 / 5;
+                ulong totalTextureMemory = Texture.nonStreamingTextureMemory;
+                ulong requestedMemory = totalTextureMemory + (ulong)TextureStreaming.MipmapStreamingBudgetMb * MB;
+
+                // Always request at least the configured budget, but if there is more
+                // memory available then we might as well allow unity to use it.
+                //
+                // We do have to deal with other mods loading large textures on-demand
+                // so it doesn't really work to just set a fixed budget.
+                QualitySettings.streamingMipmapsMemoryBudget = Math.Max(
+                    (requestedMemory + (MB - 1)) / MB,
+                    totalGraphicsMemory);
+            }
+            else if (QualitySettings.streamingMipmapsMemoryBudget != 0)
+            {
+                QualitySettings.streamingMipmapsMemoryBudget = 0;
+            }
+        }
+    }
+}

--- a/KSPCommunityFixes/Performance/TextureStreaming.cs
+++ b/KSPCommunityFixes/Performance/TextureStreaming.cs
@@ -9,7 +9,7 @@ internal class TextureStreaming : BasePatch
     /// <summary>
     /// Whether mipmap streaming is enabled.
     /// </summary>
-    internal static bool MipmapStreamingEnabled = false;
+    internal static bool MipmapStreamingEnabled = true;
 
     // The minimum amount of memory reserved for streaming, in megabytes.
     internal static int MipmapStreamingBudgetMb = 1024;


### PR DESCRIPTION
This PR uses unity's [mipmap streaming](https://docs.unity3d.com/2019.4/Documentation/Manual/TextureStreaming.html) feature to stream in part and IVA textures on demand. This means that you get to set a memory budget and unity will take care of automatically streaming mipmaps from disk to vram depending on what parts are currently visible.

Here's how it works behind the scenes:
* With #369 we now load all dds and cached png textures by creating an asset bundle that points to their files on disk, then having unity load that asset bundle.
* With #411 we do something similar for mu files, though without the streaming.

With a few edits to these two we can:
* enable mipmap streaming on all textures we load, and,
* calculate the appropriate UV distribution metrics for all meshes loaded via mu files.

As it turns out, that's basically all you need to get mipmap streaming working. We can set [`QualitySettings.streamingMipmapsAddAllCameras`](https://docs.unity3d.com/2019.4/Documentation/ScriptReference/QualitySettings-streamingMipmapsAddAllCameras.html), then toggle whether it is enabled using [`QualitySettings.streamingMipmapsActive`](https://docs.unity3d.com/2019.4/Documentation/ScriptReference/QualitySettings-streamingMipmapsActive.html).

I don't have a profile in front of me right now, but the overhead for this looks to be about 0.5ms/frame. On the other hand, for an install with many part mods it looks to be able to save up to ~5GB of VRAM.

A testing build is available here for those who want to try it out
[KSPCommunityFixes_1.41.1.zip](https://github.com/user-attachments/files/30441817/KSPCommunityFixes_1.41.1.zip)
