### PR TITLE
Parallelize FastLoader second config pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ##### Unreleased
 **New/Improved patches**
 - Improved the **FastLoader** patch to reuse the initial GameDatabase directory tree during the second config pass while refreshing files and directories created or modified by `Startup.Instantly` addons. Avoids reparsing unchanged configs and saves several seconds in heavily modded installs.
+- Improved the **FastLoader** second config pass by refreshing GameData directories in parallel and using faster filesystem functions.
 
 **Bug Fixes**
 - **EditorAnimatedPartsShipModified** : Fixed a memory leak ([issue #396](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/396)) where listeners were not properly cleaned up.

--- a/KSPCommunityFixes/Performance/FastLoader.cs
+++ b/KSPCommunityFixes/Performance/FastLoader.cs
@@ -166,7 +166,7 @@ namespace KSPCommunityFixes.Performance
 
         private static Harmony assetAndPartLoaderHarmony;
         private static string AssetAndPartLoaderHarmonyID => typeof(KSPCFFastLoader).FullName + "AssetAndPartLoader";
-        
+
         private static Harmony expansionsLoaderHarmony;
         private static string ExpansionsLoaderHarmonyID => typeof(KSPCFFastLoader).FullName + "ExpansionsLoader";
 
@@ -782,95 +782,130 @@ namespace KSPCommunityFixes.Performance
             }
 
             DateTime recentConfigCutoffUtc = DateTime.UtcNow.AddSeconds(-Time.realtimeSinceStartup);
+
+            var directoriesToRefresh = new List<UrlDir>();
             for (int i = 0; i < root.children.Count; i++)
-                RefreshDirectoryRecursive(root.children[i], fileConfig, recentConfigCutoffUtc);
+            {
+                UrlDir directory = root.children[i];
+                directoriesToRefresh.Add(directory);
+                directoriesToRefresh.AddRange(directory.AllDirectories);
+            }
+
+            Parallel.For(0, directoriesToRefresh.Count,
+                i => RefreshDirectory(directoriesToRefresh[i], fileConfig, recentConfigCutoffUtc));
 
             return true;
         }
 
-        private static void RefreshDirectoryRecursive(UrlDir dir, ConfigFileType[] fileConfig, DateTime recentConfigCutoffUtc)
+        // Not safe to create UrlFile on multiple threads
+        private static readonly object urlCreationLock = new object();
+
+        private static void RefreshDirectory(UrlDir dir, ConfigFileType[] fileConfig, DateTime recentConfigCutoffUtc)
         {
-            var directoryInfo = new DirectoryInfo(dir.path);
+            string[] entries;
+            try
+            {
+                // Fastest way to get all files and directories in a directory with ksp's mono
+                entries = Directory.GetFileSystemEntries(dir.path);
+            }
+            catch (DirectoryNotFoundException)
+            {
+                return;
+            }
+
             var existingFiles = new Dictionary<string, UrlFile>(dir.files.Count, StringComparer.Ordinal);
             for (int i = 0; i < dir.files.Count; i++)
                 existingFiles[dir.files[i].fullPath] = dir.files[i];
-
-            var refreshedFiles = new List<UrlFile>(dir.files.Count);
-            foreach (FileInfo file in directoryInfo.GetFiles())
-            {
-                // Files changed by Startup.Instantly need a new UrlFile so config contents and
-                // metadata such as fileTime match the second stock directory scan.
-                if (!existingFiles.Remove(file.FullName, out UrlFile urlFile)
-                    || !CanReuseFile(urlFile, file, recentConfigCutoffUtc))
-                {
-                    urlFile = new UrlFile(dir, file);
-                }
-
-                urlFile.ConfigureFile(fileConfig);
-                refreshedFiles.Add(urlFile);
-            }
-
-            dir.files.Clear();
-            dir.files.AddRange(refreshedFiles);
 
             var existingChildren = new Dictionary<string, UrlDir>(dir.children.Count, StringComparer.Ordinal);
             for (int i = 0; i < dir.children.Count; i++)
                 existingChildren[dir.children[i].path] = dir.children[i];
 
+            var refreshedFiles = new List<UrlFile>(dir.files.Count);
             var refreshedChildren = new List<UrlDir>(dir.children.Count);
-            foreach (DirectoryInfo directory in directoryInfo.GetDirectories())
+
+            for (int i = 0; i < entries.Length; i++)
             {
-                if (ShouldSkipStockDirectory(directory.Name))
+                string entryPath = entries[i];
+                if (!TryGetFileStat(entryPath, out MonoIOStat stat))
                     continue;
 
-                if (!existingChildren.Remove(directory.FullName, out UrlDir childDir))
+                // If directory
+                if ((stat.fileAttributes & FileAttributes.Directory) != 0)
                 {
-                    childDir = new UrlDir(dir, directory);
+                    if (existingChildren.TryGetValue(entryPath, out UrlDir childDir))
+                    {
+                        refreshedChildren.Add(childDir);
+                        continue;
+                    }
+
+                    var directory = new DirectoryInfo(entryPath);
+                    if (ShouldSkipStockDirectory(directory.Name))
+                        continue;
+
+                    lock (urlCreationLock)
+                        childDir = new UrlDir(dir, directory);
+
                     foreach (UrlFile file in childDir.files)
                         file.ConfigureFile(fileConfig);
                     foreach (UrlFile file in childDir.AllFiles)
                         file.ConfigureFile(fileConfig);
+
+                    refreshedChildren.Add(childDir);
                 }
                 else
                 {
-                    RefreshDirectoryRecursive(childDir, fileConfig, recentConfigCutoffUtc);
-                }
+                    if (!existingFiles.TryGetValue(entryPath, out UrlFile urlFile)
+                        || !CanReuseFile(urlFile, stat, recentConfigCutoffUtc))
+                    {
+                        lock (urlCreationLock)
+                            urlFile = new UrlFile(dir, new FileInfo(entryPath));
+                    }
 
-                refreshedChildren.Add(childDir);
+                    urlFile.ConfigureFile(fileConfig);
+                    refreshedFiles.Add(urlFile);
+                }
             }
 
+            dir.files.Clear();
+            dir.files.AddRange(refreshedFiles);
             dir.children.Clear();
             dir.children.AddRange(refreshedChildren);
         }
 
-        private static bool CanReuseFile(UrlFile urlFile, FileInfo file, DateTime recentConfigCutoffUtc)
+        // Much faster than FileInfo
+        private static bool TryGetFileStat(string path, out MonoIOStat stat)
         {
-            if (urlFile.fileTime != GetLastWriteTime(file))
-                return false;
-
-            if (urlFile.fileType != FileType.Config)
+            if (MonoIO.GetFileStat(path, out stat, out MonoIOError error))
                 return true;
 
+            if (error == MonoIOError.ERROR_FILE_NOT_FOUND
+                || error == MonoIOError.ERROR_PATH_NOT_FOUND
+                || error == MonoIOError.ERROR_NOT_READY)
+            {
+                return false;
+            }
+
+            throw MonoIO.GetException(path, error);
+        }
+
+        private static bool CanReuseFile(UrlFile urlFile, MonoIOStat stat, DateTime recentConfigCutoffUtc)
+        {
             try
             {
-                return file.LastWriteTimeUtc < recentConfigCutoffUtc
-                    && file.CreationTimeUtc < recentConfigCutoffUtc;
+                DateTime lastWriteTimeUtc = DateTime.FromFileTimeUtc(stat.LastWriteTime);
+                if (urlFile.fileTime != lastWriteTimeUtc.ToLocalTime())
+                    return false;
+
+                if (urlFile.fileType != FileType.Config)
+                    return true;
+
+                return lastWriteTimeUtc < recentConfigCutoffUtc
+                    && DateTime.FromFileTimeUtc(stat.CreationTime) < recentConfigCutoffUtc;
             }
             catch
             {
                 return false;
-            }
-        }
-
-        private static DateTime GetLastWriteTime(FileInfo file)
-        {
-            try
-            {
-                return file.LastWriteTime;
-            }
-            catch
-            {
-                return DateTime.MinValue;
             }
         }
 


### PR DESCRIPTION
This PR follows up #415 by parallelizing the refresh of existing `GameData` directories during FastLoader's second config pass.

A flat list of existing directories are iterated over with `Parallel.For` and refreshed similarly like it was before
It builds a flat list of the existing directories and refreshes them using `Parallel.For`. `UrlDir` and `UrlFile` ctor aren't thread safe and so are guarded by locking

It also replaces `DirectoryInfo` enumeration and `FileInfo` metadata reads with `Directory.GetFileSystemEntries` and `MonoIO.GetFileStat`, which are faster on KSP's Mono runtime, at least on my machine.

The refresh still detects files and directories added, removed, or modified by `Startup.Instantly` addons.

### Modded profiles
<details>
<summary>Mods used when profiling</summary>
<pre>
KSP version: 1.12.5.3190

Installed modules:

\- ALCOR 1.0.1
\+ ASETAgency v2.0.2
\- ASETAvionics v3.0.1
\+ ASETProps v2.0.7
\- Astrogator v1.0.2
A Atmosphere (unmanaged)
\- AvalanchePlumes v1.0.5.1
\+ B9PartSwitch v2.21.0.4
\- BackgroundResourceProcessing 0.3.2
A BreakingGround-DLC 1.7.1 (unmanaged)
A BuildManager (unmanaged)
\- BurstPQS 0.1.24
A CelestialShadows (unmanaged)
\- Chatterer 0.9.99
\- ChattererExtended 0.6.2
A CityLights (unmanaged)
\- ClickThroughBlocker 1:2.1.10.23
\- CommunityCategoryKit v112.0.1
\+ CommunityResourcePack v112.0.1
\+ CommunityTechTree 1:3.4.5
\- ContractConfigurator v2.13.3.0
\- DE-IVAExtension v1.3.0
\- Deferred 1.3.5.0
\- DistantObject v2.2.1.7
\+ DistantObject-default v2.2.1.7
\- DockingPortAlignmentIndicator 6.13.1.0
\- EasyVesselSwitch 2.3
\- EditorExtensionsRedux 3.4.7
A EVEManager (unmanaged)
\+ FilterExtensions 3.2.9.1
\- FilterExtensionsDefaultConfig 3.2.9.1
\- Firefly 1.0.6
\+ FireflyAPI 1.0.0.0
\- Firespitter v7.17
\+ FirespitterCore v7.17
\+ FirespitterResourcesConfig v7.17
\- FreeIva 0.2.20.2
\+ Harmony2 2.2.1.0
\- HullcamVDSContinued 0.2.2.4
\- JanitorsCloset 0.4.1.3
\- KAS 1.12
\- KerbalChangelog v1.4.2
\- KerbalEngineerRedux 1.1.9.5
\- KerbalFX-AeroFX 0.8.1
\- KerbalFX-BlastFX 0.8.1
\+ KerbalFX-Core 0.8.1
\- KerbalFX-ImpactPuffs 0.8.1
\- KerbalFX-RoverDust 0.8.1
\- KIS 1.29
\+ Konstruction v112.0.1
\+ Kopernicus 2:release-1.12.1-247
\- kOS 1:1.6.0.1
\- kOS-Astrogator v0.2.2
\- kOS-Career 0.3.0.0
\- kOS-EVA 0.2.0.0
\- kOS-KerbalEngineer v0.1.1
\- kOS-MechJeb2 0.0.4
\- kOS-SCANSat 1.2.0.0
\- kOS-StockCamera 0.2.0.0
\- kOSforAll 0.0.5
\- kOSPropMonitor 1.7.3
\- KSAIVAUpgrade v1.6.7
\+ KSPBurst v1.7.4.11
\+ KSPBurst-Lite v1.7.4.11
\^ KSPCommunityFixes 1:1.41.1
\+ KSPTextureLoader 1.0.35
A MakingHistory-DLC 1.12.1 (unmanaged)
\- MechJeb2 2.15.3.0
\- MK12PodIVAReplacementbyASET 1:v2.0.1
\- Mk1LanderCanIVAReplbyASET v2.0.1
\- MoarFEConfigs 1.0.5.2
\+ ModularFlightIntegrator 1.2.10.0
\+ ModuleManager 4.2.3
\- NavUtilitiesUpdated 0.8.1.1
\+ NearFutureProps 1:0.7.2
\- ParallaxContinued 1.0.4
\- ParallaxContinued-Lifeless-Eve-Patch 1.0.0
\- ParallaxContinued-Planet-Textures 1.0.3
\- ParallaxContinued-Scatter-Textures 1.0.3
\- ParallaxContinued-Terrain-Textures 1.0.3
A PartFX (unmanaged)
\- PlanetShine 0.2.6.6
\+ PlanetShine-Config-Default 0.2.6.6
A PQSManager (unmanaged)
\- ProbeControlRoomRecontrolled 1.4.0
\- ProbesBeforeCrew 3.3.2
\- QuickIVA 1:1.3.0.11
\- QuickStart 1:2.2.1.5
\- RasterPropMonitor 1:v1.1.0.1
\+ RasterPropMonitor-Core 1:v1.1.0.1
\- ReStock 1.5.1
\- ReStockPlus 1.5.1
\- RestockWaterfallExpansion 0.2.0
\- Reviva 1.0.2
\- RocketSoundEnhancement 0.9.13
\+ RocketSoundEnhancement-Config-Default 1.3.1
\- SCANsat v21.1
A Scatterer (unmanaged)
\- ScienceAlert 1.9.20.5
\+ Shabby 0.4.2
A ShaderLoader (unmanaged)
\+ SmokeScreen 2.8.14.0
\+ SpaceTuxLibrary 0.0.9
\- StationPartsExpansionRedux 2.0.11
\- StationPartsExpansionRedux-IVAs 2.0.11
\- StockWaterfallEffects 0.8.0
A Terrain (unmanaged)
A TextureConfig (unmanaged)
\- Toolbar 1:1.8.1.2
\- ToolbarController 1:0.1.9.14
\- TrackingStationEvolved 2:1.0.9.1
\- Trajectories v2.4.5.4
\- TransferWindowPlannerFork v1.9.1.1
\- TriggerAu-Flags v2.11.0.0
\- TUFX 1.1.1
\- UKS 1:v112.0.1
\+ USI-Core v112.0.1
\+ USITools v112.0.1
A Utils (unmanaged)
\- VaporCones 1.2.0
\- VesselView 2:0.8.9
\+ VesselView-UI-RasterPropMonitor 1:0.8.9
\- VolumetricVaporCones 1.0.1
\- Waterfall 0.11.0
\- WaterfallRestock 0.2.3
\- WaypointManager 2.8.4.7
\- xScienceContinued 6.0.3.1
</pre>
</details>

Before:
<pre>
[LOG 17:02:50.111] [KSPCF:FastLoader] AMD Ryzen 9 5900X 12-Core Processor  | 32693 MB | NVIDIA GeForce RTX 5080 (15979 MB)
Total loading time to main menu : 58.232s
- Configs and assemblies loaded in 9.302s
- Configs reload done in <b>1.022s</b>
- Configs translated in 0.086s
- 8727 assets loaded in 8.921s :
  - 1393 audio assets (312.77 MiB) in 7.437s, 42.057 MiB/s
  - 4442 texture assets (2.461 GiB) in 0.526s, 4.676 GiB/s
  - 2874 model assets (437.884 MiB) in 0.942s, 464.829 MiB/s
- Asset bundles loaded in 0.314s
- GameDatabase (configs, resources, traits, upgrades...) loaded in 0.261s
- Built-in parts copied in 0.020s
- Part and internal configs extracted in 0.007s
- 1096 parts and 11617 modules compiled in 7.057s
  - 10.6 modules/part, 6.438 ms/part, 0.607 ms/module
  - PartIcon compilation : 2.224s
- 199 internal spaces and 1632 props compiled in 4.780s
- 2 DLC (Making History, Breaking Ground) loaded in 0.431s
- Planetary system loaded in 7.194s
</pre>

After:
<pre>
[LOG 16:54:39.846] [KSPCF:FastLoader] AMD Ryzen 9 5900X 12-Core Processor  | 32693 MB | NVIDIA GeForce RTX 5080 (15979 MB)
Total loading time to main menu : 56.611s
- Configs and assemblies loaded in 9.059s
- Configs reload done in <b>0.143s</b>
- Configs translated in 0.091s
- 8727 assets loaded in 8.922s :
  - 1393 audio assets (312.77 MiB) in 7.394s, 42.303 MiB/s
  - 4442 texture assets (2.461 GiB) in 0.538s, 4.576 GiB/s
  - 2874 model assets (437.884 MiB) in 0.979s, 447.265 MiB/s
- Asset bundles loaded in 0.375s
- GameDatabase (configs, resources, traits, upgrades...) loaded in 0.261s
- Built-in parts copied in 0.019s
- Part and internal configs extracted in 0.005s
- 1096 parts and 11617 modules compiled in 6.877s
  - 10.6 modules/part, 6.275 ms/part, 0.592 ms/module
  - PartIcon compilation : 2.178s
- 199 internal spaces and 1632 props compiled in 4.622s
- 2 DLC (Making History, Breaking Ground) loaded in 0.433s
- Planetary system loaded in 7.455s
</pre>