### PR TITLE
Fix GetAudioClip fallback result bug

### DIFF
--- a/KSPCommunityFixes/Performance/GameDatabasePerf.cs
+++ b/KSPCommunityFixes/Performance/GameDatabasePerf.cs
@@ -141,7 +141,7 @@ namespace KSPCommunityFixes.Performance
             {
                 // Fallback in case audio is added after indexing
                 List<AudioClip> audioClips = gdb.databaseAudio;
-                for (int i = audioClips.Count - 1; i >= 0; i--)
+                for (int i = audioClips.Count; i-- > 0;)
                 {
                     if (audioClips[i].name == url)
                     {
@@ -150,9 +150,6 @@ namespace KSPCommunityFixes.Performance
                         break;
                     }
                 }
-
-                KSPCFFastLoader.audioByUrl.Remove(url);
-                return null;
             }
 
             return result;


### PR DESCRIPTION
I double checked my recent pr https://github.com/KSPModdingLibs/KSPCommunityFixes/pull/416 and noticed the result from the fallback check doesn't actually return the result. This pr fixes that bug.