### PR TITLE
Stop blocking map view part clicks before there is a camera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Improved the **FastLoader** patch to reuse the initial GameDatabase directory tree during the second config pass while refreshing files and directories created or modified by `Startup.Instantly` addons. Avoids reparsing unchanged configs and saves several seconds in heavily modded installs.
 
 **Bug Fixes**
+- **BlockMapViewPartClick** : Fixed a `NullReferenceException` thrown from `Part.UpdateMouseOver` on every frame of a scene load into flight. The scene reports itself as flight well before `CameraManager.Instance` exists, and both the patch and stock dereferenced it unconditionally. `Part.UpdateMouseOver` is now skipped until there is a camera manager.
 - **EditorAnimatedPartsShipModified** : Fixed a memory leak ([issue #396](https://github.com/KSPModdingLibs/KSPCommunityFixes/issues/396)) where listeners were not properly cleaned up.
 - **EditorAnimatedPartsShipModified** : This patch is now disabled if DMagic Orbital Science is installed because DMagic Orbital Science has a bug that causes a stack overflow crash if you ever call `DMSoilMoisture.OnStop`, which this patch does.
 

--- a/KSPCommunityFixes/BugFixes/BlockMapViewPartClick.cs
+++ b/KSPCommunityFixes/BugFixes/BlockMapViewPartClick.cs
@@ -13,7 +13,14 @@ namespace KSPCommunityFixes
 
         static bool Part_UpdateMouseOver_Prefix()
         {
-            return !HighLogic.LoadedSceneIsFlight || CameraManager.Instance.currentCameraMode != CameraManager.CameraMode.Map;
+            if (!HighLogic.LoadedSceneIsFlight)
+                return true;
+
+            CameraManager cameraManager = CameraManager.Instance;
+            if (cameraManager.IsNullOrDestroyed())
+                return false;
+
+            return cameraManager.currentCameraMode != CameraManager.CameraMode.Map;
         }
     }
 }


### PR DESCRIPTION
`Part_UpdateMouseOver_Prefix` reads `CameraManager.Instance.currentCameraMode` as soon as `HighLogic.LoadedSceneIsFlight` is true. The scene calls itself flight from the moment it starts loading, a good while before the camera manager exists, so every frame of a load into flight throws an NRE.

Returning `true` when the camera manager is missing, so that stock runs as it would unpatched, only moves the exception: stock `Part.UpdateMouseOver` reads the same field just as unguarded, and the NREs still occur.

We can safely skip the method (returning `false`) until there is a camera manager. Nothing can be moused over before then, and stock threw straight back out of the method at that point anyway. This change maintains the existing behaviour, without the NREs polluting the game log.