### PR TITLE
Allow concurrent ConfigNode parsing in FastLoader

### DIFF
--- a/KSPCommunityFixes/Performance/ConfigNodePerf.cs
+++ b/KSPCommunityFixes/Performance/ConfigNodePerf.cs
@@ -2,6 +2,7 @@
 //#define COMPARE_PARSE_RESULTS
 //#define CONFIGNODE_PERF_TEST
 using HarmonyLib;
+using KSPCommunityFixes.Library.Buffers;
 using KSP.Localization;
 using System;
 using System.Collections;
@@ -27,10 +28,11 @@ namespace KSPCommunityFixes.Performance
 
         const int _SaveBufferSize = 64 * 1024;
         const int _ReadBufferSize = 1024 * 1024;
-        private static readonly char[] _charBuf = new char[_ReadBufferSize];
+        private static readonly ArrayPool<char> _charBufPool = ArrayPool<char>.Create(_ReadBufferSize, 1);
         static readonly UTF8Encoding _UTF8NoBOM = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
         static readonly string _Newline = Environment.NewLine;
-        static readonly Stack<ConfigNode> _nodeStack = new Stack<ConfigNode>(128);
+        [ThreadStatic]
+        private static Stack<ConfigNode> _nodeStack;
         public static bool _doClean = true; // so it is accessible from ModUpgradePipeline
         public static bool _AllowSkipIndent = false; // so it is accessible from other things if needed
         // This large-size stringbuilder is used for writing ConfigNodes to string.
@@ -749,45 +751,50 @@ namespace KSPCommunityFixes.Performance
 #endif
             char[] chars = null;
             int numChars = 0;
-            using (var reader = new StreamReader(path, Encoding.UTF8, true, 1024 * 1024))
+            try
             {
-                FileInfo fi = new FileInfo(path);
-                if (fi.Length > int.MaxValue)
-                    throw new FileLoadException("file size too large for int length");
-                int fLength = (int)fi.Length;
-                if (fLength > _ReadBufferSize)
-                    chars = new char[fLength];
-                else
-                    chars = _charBuf;
+                using (var reader = new StreamReader(path, Encoding.UTF8, true, 1024 * 1024))
+                {
+                    FileInfo fi = new FileInfo(path);
+                    if (fi.Length > int.MaxValue)
+                        throw new FileLoadException("file size too large for int length");
+                    int fLength = (int)fi.Length;
+                    chars = _charBufPool.Rent(Math.Max(fLength, _ReadBufferSize));
 
-                numChars = reader.Read(chars, 0, chars.Length);
-            }
+                    numChars = reader.Read(chars, 0, chars.Length);
+                }
 #if DEBUG_CONFIGNODE_PERF
-            _readTime = sw.ElapsedMilliseconds;
+                _readTime = sw.ElapsedMilliseconds;
 #endif
 
-            ConfigNode result;
-            if (numChars == 0)
-            {
-                result = new ConfigNode("root");
-            }
-            else
-            {
-                fixed (char* pBase = chars)
+                ConfigNode result;
+                if (numChars == 0)
                 {
-                    result = ParseConfigNode(pBase, numChars);
+                    result = new ConfigNode("root");
                 }
-            }
+                else
+                {
+                    fixed (char* pBase = chars)
+                    {
+                        result = ParseConfigNode(pBase, numChars);
+                    }
+                }
 
 #if COMPARE_PARSE_RESULTS
-            string input = new string(chars, 0, numChars);
-            ConfigNode stockNode = RecurseFormat(PreFormatConfig(input.Split('\n', '\r')));
-            if (!AreNodesEqual(result, stockNode, true))
-            {
-                Debug.LogError($"[KSPCommunityFixes] ConfigNodePerf : mismatch in parsed node !\nSTOCK NODE\n{stockNode}\nKSPCF NODE\n{result}");
-            }
+                string input = new string(chars, 0, numChars);
+                ConfigNode stockNode = RecurseFormat(PreFormatConfig(input.Split('\n', '\r')));
+                if (!AreNodesEqual(result, stockNode, true))
+                {
+                    Debug.LogError($"[KSPCommunityFixes] ConfigNodePerf : mismatch in parsed node !\nSTOCK NODE\n{stockNode}\nKSPCF NODE\n{result}");
+                }
 #endif
-            return result;
+                return result;
+            }
+            finally
+            {
+                if (chars != null)
+                    _charBufPool.Return(chars);
+            }
         }
 
         public static unsafe ConfigNode ParseConfigNode(char* pBase, int numChars)
@@ -796,6 +803,7 @@ namespace KSPCommunityFixes.Performance
             int pos = 0;
             string savedName = string.Empty;
             ParseMode mode = ParseMode.SkipToKey;
+            _nodeStack ??= new Stack<ConfigNode>(128);
             _nodeStack.Push(node);
 
 

--- a/KSPCommunityFixes/Performance/FastLoader.cs
+++ b/KSPCommunityFixes/Performance/FastLoader.cs
@@ -797,9 +797,6 @@ namespace KSPCommunityFixes.Performance
             return true;
         }
 
-        // Not safe to create UrlFile on multiple threads
-        private static readonly object urlCreationLock = new object();
-
         private static void RefreshDirectory(UrlDir dir, ConfigFileType[] fileConfig, DateTime recentConfigCutoffUtc)
         {
             string[] entries;
@@ -843,8 +840,7 @@ namespace KSPCommunityFixes.Performance
                     if (ShouldSkipStockDirectory(directory.Name))
                         continue;
 
-                    lock (urlCreationLock)
-                        childDir = new UrlDir(dir, directory);
+                    childDir = new UrlDir(dir, directory);
 
                     foreach (UrlFile file in childDir.files)
                         file.ConfigureFile(fileConfig);
@@ -858,8 +854,7 @@ namespace KSPCommunityFixes.Performance
                     if (!existingFiles.TryGetValue(entryPath, out UrlFile urlFile)
                         || !CanReuseFile(urlFile, stat, recentConfigCutoffUtc))
                     {
-                        lock (urlCreationLock)
-                            urlFile = new UrlFile(dir, new FileInfo(entryPath));
+                        urlFile = new UrlFile(dir, new FileInfo(entryPath));
                     }
 
                     urlFile.ConfigureFile(fileConfig);


### PR DESCRIPTION
This PR follows up #422 by making the config node parsing tread-safe so the `urlCreationLock` lock could be removed from `FastLoader`. This doesn't really affect performance at all in my tests.

### Modded profiles
<details>
<summary>Mods used when profiling</summary>
<pre>
KSP version: 1.12.5.3190

Installed modules:

\- ALCOR 1.0.1
\+ ASETAgency v2.0.2
\- ASETAvionics v3.0.1
\+ ASETProps v2.0.7
\- Astrogator v1.0.2
\A Atmosphere (unmanaged)
\- AvalanchePlumes v1.0.5.1
\+ B9PartSwitch v2.21.0.4
\- BackgroundResourceProcessing 0.3.2
A BreakingGround-DLC 1.7.1 (unmanaged)
A BuildManager (unmanaged)
\- BurstPQS 0.1.24
A CelestialShadows (unmanaged)
\- Chatterer 0.9.99
\- ChattererExtended 0.6.2
A CityLights (unmanaged)
\^ ClickThroughBlocker 1:2.1.10.23
\- CommunityCategoryKit v112.0.1
\+ CommunityResourcePack v112.0.1
\- CommunityTechTree 1:3.4.5
\^ ContractConfigurator v2.13.3.0
\- DE-IVAExtension v1.3.0
\- Deferred 1.3.5.0
\- DistantObject v2.2.1.7
\+ DistantObject-default v2.2.1.7
\- DockingPortAlignmentIndicator 6.13.1.0
\- EasyVesselSwitch 2.3
\- EditorExtensionsRedux 3.4.7
A EVEManager (unmanaged)
\- FilterExtensions 3.2.9.1
\- FilterExtensionsDefaultConfig 3.2.9.1
\- Firefly 1.0.6
\+ FireflyAPI 1.0.0.0
\- Firespitter v7.17
\+ FirespitterCore v7.17
\+ FirespitterResourcesConfig v7.17
\- FreeIva 0.2.20.2
\+ Harmony2 2.2.1.0
\- HullcamVDSContinued 0.2.2.4
\^ JanitorsCloset 0.4.1.3
\- KAS 1.12
\- KerbalChangelog v1.4.2
\- KerbalEngineerRedux 1.1.9.5
A KerbalFX (unmanaged)
\- KIS 1.29
\+ Konstruction v112.0.1
\+ Kopernicus 2:release-1.12.1-247
\- kOS 1:1.6.0.1
\- kOS-Astrogator v0.2.2
\- kOS-Career 0.3.0.0
\- kOS-EVA 0.2.0.0
\- kOS-MechJeb2 0.0.4
\- kOS-SCANSat 1.2.0.0
\- kOS-StockCamera 0.2.0.0
\- kOSforAll 0.0.5
\- kOSPropMonitor 1.7.3
\- KSAIVAUpgrade v1.6.7
\- KSPBurst v1.7.4.11
\+ KSPBurst-Lite v1.7.4.11
\^ KSPCommunityFixes 1:1.41.1
\^ KSPTextureLoader 1.0.35
A MakingHistory-DLC 1.12.1 (unmanaged)
\- MechJeb2 2.15.3.0
\- MK12PodIVAReplacementbyASET 1:v2.0.1
\- Mk1LanderCanIVAReplbyASET v2.0.1
\- MoarFEConfigs 1.0.5.2
\+ ModularFlightIntegrator 1.2.10.0
\+ ModuleManager 4.2.3
\- NavUtilitiesUpdated 0.8.1.1
\+ NearFutureProps 1:0.7.2
\- ParallaxContinued 1.0.4
\- ParallaxContinued-Lifeless-Eve-Patch 1.0.0
\- ParallaxContinued-Planet-Textures 1.0.3
\- ParallaxContinued-Scatter-Textures 1.0.3
\- ParallaxContinued-Terrain-Textures 1.0.3
A PartFX (unmanaged)
\- PlanetShine 0.2.6.6
\+ PlanetShine-Config-Default 0.2.6.6
A PQSManager (unmanaged)
\- ProbeControlRoomRecontrolled 1.4.0
\- ProbesBeforeCrew 3.3.2
\- QuickIVA 1:1.3.0.11
\- QuickStart 1:2.2.1.5
\- RasterPropMonitor 1:v1.1.0.1
\+ RasterPropMonitor-Core 1:v1.1.0.1
\- ReStock 1.5.1
\- ReStockPlus 1.5.1
\- RestockWaterfallExpansion 3.1.0
\- Reviva 1.0.2
\- RocketSoundEnhancement 0.9.13
\+ RocketSoundEnhancement-Config-Default 1.3.1
\- SCANsat v21.1
\- Scatterer 3:v0.0878
\- Scatterer-config 3:v0.0878
\- Scatterer-sunflare 3:v0.0878
\- ScienceAlert 1.9.20.5
\+ Shabby 0.4.2
A ShaderLoader (unmanaged)
\+ SmokeScreen 2.8.14.0
\+ SpaceTuxLibrary 0.0.9
\- StationPartsExpansionRedux 2.0.11
\- StationPartsExpansionRedux-IVAs 2.0.11
A Terrain (unmanaged)
A TextureConfig (unmanaged)
\- Toolbar 1:1.8.1.2
\- ToolbarController 1:0.1.9.14
\- TrackingStationEvolved 2:1.0.9.1
\- Trajectories v2.4.5.4
\- TransferWindowPlannerFork v1.9.1.1
\- TriggerAu-Flags v2.11.0.0
\- TUFX 1.1.1
\- UKS 1:v112.0.1
\+ USI-Core v112.0.1
\+ USITools v112.0.1
A Utils (unmanaged)
\- VaporCones 1.2.0
\- VesselView 2:0.8.9
\+ VesselView-UI-RasterPropMonitor 1:0.8.9
\- VolumetricVaporCones 1.0.1
\- Waterfall 0.11.0
\- WaterfallRestock 0.2.3
\- WaypointManager 2.8.4.7
\- xScienceContinued 6.0.3.1
</pre>
</details>

Before:
<pre>
[LOG 22:31:21.143] [KSPCF:FastLoader] AMD Ryzen 9 5900X 12-Core Processor  | 32693 MB | NVIDIA GeForce RTX 5080 (15979 MB)
Total loading time to main menu : 59.147s
- Configs and assemblies loaded in 9.157s
- Configs reload done in <b>0.094s</b>
- Configs translated in 0.085s
- 8727 assets loaded in 9.132s :
  - 1393 audio assets (312.77 MiB) in 7.596s, 41.177 MiB/s
  - 4442 texture assets (2.461 GiB) in 0.581s, 4.237 GiB/s
  - 2874 model assets (437.884 MiB) in 0.947s, 462.475 MiB/s
- Asset bundles loaded in 0.378s
- GameDatabase (configs, resources, traits, upgrades...) loaded in 0.315s
- Built-in parts copied in 0.018s
- Part and internal configs extracted in 0.006s
- 1096 parts and 11617 modules compiled in 7.354s
  - 10.6 modules/part, 6.710 ms/part, 0.633 ms/module
  - PartIcon compilation : 2.255s
- 199 internal spaces and 1632 props compiled in 5.002s
- 2 DLC (Making History, Breaking Ground) loaded in 0.439s
- Planetary system loaded in 7.811s
</pre>

After:
<pre>
[LOG 22:34:49.842] [KSPCF:FastLoader] AMD Ryzen 9 5900X 12-Core Processor  | 32693 MB | NVIDIA GeForce RTX 5080 (15979 MB)
Total loading time to main menu : 58.880s
- Configs and assemblies loaded in 8.823s
- Configs reload done in <b>0.094s</b>
- Configs translated in 0.088s
- 8727 assets loaded in 9.216s :
  - 1393 audio assets (312.77 MiB) in 7.543s, 41.465 MiB/s
  - 4442 texture assets (2.461 GiB) in 0.556s, 4.43 GiB/s
  - 2874 model assets (437.884 MiB) in 1.109s, 394.868 MiB/s
- Asset bundles loaded in 0.377s
- GameDatabase (configs, resources, traits, upgrades...) loaded in 0.264s
- Built-in parts copied in 0.018s
- Part and internal configs extracted in 0.006s
- 1096 parts and 11617 modules compiled in 7.401s
  - 10.6 modules/part, 6.753 ms/part, 0.637 ms/module
  - PartIcon compilation : 2.299s
- 199 internal spaces and 1632 props compiled in 4.785s
- 2 DLC (Making History, Breaking Ground) loaded in 0.440s
- Planetary system loaded in 7.786s
</pre>