### PR TITLE
Fix condition to ignore TransparentFX in pr390 to fix issue #410.

### DIFF
--- a/KSPCommunityFixes/BugFixes/PartBoundsIgnoreDisabledTransforms.cs
+++ b/KSPCommunityFixes/BugFixes/PartBoundsIgnoreDisabledTransforms.cs
@@ -52,7 +52,7 @@ namespace KSPCommunityFixes
             //
             // This matches the same rule as done in https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/150
             // which isn't really perfect, but is probably good enough for our purposes.
-            bool ignoreTransparentFX = !p.frozen;
+            bool ignoreTransparentFX = !p.frozen && !AllParentsTransparent(p.transform);
 
             try
             {
@@ -68,6 +68,12 @@ namespace KSPCommunityFixes
             }
 
             return false;
+        }
+        static bool AllParentsTransparent(Transform t)
+        {
+            if (t.gameObject.layer != LayerMask.NameToLayer("TransparentFX")) return false;
+            if (t.parent == null) return true;
+            return AllParentsTransparent(t.parent);
         }
 
         static readonly List<Renderer> rendererBuffer = [];


### PR DESCRIPTION
PR #390 introduced a condition to ignore TransparentFX when calculating part renderer bounds.

> This updates the patch to exclude said renderers. There are cases in the editor where everything is on the TransparentFX layer (detached parts) so we can't do this unconditionally, but it should work in all the cases that matter.

The condition used is insufficient and breaks mods that rely on those bounds for their calculations #410. E.g., BDArmory uses these as part of its hitpoint calculations when the part is created (i.e., while the part is detached).

This PR modifies the condition for when to ignore TransparentFX to take into account detached parts by checking if all parents of the part transform are on the TransparentFX layer.